### PR TITLE
Fixes issue with initial positioning when some actions are disabled

### DIFF
--- a/src/js/medium.editor.js
+++ b/src/js/medium.editor.js
@@ -180,8 +180,8 @@ function MediumEditor(elements, options) {
                     this.selection = newSelection;
                     this.selectionRange = this.selection.getRangeAt(0);
                     this.toolbar.style.display = 'block';
-                    this.setToolbarPosition()
-                        .setToolbarButtonStates()
+                    this.setToolbarButtonStates()
+                        .setToolbarPosition()
                         .showToolbarActions();
                 }
             }


### PR DESCRIPTION
When disabling actions, the toolbar will position itself wrong on the first invocation. It then jumps into place on subsequent displays. This fixes the issue.
