### PR TITLE
checkSelection shouldn't be passed an event argument

### DIFF
--- a/src/js/medium-editor.js
+++ b/src/js/medium-editor.js
@@ -272,7 +272,7 @@ if (typeof module === 'object') {
             this.checkSelectionWrapper = function (e) {
                 clearTimeout(timer);
                 setTimeout(function () {
-                    self.checkSelection(e);
+                    self.checkSelection();
                 }, self.options.delay);
             };
 
@@ -417,7 +417,7 @@ if (typeof module === 'object') {
                     e.preventDefault();
                     e.stopPropagation();
                     if (self.selection === undefined) {
-                        self.checkSelection(e);
+                        self.checkSelection();
                     }
                     if (this.className.indexOf('medium-editor-button-active') > -1) {
                         this.classList.remove('medium-editor-button-active');
@@ -512,10 +512,10 @@ if (typeof module === 'object') {
         bindElementToolbarEvents: function (el) {
             var self = this;
             el.addEventListener('mouseup', function (e) {
-                self.checkSelection(e);
+                self.checkSelection();
             });
             el.addEventListener('keyup', function (e) {
-                self.checkSelection(e);
+                self.checkSelection();
             });
         },
 


### PR DESCRIPTION
Some, but not all, calls to `checkSelection` were passing an event argument. The `checkSelection` method does not explicitly take arguments and does not use any via `arguments`.

I changed those calls to no longer pass an argument.
