### PR TITLE
make plaintext paste work in IE

### DIFF
--- a/src/js/medium-editor.js
+++ b/src/js/medium-editor.js
@@ -110,6 +110,39 @@ else if (typeof define === 'function' && define.amd) {
         return !!(obj && obj.nodeType === 1);
     }
 
+    // http://stackoverflow.com/questions/6690752/insert-html-at-caret-in-a-contenteditable-div
+    function insertHTMLCommand(doc, html) {
+        var selection, range, el, fragment, node, lastNode;
+
+        if (doc.queryCommandSupported('insertHTML')) {
+            return doc.execCommand('insertHTML', false, html);
+        }
+
+        selection = window.getSelection();
+        if (selection.getRangeAt && selection.rangeCount) {
+            range = selection.getRangeAt(0);
+            range.deleteContents();
+
+            el = doc.createElement("div");
+            el.innerHTML = html;
+            fragment = doc.createDocumentFragment();
+            while (el.firstChild) {
+                node = el.firstChild;
+                lastNode = fragment.appendChild(node);
+            }
+            range.insertNode(fragment);
+
+            // Preserve the selection:
+            if (lastNode) {
+                range = range.cloneRange();
+                range.setStartAfter(lastNode);
+                range.collapse(true);
+                selection.removeAllRanges();
+                selection.addRange(range);
+            }
+        }
+    }
+
     MediumEditor.prototype = {
         defaults: {
             allowMultiParagraphSelection: true,
@@ -1511,21 +1544,34 @@ else if (typeof define === 'function' && define.amd) {
             this.pasteWrapper = function (e) {
                 var paragraphs,
                     html = '',
-                    p;
+                    p,
+                    dataFormatHTML = 'text/html',
+                    dataFormatPlain = 'text/plain';
 
                 this.classList.remove('medium-editor-placeholder');
                 if (!self.options.forcePlainText && !self.options.cleanPastedHTML) {
                     return this;
                 }
 
+                if (window.clipboardData && e.clipboardData === undefined) {
+                    e.clipboardData = window.clipboardData;
+                    // If window.clipboardData exists, but e.clipboardData doesn't exist,
+                    // we're probably in IE. IE only has two possibilities for clipboard
+                    // data format: 'Text' and 'URL'.
+                    //
+                    // Of the two, we want 'Text':
+                    dataFormatHTML = 'Text';
+                    dataFormatPlain = 'Text';
+                }
+
                 if (e.clipboardData && e.clipboardData.getData && !e.defaultPrevented) {
                     e.preventDefault();
 
-                    if (self.options.cleanPastedHTML && e.clipboardData.getData('text/html')) {
-                        return self.cleanPaste(e.clipboardData.getData('text/html'));
+                    if (self.options.cleanPastedHTML && e.clipboardData.getData(dataFormatHTML)) {
+                        return self.cleanPaste(e.clipboardData.getData(dataFormatHTML));
                     }
                     if (!(self.options.disableReturn || this.getAttribute('data-disable-return'))) {
-                        paragraphs = e.clipboardData.getData('text/plain').split(/[\r\n]/g);
+                        paragraphs = e.clipboardData.getData(dataFormatPlain).split(/[\r\n]/g);
                         for (p = 0; p < paragraphs.length; p += 1) {
                             if (paragraphs[p] !== '') {
                                 if (navigator.userAgent.match(/firefox/i) && p === 0) {
@@ -1535,10 +1581,10 @@ else if (typeof define === 'function' && define.amd) {
                                 }
                             }
                         }
-                        self.options.ownerDocument.execCommand('insertHTML', false, html);
+                        insertHTMLCommand(self.options.ownerDocument, html);
                     } else {
-                        html = self.htmlEntities(e.clipboardData.getData('text/plain'));
-                        self.options.ownerDocument.execCommand('insertHTML', false, html);
+                        html = self.htmlEntities(e.clipboardData.getData(dataFormatPlain));
+                        insertHTMLCommand(self.options.ownerDocument, html);
                     }
                 }
             };


### PR DESCRIPTION
here's one approach to resolving #340.

here's stuff I found:
1. the `event` object (used as `e` in the code) doesn't have a `clipboardData` object in IE. instead, `clipboardData` is on window.
2. once we finally get `clipboardData`, its `getData` method [takes different strings for arguments in IE](http://msdn.microsoft.com/en-us/library/ie/ms536436%28v=vs.85%29.aspx). Looks like we want to pass `'Text'`  in that case.
3. IE11 no longer supports `document.execCommand('insertHTML' ... )`, so we need to use a different strategy for inserting the content into the document.
