### PR TITLE
changes to the element list or element selector now take effect on reactivation

### DIFF
--- a/src/js/medium-editor.js
+++ b/src/js/medium-editor.js
@@ -807,7 +807,7 @@ if (typeof module === 'object') {
                 defaultLeft,
                 timer;
 
-            self.anchorPreview.querySelector('i').innerHTML = anchor_el.href;
+            self.anchorPreview.querySelector('i').textContent = anchor_el.href;
             halfOffsetWidth = self.anchorPreview.offsetWidth / 2;
             defaultLeft = self.options.diffLeft - halfOffsetWidth;
 


### PR DESCRIPTION
Also, previously the assignment of content to the anchorPreview's <i> tag was going through innerHTML, which was an XSS vector for my application. Changed to a textContent. Not sure why it wasn't one in the first place.
