### PR TITLE
Expose save-/restoreSelection()

### DIFF
--- a/src/js/medium-editor.js
+++ b/src/js/medium-editor.js
@@ -788,9 +788,17 @@ if (typeof module === 'object') {
             }, 100);
         },
 
+        saveSelection: function() {
+            this.savedSelection = saveSelection();
+        },
+
+        restoreSelection: function() {
+            restoreSelection(this.savedSelection);
+        },
+
         showAnchorForm: function (link_value) {
             this.toolbarActions.style.display = 'none';
-            this.savedSelection = saveSelection();
+            this.saveSelection();
             this.anchorForm.style.display = 'block';
             this.keepToolbarAlive = true;
             this.anchorInput.focus();


### PR DESCRIPTION
This is handy if you're extending medium-editor (context menus, customized dialogs, etc...).
