### PR TITLE
Fix hidden placeholder content override

### DIFF
--- a/src/sass/medium-editor.scss
+++ b/src/sass/medium-editor.scss
@@ -134,7 +134,7 @@
         position: absolute;
         top: 0;
         left: 0;
-        content: attr(data-placeholder);
+        content: attr(data-placeholder) !important;
         font-style: italic;
     }
 }


### PR DESCRIPTION
When a user sets a data placeholder, they really want a placeholder.

Set content to !important and ensure it's not overridden (e.g. by Bootstrap).

Closes #255

Signed-off-by: Nick Semenkovich <semenko@alum.mit.edu>
