### PR TITLE
Using `options.elementsContainer` to calculate ID

### DIFF
--- a/src/js/medium-editor.js
+++ b/src/js/medium-editor.js
@@ -154,7 +154,9 @@ else if (typeof define === 'function' && define.amd) {
                 return;
             }
             this.parentElements = ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'pre'];
-            this.options.elementsContainer || (this.options.elementsContainer = document.body);
+            if (!this.options.elementsContainer) {
+                this.options.elementsContainer = document.body;
+            }
             this.id = this.options.elementsContainer.querySelectorAll('.medium-editor-toolbar').length + 1;
             return this.setup();
         },


### PR DESCRIPTION
Since the container for toolbar and anchor input can be changed to be 
other than `document.body`, in some cases, querying for the number of
`.medium-editor-toolbar` from `document` will not work. This made all
editor instances to have the same ID of 1.

Shadow DOM is an example in which, if `options.elementsContainer` is
set to an element inside it, it will not be available in the Light DOM to
query.

This updated to use `options.elementsContainer` to query for number of
`.medium-editor-toolbar` elements.
