### PR TITLE
Add optional support for double return entered.

### DIFF
--- a/src/js/medium-editor.js
+++ b/src/js/medium-editor.js
@@ -97,6 +97,7 @@ if (typeof module === 'object') {
             diffLeft: 0,
             diffTop: -10,
             disableReturn: false,
+            disableDoubleReturn: false;
             disableToolbar: false,
             firstHeader: 'h3',
             forcePlainText: true,
@@ -208,10 +209,23 @@ if (typeof module === 'object') {
 
         bindReturn: function (index) {
             var self = this;
+            var double_return = 0;
             this.elements[index].addEventListener('keypress', function (e) {
-                if (e.which === 13) {
-                    if (self.options.disableReturn || this.getAttribute('data-disable-return')) {
-                        e.preventDefault();
+                if (self.options.disableDoubleReturn){
+                    if (e.which === 13) {
+                        if (double_return === 1){
+                            e.preventDefault();
+                        }else{
+                            double_return = 1;
+                        }
+                    }else{
+                        double_return = 0;
+                    }
+                }else{
+                    if (e.which === 13) {
+                        if (self.options.disableReturn || this.getAttribute('data-disable-return')) {
+                            e.preventDefault();
+                        }
                     }
                 }
             });


### PR DESCRIPTION
Add one option `disableDoubleReturn`.
When enabled, users can and olny create one new `<p>` blocks.
I think It's more useful than simply disable all new block creation.
