### PR TITLE
Fix: prevent a way to open toolbar on a disabled toolbar editor

### DIFF
--- a/src/js/medium-editor.js
+++ b/src/js/medium-editor.js
@@ -244,7 +244,9 @@ if (window.module !== undefined) {
         checkSelection: function () {
             var newSelection,
                 pCount,
-                selectionHtml;
+                selectionHtml,
+                selectionElement;
+
             if (this.keepToolbarAlive !== true && this.toolbar !== undefined) {
                 newSelection = window.getSelection();
 
@@ -257,9 +259,10 @@ if (window.module !== undefined) {
                     this.toolbar.style.display = 'none';
                     this.toolbar.classList.remove('medium-editor-toolbar-active');
                 } else {
+                    selectionElement = this.getSelectionElement();
                     this.selection = newSelection;
                     this.selectionRange = this.selection.getRangeAt(0);
-                    if (!this.getSelectionElement().getAttribute('data-disable-toolbar')) {
+                    if (selectionElement && this.elements[0] === selectionElement && !selectionElement.getAttribute('data-disable-toolbar')) {
                         this.toolbar.style.display = 'block';
                         this.toolbar.classList.add('medium-editor-toolbar-active');
                         this.setToolbarButtonStates()
@@ -280,7 +283,7 @@ if (window.module !== undefined) {
                     parent = parent.parentNode;
                 }
             } catch (err) {
-                return this.elements[0];
+                return false;
             }
             return parent;
         },


### PR DESCRIPTION
**Situation:**

``` js
var editor1 = new MediumEditor('#editor1', {});
var editor2 = new MediumEditor('#editor2', {
    disableToolbar: true
});
```

**Reproducing:**
Click two times to select a word on the editor with `disableToolbar`.
Then without releasing the click, move you mouse to the other editor (the one without the `disableToolbar`).
Then release it.

**Result:**
It will open a toolbar on the editor with `disableToolbar`.
