### PR TITLE
bindSelect timeout var never being assigned

### DIFF
--- a/src/js/medium-editor.js
+++ b/src/js/medium-editor.js
@@ -271,7 +271,7 @@ if (typeof module === 'object') {
                 i;
             this.checkSelectionWrapper = function (e) {
                 clearTimeout(timer);
-                setTimeout(function () {
+                timer = setTimeout(function () {
                     self.checkSelection(e);
                 }, self.options.delay);
             };


### PR DESCRIPTION
The timer var was not being assigned, making the clearTimeout call pointless.
