### PR TITLE
Fix <shift+enter>

### DIFF
--- a/src/js/medium.editor.js
+++ b/src/js/medium.editor.js
@@ -354,7 +354,7 @@ function MediumEditor(selector, options) {
             };
 
             input.onkeyup = function (e) {
-                if (e.keyCode === 13) {
+                if (e.keyCode === 13 && !e.shiftKey) {
                     e.preventDefault();
                     self.createLink(this);
                 }


### PR DESCRIPTION
When hitting `<shift+enter>` it does a line break `<br>` but then wraps the new line into a paragraph such as:

```
<p>Now that there is the Tec-9, a crappy spray gun from South Miami.
    <br>
    <p>This gun is advertised as the most popular gun in American crime. Do you believe that shit? It actually says that in the little book that comes with it: the most popular gun in American crime. Like they're actually proud of that shit.</p>
</p>
```
