### PR TITLE
Remove Unused Methods

### DIFF
--- a/spec/extension.spec.js
+++ b/spec/extension.spec.js
@@ -26,29 +26,6 @@ describe('Extensions TestCase', function () {
             expect(editor.options.extensions).toBe(extensions);
         });
 
-        it('should call methods on all extensions with callExtensions is used', function () {
-            var Extension = function () {},
-                ext1 = new Extension(),
-                ext2 = new Extension(),
-                editor = this.newMediumEditor('.editor', {
-                    extensions: {
-                        'one': ext1,
-                        'two': ext2
-                    }
-                });
-
-            Extension.prototype.aMethod = function () {
-                // just a stub function
-            };
-
-            spyOn(ext1, 'aMethod');
-            spyOn(ext2, 'aMethod');
-
-            editor.callExtensions('aMethod', 'theParam');
-            expect(ext1.aMethod).toHaveBeenCalledWith('theParam');
-            expect(ext2.aMethod).toHaveBeenCalledWith('theParam');
-        });
-
         it('should set the base property to an instance of MediumEditor', function () {
             var extOne = new MediumEditor.Extension(),
                 editor = this.newMediumEditor('.editor', {

--- a/spec/util.spec.js
+++ b/spec/util.spec.js
@@ -79,42 +79,6 @@ describe('Util', function () {
         });
     });
 
-    describe('getobject', function () {
-        it('should get nested objects', function () {
-            var obj = { a: { b: { c: { d: 10 } } } };
-            expect(Util.getObject('a.b.c.d', false, obj)).toBe(10);
-            expect(Util.getObject('a.b.c.d', false, false)).toBe(undefined);
-            expect(Util.getObject(false, false, obj)).toBe(obj);
-            expect(Util.getObject('a.b.c', false, obj)).toEqual({ d: 10 });
-            expect(Util.getObject('a', false, obj)).toEqual({ b: { c: { d: 10 } } });
-        });
-
-        it('should create a path if told to', function () {
-            var obj = {};
-            expect(Util.getObject('a.b.c.d', true, obj)).toEqual({});
-            expect(obj.a.b.c.d).toBeTruthy();
-        });
-
-        it('should NOT create a path', function () {
-            var obj = {};
-            expect(Util.getObject('a.b.c.d.e.f.g', false, obj)).toBe(undefined);
-            expect(obj.a).toBe(undefined);
-        });
-    });
-
-    describe('setobject', function () {
-        it('sets returns the value', function () {
-            var obj = {};
-            expect(Util.setObject('a.b.c', 10, obj)).toBe(10);
-            expect(obj.a.b.c).toBe(10);
-        });
-
-        it('sets returns undefined because of empty string', function () {
-            var obj = {};
-            expect(Util.setObject('', 10, obj)).toBe(undefined);
-        });
-    });
-
     describe('settargetblank', function () {
         it('sets target blank on a A element from a A element', function () {
             var el = this.createElement('a', '', 'lorem ipsum');

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -648,34 +648,6 @@ function MediumEditor(elements, options) {
             return extension;
         },
 
-        /**
-         * NOT DOCUMENTED - exposed for backwards compatability
-         * Helper function to call a method with a number of parameters on all registered extensions.
-         * The function assures that the function exists before calling.
-         *
-         * @param {string} funcName name of the function to call
-         * @param [args] arguments passed into funcName
-         */
-        callExtensions: function (funcName) {
-            if (arguments.length < 1) {
-                return;
-            }
-
-            var args = Array.prototype.slice.call(arguments, 1),
-                ext,
-                name;
-
-            for (name in this.options.extensions) {
-                if (this.options.extensions.hasOwnProperty(name)) {
-                    ext = this.options.extensions[name];
-                    if (ext[funcName] !== undefined) {
-                        ext[funcName].apply(ext, args);
-                    }
-                }
-            }
-            return this;
-        },
-
         stopSelectionUpdates: function () {
             this.preventSelectionUpdates = true;
         },

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -5,31 +5,6 @@ var Util;
 (function (window) {
     'use strict';
 
-    // Params: Array, Boolean, Object
-    function getProp(parts, create, context) {
-        if (!context) {
-            context = window;
-        }
-
-        try {
-            for (var i = 0; i < parts.length; i++) {
-                var p = parts[i];
-                if (!(p in context)) {
-                    if (create) {
-                        context[p] = {};
-                    } else {
-                        return;
-                    }
-                }
-                context = context[p];
-            }
-            return context;
-        } catch (e) {
-            // 'p in context' throws an exception when context is a number, boolean, etc. rather than an object,
-            // so in that corner case just return undefined (by having no return statement)
-        }
-    }
-
     function copyInto(overwrite, dest) {
         var prop,
             sources = Array.prototype.slice.call(arguments, 2);
@@ -698,22 +673,6 @@ var Util;
             } else {
                 el.parentNode.removeChild(el);
             }
-        },
-
-        setObject: function (name, value, context) {
-            // summary:
-            //      Set a property from a dot-separated string, such as 'A.B.C'
-            var parts = name.split('.'),
-                p = parts.pop(),
-                obj = getProp(parts, true, context);
-            return obj && p ? (obj[p] = value) : undefined; // Object
-        },
-
-        getObject: function (name, create, context) {
-            // summary:
-            //      Get a property from a dot-separated string, such as 'A.B.C'
-            return getProp(name ? name.split('.') : [], create, context); // Object
         }
-
     };
 }(window));

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -100,16 +100,6 @@ var Util;
             return copyInto.apply(this, args);
         },
 
-        derives: function derives(base, derived) {
-            var origPrototype = derived.prototype;
-            function Proto() { }
-            Proto.prototype = base.prototype;
-            derived.prototype = new Proto();
-            derived.prototype.constructor = base;
-            derived.prototype = copyInto(false, derived.prototype, origPrototype);
-            return derived;
-        },
-
         // Find the next node in the DOM tree that represents any text that is being
         // displayed directly next to the targetNode (passed as an argument)
         // Text that appears directly next to the current node can be:


### PR DESCRIPTION
This PR removes some old methods that we aren't currently using and which would be good to remove since we're prepping v5.0.0 right now.

* `MediumEditor.callExtensions()`
* `MediumEditor.util.getObject()`
* `MediumEditor.util.setObject()`