### PR TITLE
On paste, check for data-disable-return on element

### DIFF
--- a/src/js/medium-editor.js
+++ b/src/js/medium-editor.js
@@ -1075,7 +1075,7 @@ if (typeof module === 'object') {
                     if (self.options.cleanPastedHTML && e.clipboardData.getData('text/html')) {
                         return self.cleanPaste(e.clipboardData.getData('text/html'));
                     }
-                    if (!self.options.disableReturn) {
+                    if (!(self.options.disableReturn || e.target.getAttribute('data-disable-return'))) {
                         paragraphs = e.clipboardData.getData('text/plain').split(/[\r\n]/g);
                         for (p = 0; p < paragraphs.length; p += 1) {
                             if (paragraphs[p] !== '') {


### PR DESCRIPTION
In every other location where you check disableReturn on the options you check the data on the element too. It was missing in the pasteWrapper.
