### PR TITLE
Fixed filenames for main in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,8 +6,8 @@
     "Davi Ferreira <hi@daviferreira.com>"
   ],
   "description": "Medium.com WYSIWYG editor clone written in pure JavaScript.",
-  "main": ["dist/js/medium.editor.js", "dist/js/medium.editor.min.js",
-           "dist/css/medium.editor.css"],
+  "main": ["dist/js/medium-editor.js", "dist/js/medium-editor.min.js",
+           "dist/css/medium-editor.css"],
   "keywords": [
     "wysiwyg",
     "medium",


### PR DESCRIPTION
Just some quick fixes, was trying to use this with browserify and bower and the filenames didn't match up with `bower.json`. Not sure which convention (`medium-editor.js` vs `medium.editor.js`) is correct, but changing the `bower.json` file was more painless.
