### PR TITLE
[bower] Only include the minified script file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "Davi Ferreira <hi@daviferreira.com>"
   ],
   "description": "Medium.com WYSIWYG editor clone written in pure JavaScript.",
-  "main": ["dist/js/medium-editor.js", "dist/js/medium-editor.min.js",
+  "main": ["dist/js/medium-editor.min.js",
            "dist/css/medium-editor.css"],
   "keywords": [
     "wysiwyg",


### PR DESCRIPTION
With plugins like https://github.com/taptapship/wiredep, it will automatically include all files listed under `main`. To integrate properly with these types of plugins, only include one of the built javascript files.
