### PR TITLE
added call to setToolbarPosition in showAnchorForm

### DIFF
--- a/src/js/medium-editor.js
+++ b/src/js/medium-editor.js
@@ -890,6 +890,7 @@ if (typeof module === 'object') {
             this.toolbarActions.style.display = 'none';
             this.saveSelection();
             this.anchorForm.style.display = 'block';
+            this.setToolbarPosition();
             this.keepToolbarAlive = true;
             this.anchorInput.focus();
             this.anchorInput.value = link_value || '';


### PR DESCRIPTION
This is a one-line change which repositions the toolbar after showing the anchorform, so the triangle still points at the selected word.
