### PR TITLE
Fixed issue on deactivation without enabled toolbar

### DIFF
--- a/src/js/medium-editor.js
+++ b/src/js/medium-editor.js
@@ -497,7 +497,10 @@ if (window.module !== undefined) {
                 return;
             }
             this.isActive = false;
-            this.toolbar.style.display = 'none';
+            
+            if(this.toolbar)
+                this.toolbar.style.display = 'none';
+            
             for (i = 0; i < this.elements.length; i += 1) {
                 this.elements[i].removeEventListener('mouseup', this.checkSelectionWrapper);
                 this.elements[i].removeEventListener('keyup', this.checkSelectionWrapper);


### PR DESCRIPTION
On activation of the editor you may pass along the option '{disableToolbar: true}'. This will cause the toolbar not to appear. When .deactivate is then called on the object, an error is written to the console on line 500: this.toolbar.style.display = 'none'. The toolbar object is not set. So I simply have added an if(this.toolbar).
