### PR TITLE
Fix updateOnEmptySelection option

### DIFF
--- a/src/js/selection.js
+++ b/src/js/selection.js
@@ -209,7 +209,7 @@ var Selection;
 
         getSelectionRange: function (ownerDocument) {
             var selection = ownerDocument.getSelection();
-            if (selection.rangeCount === 0 || true === selection.isCollapsed) {
+            if (selection.rangeCount === 0) {
                 return null;
             }
             return selection.getRangeAt(0);


### PR DESCRIPTION
We allow the toolbar to be updated even with a collapsed range when the user enables the `staticToolbar` option along with the `updateOnEmptySelection` option.

Since this is a valid case where we want a range even if the selection is collapsed, `getSelectionRange()` should still return a range in this case.