### PR TITLE
Redesign Header Buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ var editor = new MediumEditor('.editable', {
 * __diffLeft__: value in pixels to be added to the X axis positioning of the toolbar. Default: `0`
 * __diffTop__: value in pixels to be added to the Y axis positioning of the toolbar. Default: `-10`
 * __firstButtonClass__: CSS class added to the first button in the toolbar. Default: `'medium-editor-button-first'`
-* __headerTags__: the types of html elements to create when the <kbd>H1</kbd>, <kbd>H2</kbd>, or <kbd>H3</kbd> toolbar buttons are clicked.  The first element in the array (index 0) indicates which tag name (ie `<h3>`) will be used when the <kbd>H1</kbd> button is clicked.  The second element in the array (index 1) corresponds to the <kbd>H2</kbd> button and the last element (index 2) corresponds to the <kbd>H3</kbd> button. Default: `['h2', 'h3', 'h4']`
+* __headerTags__: the types of html elements to create when the <kbd>H1</kbd>, <kbd>H2</kbd>, or <kbd>H3</kbd> toolbar buttons are clicked.  The first element in the array (index 0) indicates which tag name (ie `<h2>`) will be used when the <kbd>H1</kbd> button is clicked.  The second element in the array (index 1) corresponds to the <kbd>H2</kbd> button and the last element (index 2) corresponds to the <kbd>H3</kbd> button. Default: `['h2', 'h3', 'h4']`
 * __lastButtonClass__: CSS class added to the last button in the toolbar. Default: `'medium-editor-button-last'`
 * __standardizeSelectionStart__: enables/disables standardizing how the beginning of a range is decided between browsers whenever the selected text is analyzed for updating toolbar buttons status. Default: `false`
 * __static__: enable/disable the toolbar always displaying in the same location relative to the medium-editor element. Default: `false`

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ var editor = new MediumEditor('.editable', {
         diffLeft: 0,
         diffTop: -10,
         firstButtonClass: 'medium-editor-button-first',
-        headerTags: ['h3', 'h4', 'h5'],
+        headerTags: ['h2', 'h3', 'h4'],
         lastButtonClass: 'medium-editor-button-last',
         standardizeSelectionStart: false,
         static: false,
@@ -134,7 +134,7 @@ var editor = new MediumEditor('.editable', {
 * __diffLeft__: value in pixels to be added to the X axis positioning of the toolbar. Default: `0`
 * __diffTop__: value in pixels to be added to the Y axis positioning of the toolbar. Default: `-10`
 * __firstButtonClass__: CSS class added to the first button in the toolbar. Default: `'medium-editor-button-first'`
-* __headerTags__: the types of html elements to create when the h1, h2, or h3 toolbar buttons are clicked.  The first element in the array (index 0) indicates which tag name (ie `<h3>`) will be used when the <kbd>H1</kbd> button is clicked.  The second elemenet (index 1) corresponds to the <kbd>H2<kbd> button and the last element (index 2) corresponds to the <kbd>H3</kbd> button. Default: `['h3', 'h4', 'h5']`
+* __headerTags__: the types of html elements to create when the <kbd>H1</kbd>, <kbd>H2</kbd>, or <kbd>H3</kbd> toolbar buttons are clicked.  The first element in the array (index 0) indicates which tag name (ie `<h3>`) will be used when the <kbd>H1</kbd> button is clicked.  The second element in the array (index 1) corresponds to the <kbd>H2</kbd> button and the last element (index 2) corresponds to the <kbd>H3</kbd> button. Default: `['h2', 'h3', 'h4']`
 * __lastButtonClass__: CSS class added to the last button in the toolbar. Default: `'medium-editor-button-last'`
 * __standardizeSelectionStart__: enables/disables standardizing how the beginning of a range is decided between browsers whenever the selected text is analyzed for updating toolbar buttons status. Default: `false`
 * __static__: enable/disable the toolbar always displaying in the same location relative to the medium-editor element. Default: `false`
@@ -338,10 +338,10 @@ var editor = new MediumEditor('.editable', {
     delay: 1000,
     targetBlank: true,
     toolbar: {
-        buttons: ['bold', 'italic', 'quote'],
+        buttons: ['bold', 'italic', 'quote', 'h1', 'h2', 'h3'],
         diffLeft: 25,
         diffTop: 10,
-        headerTags: ['h1', 'h2']
+        headerTags: ['h1', 'h3', 'h5']
     },
     anchor: {
         placeholderText: 'Type a link',

--- a/README.md
+++ b/README.md
@@ -100,8 +100,6 @@ MediumEditor also supports textarea. If you provide a textarea element, the scri
 * __disableEditing__: enables/disables adding the contenteditable behavior. Useful for using the toolbar with customized buttons/actions. You can also set specific element behavior by using setting a data-disable-editing attribute. Default: `false`
 * __elementsContainer__: specifies a DOM node to contain MediumEditor's toolbar and anchor preview elements. Default: `document.body`
 * __extensions__: extension to use (see [Custom Buttons and Extensions](https://github.com/yabwe/medium-editor/wiki/Custom-Buttons-and-Extensions)) for more. Default: `{}`
-* __firstHeader__: HTML tag to be used as first header. Default: `h3`
-* __secondHeader__: HTML tag to be used as second header. Default: `h4`
 * __spellcheck__: Enable/disable native contentEditable automatic spellcheck. Default: `true`
 * __targetBlank__: enables/disables target="\_blank" for anchor tags. Default: `false`
 
@@ -115,10 +113,11 @@ var editor = new MediumEditor('.editable', {
     toolbar: {
         /* These are the default options for the toolbar,
            if nothing is passed this is what is used */
-        buttons: ['bold', 'italic', 'underline', 'anchor', 'header1', 'header2', 'quote'],
+        buttons: ['bold', 'italic', 'underline', 'anchor', 'h1', 'h2', 'quote'],
         diffLeft: 0,
         diffTop: -10,
         firstButtonClass: 'medium-editor-button-first',
+        headerTags: ['h3', 'h4', 'h5'],
         lastButtonClass: 'medium-editor-button-last',
         standardizeSelectionStart: false,
         static: false,
@@ -131,10 +130,11 @@ var editor = new MediumEditor('.editable', {
 });
 ```
 
-* __buttons__: the set of buttons to display on the toolbar. Default: `['bold', 'italic', 'underline', 'anchor', 'header1', 'header2', 'quote']`
+* __buttons__: the set of buttons to display on the toolbar. Default: `['bold', 'italic', 'underline', 'anchor', 'h1', 'h2', 'quote']`
 * __diffLeft__: value in pixels to be added to the X axis positioning of the toolbar. Default: `0`
 * __diffTop__: value in pixels to be added to the Y axis positioning of the toolbar. Default: `-10`
 * __firstButtonClass__: CSS class added to the first button in the toolbar. Default: `'medium-editor-button-first'`
+* __headerTags__: the types of html elements to create when the h1, h2, or h3 toolbar buttons are clicked.  The first element in the array (index 0) indicates which tag name (ie `<h3>`) will be used when the <kbd>H1</kbd> button is clicked.  The second elemenet (index 1) corresponds to the <kbd>H2<kbd> button and the last element (index 2) corresponds to the <kbd>H3</kbd> button. Default: `['h3', 'h4', 'h5']`
 * __lastButtonClass__: CSS class added to the last button in the toolbar. Default: `'medium-editor-button-last'`
 * __standardizeSelectionStart__: enables/disables standardizing how the beginning of a range is decided between browsers whenever the selected text is analyzed for updating toolbar buttons status. Default: `false`
 * __static__: enable/disable the toolbar always displaying in the same location relative to the medium-editor element. Default: `false`
@@ -335,14 +335,13 @@ var editor = new MediumEditor('.editable', {
 
 ```javascript
 var editor = new MediumEditor('.editable', {
-    firstHeader: 'h1',
-    secondHeader: 'h2',
     delay: 1000,
     targetBlank: true,
     toolbar: {
         buttons: ['bold', 'italic', 'quote'],
         diffLeft: 25,
         diffTop: 10,
+        headerTags: ['h1', 'h2']
     },
     anchor: {
         placeholderText: 'Type a link',
@@ -365,22 +364,31 @@ var editor = new MediumEditor('.editable', {
 
 ## Extra buttons
 
-Medium Editor, by default, will show only the buttons listed above to avoid a huge toolbar. There are a few extra buttons you can use:
+Medium Editor, by default, will show only the buttons listed above to avoid a huge toolbar. However, there are some additional built-in buttons which can be used.
 
-* __superscript__
-* __subscript__
-* __strikethrough__
-* __unorderedlist__
-* __orderedlist__
-* __pre__
-* __justifyLeft__
-* __justifyFull__
-* __justifyCenter__
-* __justifyRight__
+#### All bult-in buttons supported by MediumEditor
+
+* __bold__ _(enabled by default)_
+* __h1__ _(enabled by default)_
+* __h2__ _(enabled by default)_
+* __h3__
 * __image__ (this simply converts selected text to an image tag)
 * __indent__ (moves the selected text up one level)
+* __italic__ _(enabled by default)_
+* __justifyCenter__
+* __justifyFull__
+* __justifyLeft__
+* __justifyRight__
+* __orderedlist__
 * __outdent__ (moves the selected text down one level)
+* __pre__
+* __quote__ _(enabled by default)_
 * __removeFormat__ (clears inline style formatting, preserves blocks)
+* __strikethrough__
+* __subscript__
+* __superscript__
+* __underline__ _(enabled by default)_
+* __unorderedlist__
 
 
 ## Themes

--- a/demo/css/demo.css
+++ b/demo/css/demo.css
@@ -36,14 +36,19 @@ h1 {
     border-bottom: 1px solid #dbdbdb;
 }
 
-h3 {
+h2 {
     font-size: 32px;
     line-height: 42px;
 }
 
-h4 {
+h3 {
     font-size: 26px;
     line-height: 32px;
+}
+
+h4 {
+    font-size: 24px;
+    line-height: 28px;
 }
 
 p {

--- a/demo/custom-toolbar.html
+++ b/demo/custom-toolbar.html
@@ -27,7 +27,7 @@
     <script>
         var editor = new MediumEditor('.editable', {
                 toolbar: {
-                    buttons: ['bold', 'italic', 'underline', 'strikethrough', 'quote', 'anchor', 'image', 'justifyLeft', 'justifyCenter', 'justifyRight', 'justifyFull', 'superscript', 'subscript', 'orderedlist', 'unorderedlist', 'pre', 'removeFormat', 'outdent', 'indent', 'header1', 'header2'],
+                    buttons: ['bold', 'italic', 'underline', 'strikethrough', 'quote', 'anchor', 'image', 'justifyLeft', 'justifyCenter', 'justifyRight', 'justifyFull', 'superscript', 'subscript', 'orderedlist', 'unorderedlist', 'pre', 'removeFormat', 'outdent', 'indent', 'h1', 'h2', 'h3'],
                 },
                 buttonLabels: 'fontawesome',
                 anchor: {

--- a/demo/multi-paragraph.html
+++ b/demo/multi-paragraph.html
@@ -28,11 +28,10 @@
     <script>
         var editor = new MediumEditor('.editable', {
             allowMultiParagraphSelection: false,
-            firstHeader: 'h1',
-            secondHeader: 'h2',
             delay: 0,
             toolbar: {
-                diffTop: -12
+                diffTop: -12,
+                headerTags: ['h1', 'h2']
             },
             anchor: {
                 placeholderText: 'Type a link'

--- a/demo/static-toolbar.html
+++ b/demo/static-toolbar.html
@@ -47,7 +47,7 @@
     <script>
         var editor = new MediumEditor('.editable', {
                 toolbar: {
-                    buttons: ['bold', 'italic', 'underline', 'strikethrough', 'quote', 'anchor', 'image', 'justifyLeft', 'justifyCenter', 'justifyRight', 'justifyFull', 'superscript', 'subscript', 'orderedlist', 'unorderedlist', 'pre', 'outdent', 'indent', 'header1', 'header2'],
+                    buttons: ['bold', 'italic', 'underline', 'strikethrough', 'quote', 'anchor', 'image', 'justifyLeft', 'justifyCenter', 'justifyRight', 'justifyFull', 'superscript', 'subscript', 'orderedlist', 'unorderedlist', 'pre', 'outdent', 'indent', 'h1', 'h2', 'h3'],
                     static: true,
                     sticky: true
                 }
@@ -55,7 +55,7 @@
 
         var editorColOne = new MediumEditor('#column-one', {
                 toolbar: {
-                    buttons: ['bold', 'italic', 'underline', 'strikethrough', 'quote', 'anchor', 'image', 'justifyLeft', 'justifyCenter', 'justifyRight', 'justifyFull', 'superscript', 'subscript', 'orderedlist', 'unorderedlist', 'pre', 'outdent', 'indent', 'header1', 'header2'],
+                    buttons: ['bold', 'italic', 'underline', 'strikethrough', 'quote', 'anchor', 'image', 'justifyLeft', 'justifyCenter', 'justifyRight', 'justifyFull', 'superscript', 'subscript', 'orderedlist', 'unorderedlist', 'pre', 'outdent', 'indent', 'h1', 'h2', 'h3'],
                     sticky: true,
                     static: true,
                     align: 'left',
@@ -66,7 +66,7 @@
 
         var editorColTwo = new MediumEditor('#column-two', {
                 toolbar: {
-                    buttons: ['bold', 'italic', 'underline', 'strikethrough', 'quote', 'anchor', 'image', 'justifyLeft', 'justifyCenter', 'justifyRight', 'justifyFull', 'superscript', 'subscript', 'orderedlist', 'unorderedlist', 'pre', 'outdent', 'indent', 'header1', 'header2'],
+                    buttons: ['bold', 'italic', 'underline', 'strikethrough', 'quote', 'anchor', 'image', 'justifyLeft', 'justifyCenter', 'justifyRight', 'justifyFull', 'superscript', 'subscript', 'orderedlist', 'unorderedlist', 'pre', 'outdent', 'indent', 'h1', 'h2', 'h3'],
                     sticky: true,
                     static: true,
                     align: 'center',
@@ -77,7 +77,7 @@
 
         var editorColThree = new MediumEditor('#column-three', {
                 toolbar: {
-                    buttons: ['bold', 'italic', 'underline', 'strikethrough', 'quote', 'anchor', 'image', 'justifyLeft', 'justifyCenter', 'justifyRight', 'justifyFull', 'superscript', 'subscript', 'orderedlist', 'unorderedlist', 'pre', 'outdent', 'indent', 'header1', 'header2'],
+                    buttons: ['bold', 'italic', 'underline', 'strikethrough', 'quote', 'anchor', 'image', 'justifyLeft', 'justifyCenter', 'justifyRight', 'justifyFull', 'superscript', 'subscript', 'orderedlist', 'unorderedlist', 'pre', 'outdent', 'indent', 'h1', 'h2', 'h3'],
                     sticky: true,
                     static: true,
                     align: 'right',

--- a/spec/buttons.spec.js
+++ b/spec/buttons.spec.js
@@ -218,38 +218,38 @@ describe('Buttons TestCase', function () {
                 toolbar = editor.getExtensionByName('toolbar');
             selectElementContentsAndFire(editor.elements[0]);
             jasmine.clock().tick(1);
-            button = toolbar.getToolbarElement().querySelector('[data-action="append-h3"]');
+            button = toolbar.getToolbarElement().querySelector('[data-action="append-h2"]');
             fireEvent(button, 'click');
             if (isIE()) {
-                expect(document.execCommand).toHaveBeenCalledWith('formatBlock', false, '<h3>');
+                expect(document.execCommand).toHaveBeenCalledWith('formatBlock', false, '<h2>');
             } else {
-                expect(document.execCommand).toHaveBeenCalledWith('formatBlock', false, 'h3');
+                expect(document.execCommand).toHaveBeenCalledWith('formatBlock', false, 'h2');
             }
         });
 
-        it('should create an h3 element when h1 is clicked', function () {
+        it('should create an h2 element when h1 is clicked', function () {
             this.el.innerHTML = '<p><b>lorem ipsum</b></p>';
             var button,
                 editor = this.newMediumEditor('.editor'),
                 toolbar = editor.getExtensionByName('toolbar');
             selectElementContentsAndFire(editor.elements[0]);
             jasmine.clock().tick(1);
-            button = toolbar.getToolbarElement().querySelector('[data-action="append-h3"]');
+            button = toolbar.getToolbarElement().querySelector('[data-action="append-h2"]');
             fireEvent(button, 'click');
             // depending on the styling you have,
-            // IE might strip the <b> out when it applies the H3 here.
+            // IE might strip the <b> out when it applies the H2 here.
             // so, make the <b> match optional in the output:
-            expect(this.el.innerHTML).toMatch(/<h3>(<b>)?lorem ipsum(<\/b>)?<\/h3>/);
+            expect(this.el.innerHTML).toMatch(/<h2>(<b>)?lorem ipsum(<\/b>)?<\/h2>/);
         });
 
         it('should get back to a p element if parent element is the same as the action', function () {
-            this.el.innerHTML = '<h3><b>lorem ipsum</b></h3>';
+            this.el.innerHTML = '<h2><b>lorem ipsum</b></h2>';
             var button,
                 editor = this.newMediumEditor('.editor'),
                 toolbar = editor.getExtensionByName('toolbar');
             selectElementContentsAndFire(editor.elements[0].firstChild);
             jasmine.clock().tick(1);
-            button = toolbar.getToolbarElement().querySelector('[data-action="append-h3"]');
+            button = toolbar.getToolbarElement().querySelector('[data-action="append-h2"]');
             fireEvent(button, 'click');
             expect(this.el.innerHTML).toBe('<p><b>lorem ipsum</b></p>');
         });
@@ -847,27 +847,27 @@ describe('Buttons TestCase', function () {
                     }
                 }),
                 toolbar = editor.getExtensionByName('toolbar'),
-                buttonOne = toolbar.getToolbarElement().querySelector('[data-action="append-h3"]'),
-                buttonTwo = toolbar.getToolbarElement().querySelector('[data-action="append-h4"]'),
-                buttonThree = toolbar.getToolbarElement().querySelector('[data-action="append-h5"]');
+                buttonOne = toolbar.getToolbarElement().querySelector('[data-action="append-h2"]'),
+                buttonTwo = toolbar.getToolbarElement().querySelector('[data-action="append-h3"]'),
+                buttonThree = toolbar.getToolbarElement().querySelector('[data-action="append-h4"]');
 
-            this.el.innerHTML = '<h2>lorem</h2><h3>ipsum</h3><h4>dolor</h4><h5>lorem</h5>';
-            selectElementContentsAndFire(editor.elements[0].querySelector('h2'));
+            this.el.innerHTML = '<h1>lorem</h1><h2>ipsum</h2><h3>dolor</h3><h4>lorem</h4>';
+            selectElementContentsAndFire(editor.elements[0].querySelector('h1'));
             expect(buttonOne.classList.contains('medium-editor-button-active')).toBe(false);
             expect(buttonTwo.classList.contains('medium-editor-button-active')).toBe(false);
             expect(buttonThree.classList.contains('medium-editor-button-active')).toBe(false);
 
-            selectElementContentsAndFire(editor.elements[0].querySelector('h3'), { eventToFire: 'mouseup' });
+            selectElementContentsAndFire(editor.elements[0].querySelector('h2'), { eventToFire: 'mouseup' });
             expect(buttonOne.classList.contains('medium-editor-button-active')).toBe(true);
             expect(buttonTwo.classList.contains('medium-editor-button-active')).toBe(false);
             expect(buttonThree.classList.contains('medium-editor-button-active')).toBe(false);
 
-            selectElementContentsAndFire(editor.elements[0].querySelector('h4'), { eventToFire: 'mouseup' });
+            selectElementContentsAndFire(editor.elements[0].querySelector('h3'), { eventToFire: 'mouseup' });
             expect(buttonOne.classList.contains('medium-editor-button-active')).toBe(false);
             expect(buttonTwo.classList.contains('medium-editor-button-active')).toBe(true);
             expect(buttonThree.classList.contains('medium-editor-button-active')).toBe(false);
 
-            selectElementContentsAndFire(editor.elements[0].querySelector('h5'), { eventToFire: 'mouseup' });
+            selectElementContentsAndFire(editor.elements[0].querySelector('h4'), { eventToFire: 'mouseup' });
             expect(buttonOne.classList.contains('medium-editor-button-active')).toBe(false);
             expect(buttonTwo.classList.contains('medium-editor-button-active')).toBe(false);
             expect(buttonThree.classList.contains('medium-editor-button-active')).toBe(true);

--- a/spec/buttons.spec.js
+++ b/spec/buttons.spec.js
@@ -104,26 +104,24 @@ describe('Buttons TestCase', function () {
             tempEl;
 
         Object.keys(buttonsData).forEach(function (buttonName) {
-            if (buttonName !== 'header1' && buttonName !== 'header2') {
-                allButtons.push(buttonName);
-                currButton = buttonsData[buttonName];
-                // If the labels contain HTML entities, we need to escape them
-                tempEl = document.createElement('div');
+            allButtons.push(buttonName);
+            currButton = buttonsData[buttonName];
+            // If the labels contain HTML entities, we need to escape them
+            tempEl = document.createElement('div');
 
-                // Default Labels
-                tempEl.innerHTML = currButton.contentDefault;
-                defaultLabels[buttonName] = {
-                    action: currButton.action,
-                    label: tempEl.innerHTML
-                };
+            // Default Labels
+            tempEl.innerHTML = currButton.contentDefault;
+            defaultLabels[buttonName] = {
+                action: currButton.action,
+                label: tempEl.innerHTML
+            };
 
-                // fontawesome labels
-                tempEl.innerHTML = currButton.contentFA;
-                fontAwesomeLabels[buttonName] = tempEl.innerHTML;
+            // fontawesome labels
+            tempEl.innerHTML = currButton.contentFA;
+            fontAwesomeLabels[buttonName] = tempEl.innerHTML;
 
-                // custom labels (using aria label as a test)
-                customLabels[buttonName] = currButton.aria;
-            }
+            // custom labels (using aria label as a test)
+            customLabels[buttonName] = currButton.aria;
         });
 
         it('should have aria-label and title attributes set', function () {
@@ -229,7 +227,7 @@ describe('Buttons TestCase', function () {
             }
         });
 
-        it('should create an h3 element when header1 is clicked', function () {
+        it('should create an h3 element when h1 is clicked', function () {
             this.el.innerHTML = '<p><b>lorem ipsum</b></p>';
             var button,
                 editor = this.newMediumEditor('.editor'),
@@ -845,62 +843,75 @@ describe('Buttons TestCase', function () {
         it('buttons should be active if the selection already has the element', function () {
             var editor = this.newMediumEditor('.editor', {
                     toolbar: {
-                        buttons: ['header1', 'header2']
+                        buttons: ['h1', 'h2', 'h3']
                     }
                 }),
                 toolbar = editor.getExtensionByName('toolbar'),
                 buttonOne = toolbar.getToolbarElement().querySelector('[data-action="append-h3"]'),
-                buttonTwo = toolbar.getToolbarElement().querySelector('[data-action="append-h4"]');
+                buttonTwo = toolbar.getToolbarElement().querySelector('[data-action="append-h4"]'),
+                buttonThree = toolbar.getToolbarElement().querySelector('[data-action="append-h5"]');
 
-            this.el.innerHTML = '<h2>lorem</h2><h3>ipsum</h3><h4>dolor</h4>';
+            this.el.innerHTML = '<h2>lorem</h2><h3>ipsum</h3><h4>dolor</h4><h5>lorem</h5>';
             selectElementContentsAndFire(editor.elements[0].querySelector('h2'));
             expect(buttonOne.classList.contains('medium-editor-button-active')).toBe(false);
             expect(buttonTwo.classList.contains('medium-editor-button-active')).toBe(false);
+            expect(buttonThree.classList.contains('medium-editor-button-active')).toBe(false);
 
             selectElementContentsAndFire(editor.elements[0].querySelector('h3'), { eventToFire: 'mouseup' });
             expect(buttonOne.classList.contains('medium-editor-button-active')).toBe(true);
             expect(buttonTwo.classList.contains('medium-editor-button-active')).toBe(false);
+            expect(buttonThree.classList.contains('medium-editor-button-active')).toBe(false);
 
             selectElementContentsAndFire(editor.elements[0].querySelector('h4'), { eventToFire: 'mouseup' });
             expect(buttonOne.classList.contains('medium-editor-button-active')).toBe(false);
             expect(buttonTwo.classList.contains('medium-editor-button-active')).toBe(true);
+            expect(buttonThree.classList.contains('medium-editor-button-active')).toBe(false);
+
+            selectElementContentsAndFire(editor.elements[0].querySelector('h5'), { eventToFire: 'mouseup' });
+            expect(buttonOne.classList.contains('medium-editor-button-active')).toBe(false);
+            expect(buttonTwo.classList.contains('medium-editor-button-active')).toBe(false);
+            expect(buttonThree.classList.contains('medium-editor-button-active')).toBe(true);
         });
 
         it('buttons should be active if the selection already custom defined element types', function () {
             var editor = this.newMediumEditor('.editor', {
                     toolbar: {
-                        buttons: ['header1', 'header2']
-                    },
-                    firstHeader: 'h1',
-                    secondHeader: 'h5'
+                        buttons: ['h1', 'h2', 'h3'],
+                        headerTags: ['h1', 'h4', 'h6']
+                    }
                 }),
                 toolbar = editor.getExtensionByName('toolbar'),
                 buttonOne = toolbar.getToolbarElement().querySelector('[data-action="append-h1"]'),
-                buttonTwo = toolbar.getToolbarElement().querySelector('[data-action="append-h5"]');
+                buttonTwo = toolbar.getToolbarElement().querySelector('[data-action="append-h4"]'),
+                buttonThree = toolbar.getToolbarElement().querySelector('[data-action="append-h6"]');
 
             expect(buttonOne).toBeTruthy();
             expect(buttonTwo).toBeTruthy();
+            expect(buttonThree).toBeTruthy();
 
-            this.el.innerHTML = '<h1>lorem</h1><h3>ipsum</h3><h5>dolor</h5>';
+            this.el.innerHTML = '<h1>lorem</h1><h4>ipsum</h4><h6>dolor</h6>';
             selectElementContentsAndFire(editor.elements[0].querySelector('h1'));
             expect(buttonOne.classList.contains('medium-editor-button-active')).toBe(true);
             expect(buttonTwo.classList.contains('medium-editor-button-active')).toBe(false);
+            expect(buttonThree.classList.contains('medium-editor-button-active')).toBe(false);
 
-            selectElementContentsAndFire(editor.elements[0].querySelector('h3'), { eventToFire: 'mouseup' });
-            expect(buttonOne.classList.contains('medium-editor-button-active')).toBe(false);
-            expect(buttonTwo.classList.contains('medium-editor-button-active')).toBe(false);
-
-            selectElementContentsAndFire(editor.elements[0].querySelector('h5'), { eventToFire: 'mouseup' });
+            selectElementContentsAndFire(editor.elements[0].querySelector('h4'), { eventToFire: 'mouseup' });
             expect(buttonOne.classList.contains('medium-editor-button-active')).toBe(false);
             expect(buttonTwo.classList.contains('medium-editor-button-active')).toBe(true);
+            expect(buttonThree.classList.contains('medium-editor-button-active')).toBe(false);
+
+            selectElementContentsAndFire(editor.elements[0].querySelector('h6'), { eventToFire: 'mouseup' });
+            expect(buttonOne.classList.contains('medium-editor-button-active')).toBe(false);
+            expect(buttonTwo.classList.contains('medium-editor-button-active')).toBe(false);
+            expect(buttonThree.classList.contains('medium-editor-button-active')).toBe(true);
         });
 
         it('buttons should convert between element types and "undo" back to original type', function () {
             var editor = this.newMediumEditor('.editor', {
                     toolbar: {
-                        buttons: ['header1', 'header2']
-                    },
-                    firstHeader: 'h1'
+                        buttons: ['h1', 'h2'],
+                        headerTags: ['h1', 'h4']
+                    }
                 }),
                 toolbar = editor.getExtensionByName('toolbar'),
                 buttonOne = toolbar.getToolbarElement().querySelector('[data-action="append-h1"]'),

--- a/spec/init.spec.js
+++ b/spec/init.spec.js
@@ -107,9 +107,7 @@ describe('Initialization TestCase', function () {
                 elementsContainer: document.body,
                 contentWindow: window,
                 ownerDocument: document,
-                firstHeader: 'h3',
                 allowMultiParagraphSelection: true,
-                secondHeader: 'h4',
                 buttonLabels: false,
                 targetBlank: false,
                 extensions: {},
@@ -123,8 +121,6 @@ describe('Initialization TestCase', function () {
 
         it('should accept custom options values', function () {
             var options = {
-                firstHeader: 'h2',
-                secondHeader: 'h3',
                 delay: 300,
                 toolbar: {
                     diffLeft: 10,

--- a/src/js/defaults/buttons.js
+++ b/src/js/defaults/buttons.js
@@ -183,32 +183,6 @@ var buttonDefaults;
             contentDefault: '<b>R</b>',
             contentFA: '<i class="fa fa-align-right"></i>'
         },
-        'header1': {
-            name: 'header1',
-            action: function (options) {
-                return 'append-' + options.firstHeader;
-            },
-            aria: function (options) {
-                return options.firstHeader;
-            },
-            tagNames: function (options) {
-                return [options.firstHeader];
-            },
-            contentDefault: '<b>H1</b>'
-        },
-        'header2': {
-            name: 'header2',
-            action: function (options) {
-                return 'append-' + options.secondHeader;
-            },
-            aria: function (options) {
-                return options.secondHeader;
-            },
-            tagNames: function (options) {
-                return [options.secondHeader];
-            },
-            contentDefault: '<b>H2</b>'
-        },
         // Known inline elements that are not removed, or not removed consistantly across browsers:
         // <span>, <label>, <br>
         'removeFormat': {

--- a/src/js/defaults/options.js
+++ b/src/js/defaults/options.js
@@ -14,8 +14,6 @@ var editorDefaults;
         elementsContainer: false,
         contentWindow: window,
         ownerDocument: document,
-        firstHeader: 'h3',
-        secondHeader: 'h4',
         targetBlank: false,
         extensions: {},
         spellcheck: true

--- a/src/js/extensions/toolbar.js
+++ b/src/js/extensions/toolbar.js
@@ -43,10 +43,10 @@ var Toolbar;
          * to the second header button ('h2') and the last element (index 2) corresponds
          * to the last header button ('h3')
          * NOTE: By Default, medium displays the button as 'h1' but actually creates a
-         * <h3> element.  Thus, the default for medium-editor will also be to create
-         * a <h3> element.
+         * <h2> element.  Thus, the default for medium-editor will also be to create
+         * a <h2> element.
          */
-        headerTags: ['h3', 'h4', 'h5'],
+        headerTags: ['h2', 'h3', 'h4'],
 
         /* lastButtonClass: [string]
          * CSS class added to the last button in the toolbar.

--- a/src/js/extensions/toolbar.js
+++ b/src/js/extensions/toolbar.js
@@ -2,7 +2,7 @@ var Toolbar;
 (function () {
     'use strict';
 
-    /*global Util, Selection, Extension, ButtonsData */
+    /*global Util, Selection, Extension, buttonDefaults */
 
     Toolbar = Extension.extend({
         name: 'toolbar',
@@ -93,7 +93,7 @@ var Toolbar;
                             tagNames: [tag],
                             contentDefault: '<b>' + name.toUpperCase() + '</b>'
                         };
-                    ButtonsData[name] = headerConfig;
+                    buttonDefaults[name] = headerConfig;
                 });
             }
 

--- a/src/js/extensions/toolbar.js
+++ b/src/js/extensions/toolbar.js
@@ -2,7 +2,7 @@ var Toolbar;
 (function () {
     'use strict';
 
-    /*global Util, Selection, Extension */
+    /*global Util, Selection, Extension, ButtonsData */
 
     Toolbar = Extension.extend({
         name: 'toolbar',
@@ -18,7 +18,7 @@ var Toolbar;
         /* buttons: [Array]
          * the names of the set of buttons to display on the toolbar.
          */
-        buttons: ['bold', 'italic', 'underline', 'anchor', 'header1', 'header2', 'quote'],
+        buttons: ['bold', 'italic', 'underline', 'anchor', 'h1', 'h2', 'quote'],
 
         /* diffLeft: [Number]
          * value in pixels to be added to the X axis positioning of the toolbar.
@@ -34,6 +34,14 @@ var Toolbar;
          * CSS class added to the first button in the toolbar.
          */
         firstButtonClass: 'medium-editor-button-first',
+
+        /* headerTags: [Array]
+         * the types of html elements to create when the h1, h2, or h3 toolbar
+         * buttons are clicked.
+         * The h1 button corresponds to tne tag at index 0 in the array
+         * The h2 button corresponds to index 1, and h3 to index 2
+         */
+        headerTags: ['h3', 'h4', 'h5'],
 
         /* lastButtonClass: [string]
          * CSS class added to the last button in the toolbar.
@@ -68,6 +76,21 @@ var Toolbar;
 
         init: function () {
             Extension.prototype.init.apply(this, arguments);
+
+            // Add headers into button defaults
+            if (this.headerTags && this.headerTags.length) {
+                this.headerTags.forEach(function (tag, index) {
+                    var name = 'h' + (index + 1),
+                        headerConfig = {
+                            name: name,
+                            action: 'append-' + tag,
+                            aria: tag,
+                            tagNames: [tag],
+                            contentDefault: '<b>' + name.toUpperCase() + '</b>'
+                        };
+                    ButtonsData[name] = headerConfig;
+                });
+            }
 
             this.initThrottledMethods();
             this.getEditorOption('elementsContainer').appendChild(this.getToolbarElement());

--- a/src/js/extensions/toolbar.js
+++ b/src/js/extensions/toolbar.js
@@ -37,9 +37,14 @@ var Toolbar;
 
         /* headerTags: [Array]
          * the types of html elements to create when the h1, h2, or h3 toolbar
-         * buttons are clicked.
-         * The h1 button corresponds to tne tag at index 0 in the array
-         * The h2 button corresponds to index 1, and h3 to index 2
+         * buttons are clicked.  The first element in the array (index 0) indicates
+         * which element type (tag name) will be used when the first header button
+         * is clicked (the 'H1' button).  The second elemenet (index 1) corresponds
+         * to the second header button ('h2') and the last element (index 2) corresponds
+         * to the last header button ('h3')
+         * NOTE: By Default, medium displays the button as 'h1' but actually creates a
+         * <h3> element.  Thus, the default for medium-editor will also be to create
+         * a <h3> element.
          */
         headerTags: ['h3', 'h4', 'h5'],
 


### PR DESCRIPTION
This PR is a proposal on how to handle configuration for the header buttons in MediumEditor.

![screen shot 2015-06-05 at 8 54 44 am](https://cloud.githubusercontent.com/assets/2444240/8006315/a2c7a570-0b60-11e5-9698-0d2274c40ee4.png)

Proposal:
* There are up to 3 different header buttons which can be enabled in the toolbar (this aligns with what medium actually supports)
* These 3 buttons are configured by passing the corresponding button names into the `buttons` array of the `toolbar` options:
  * `'h1'` for the <kbd>H1</kbd> Button
  * `'h2'` for the <kbd>H2</kbd> Button
  * `'h3'` for the <kbd>H3</kbd> Button
* By default, the 3 header tags will generate the following when clicked (this is what the actual medium.com editor does as well):
  * The <kbd>H1</kbd> Button will generate a `<h2>` tag
  * The <kbd>H2</kbd> Button will generate a `<h3>` tag
  * The <kbd>H3</kbd> Button will generate a `<h4>` tag
* The html tags generated by the 3 header buttons are configurable via a new `headerTags` option.  This option is an array of strings that are passed in via the `toolbar` options.
  * Example of changing the generated tags to be `<h1>`, `<h3>`, and `<h5>`:
```js
new MediumEditor('.editor', {
  toolbar: {
    buttons: ['bold', 'italic', 'quote', 'h1', 'h2', 'h3'],
    headerTags: ['h1', 'h3', 'h5']
  }
});
```