### PR TITLE
added custom doc and win functionality

### DIFF
--- a/spec/init.spec.js
+++ b/spec/init.spec.js
@@ -81,6 +81,8 @@ describe('Initialization TestCase', function () {
                 disableEditing: false,
                 disableToolbar: false,
                 elementsContainer: document.body,
+                contentWindow: window,
+                ownerDocument: document,
                 firstHeader: 'h3',
                 forcePlainText: true,
                 cleanPastedHTML: false,


### PR DESCRIPTION
This helps to load the editor in a parent frame but edit inside an iframe.

This has been discussed before here #183 and here #269. The scenarios where this can come handy is where you are developing a drag and drop editor where the text is edited inline but everything happens inside an iframe, completely isolated from the upper frame.

You still need to override the `setToolbarPosition` in your side of things, a future improvement could be pass functions to calculate this:

``` javascript
this.toolbar.style.top = buttonHeight + boundary.bottom - this.options.diffTop + offset - this.toolbar.offsetHeight + 'px';
```

But that's another story.
