### PR TITLE
Custom Button Options + Deprecate Header Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ MediumEditor also supports textarea. If you provide a textarea element, the scri
 ### Core options
 * __activeButtonClass__: CSS class added to active buttons in the toolbar. Default: `'medium-editor-button-active'`
 * __allowMultiParagraphSelection__: enables the toolbar when selecting multiple paragraphs/block elements. Default: `true`
-* __buttonLabels__: type of labels on the buttons. Values: 'fontawesome', `{'bold': '<b>b</b>', 'italic': '<i>i</i>'}`. Default: `false`
+* __buttonLabels__: type of labels on the buttons. Values: `false` | 'fontawesome'.  Default: `false`
 #### NOTE:
 Using `'fontawesome'` as the buttonLabels requires version 4.1.0 of the fontawesome css to be on the page to ensure all icons will be displayed correctly
 * __delay__: time in milliseconds to show the toolbar or anchor tag preview. Default: `0`

--- a/README.md
+++ b/README.md
@@ -94,14 +94,14 @@ MediumEditor also supports textarea. If you provide a textarea element, the scri
 * __activeButtonClass__: CSS class added to active buttons in the toolbar. Default: `'medium-editor-button-active'`
 * __allowMultiParagraphSelection__: enables the toolbar when selecting multiple paragraphs/block elements. Default: `true`
 * __buttonLabels__: type of labels on the buttons. Values: 'fontawesome', `{'bold': '<b>b</b>', 'italic': '<i>i</i>'}`. Default: `false`
+#### NOTE:
+Using `'fontawesome'` as the buttonLabels requires version 4.1.0 of the fontawesome css to be on the page to ensure all icons will be displayed correctly
 * __delay__: time in milliseconds to show the toolbar or anchor tag preview. Default: `0`
 * __disableReturn__:  enables/disables the use of the return-key. You can also set specific element behavior by using setting a data-disable-return attribute. Default: `false`
 * __disableDoubleReturn__:  allows/disallows two (or more) empty new lines. You can also set specific element behavior by using setting a data-disable-double-return attribute. Default: `false`
 * __disableEditing__: enables/disables adding the contenteditable behavior. Useful for using the toolbar with customized buttons/actions. You can also set specific element behavior by using setting a data-disable-editing attribute. Default: `false`
 * __elementsContainer__: specifies a DOM node to contain MediumEditor's toolbar and anchor preview elements. Default: `document.body`
 * __extensions__: extension to use (see [Custom Buttons and Extensions](https://github.com/yabwe/medium-editor/wiki/Custom-Buttons-and-Extensions)) for more. Default: `{}`
-* __firstHeader__: HTML tag to be used as first header. Default: `h3`
-* __secondHeader__: HTML tag to be used as second header. Default: `h4`
 * __spellcheck__: Enable/disable native contentEditable automatic spellcheck. Default: `true`
 * __targetBlank__: enables/disables target="\_blank" for anchor tags. Default: `false`
 
@@ -115,7 +115,7 @@ var editor = new MediumEditor('.editable', {
     toolbar: {
         /* These are the default options for the toolbar,
            if nothing is passed this is what is used */
-        buttons: ['bold', 'italic', 'underline', 'anchor', 'header1', 'header2', 'quote'],
+        buttons: ['bold', 'italic', 'underline', 'anchor', 'h2', 'h3', 'quote'],
         diffLeft: 0,
         diffTop: -10,
         firstButtonClass: 'medium-editor-button-first',
@@ -131,7 +131,7 @@ var editor = new MediumEditor('.editable', {
 });
 ```
 
-* __buttons__: the set of buttons to display on the toolbar. Default: `['bold', 'italic', 'underline', 'anchor', 'header1', 'header2', 'quote']`
+* __buttons__: the set of buttons to display on the toolbar. Default: `['bold', 'italic', 'underline', 'anchor', 'h2', 'h3', 'quote']`
 * __diffLeft__: value in pixels to be added to the X axis positioning of the toolbar. Default: `0`
 * __diffTop__: value in pixels to be added to the Y axis positioning of the toolbar. Default: `-10`
 * __firstButtonClass__: CSS class added to the first button in the toolbar. Default: `'medium-editor-button-first'`
@@ -335,8 +335,6 @@ var editor = new MediumEditor('.editable', {
 
 ```javascript
 var editor = new MediumEditor('.editable', {
-    firstHeader: 'h1',
-    secondHeader: 'h2',
     delay: 1000,
     targetBlank: true,
     toolbar: {

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ var editor = new MediumEditor('.editable', {
                 contentDefault: '<b>H1</b>',
                 classList: ['custom-class-h1'],
                 attrs: {
-                    'data-header-type': 'h1'
+                    'data-custom-attr': 'attr-value-h1'
                 }
             },
             {
@@ -203,7 +203,7 @@ var editor = new MediumEditor('.editable', {
                 contentDefault: '<b>H2</b>',
                 classList: ['custom-class-h2'],
                 attrs: {
-                    'data-header-type': 'h2'
+                    'data-custom-attr': 'attr-value-h2'
                 }
             },
             'justifyCenter',

--- a/README.md
+++ b/README.md
@@ -94,8 +94,10 @@ MediumEditor also supports textarea. If you provide a textarea element, the scri
 * __activeButtonClass__: CSS class added to active buttons in the toolbar. Default: `'medium-editor-button-active'`
 * __allowMultiParagraphSelection__: enables the toolbar when selecting multiple paragraphs/block elements. Default: `true`
 * __buttonLabels__: type of labels on the buttons. Values: `false` | 'fontawesome'.  Default: `false`
+
 #### NOTE:
 Using `'fontawesome'` as the buttonLabels requires version 4.1.0 of the fontawesome css to be on the page to ensure all icons will be displayed correctly
+
 * __delay__: time in milliseconds to show the toolbar or anchor tag preview. Default: `0`
 * __disableReturn__:  enables/disables the use of the return-key. You can also set specific element behavior by using setting a data-disable-return attribute. Default: `false`
 * __disableDoubleReturn__:  allows/disallows two (or more) empty new lines. You can also set specific element behavior by using setting a data-disable-double-return attribute. Default: `false`
@@ -132,6 +134,7 @@ var editor = new MediumEditor('.editable', {
 ```
 
 * __buttons__: the set of buttons to display on the toolbar. Default: `['bold', 'italic', 'underline', 'anchor', 'h2', 'h3', 'quote']`
+  * See [Button Options](#button-options) for details on more button options
 * __diffLeft__: value in pixels to be added to the X axis positioning of the toolbar. Default: `0`
 * __diffTop__: value in pixels to be added to the Y axis positioning of the toolbar. Default: `-10`
 * __firstButtonClass__: CSS class added to the first button in the toolbar. Default: `'medium-editor-button-first'`
@@ -148,6 +151,66 @@ To disable the toolbar (which also disables the anchor-preview extension), set t
 ```javascript
 var editor = new MediumEditor('.editable', {
     toolbar: false
+});
+```
+
+#### Button Options
+
+Button behavior can be modified by passing an object into the buttons array instead of a string. This allow for overriding some of the default behavior of buttons. The following options are some of the basic parts of buttons that you may override, but any part of the `MediumEditor.extension.prototype` can be overriden via these button options. (Check out the [source code for buttons](https://github.com/yabwe/medium-editor/blob/master/src/js/extensions/button.js) to see what all can be overriden).
+
+* __name__: name of the button being overriden
+* __action__: argument to pass to `MediumEditor.execAction()` when the button is clicked.
+* __aria__: value to add as the aria-label attribute of the button element displayed in the toolbar. This is also used as the tooltip for the button.
+* __tagNames__: array of element tag names that would indicate that this button has already been applied. If this action has already been applied, the button will be displayed as 'active' in the toolbar.
+  * _Example_: For 'bold', if the text is ever within a `<b>` or `<strong>` tag that indicates the text is already bold. So the array of tagNames for bold would be: `['b', 'strong']`
+  * __NOTE__: This is not used if `useQueryState` is set to `true`.
+* __style__: A pair of css property & value(s) that indicate that this button has already been applied. If this action has already been applied, the button will be displayed as 'active' in the toolbar.
+  * _Example_: For 'bold', if the text is ever within an element with a `'font-weight'` style property set to `700` or `'bold'`, that indicates the text is already bold.  So the style object for bold would be `{ prop: 'font-weight', value: '700|bold' }`
+  * __NOTE__: This is not used if `useQueryState` is set to `true`.
+  * Properties of the __style__ object:
+    * __prop__: name of the css property
+    * __value__: value(s) of the css property (multiple values can be separated by a `'|'`)
+* __useQueryState__: Enables/disables whether this button should use the built-in `document.queryCommandState()` method to determine whether the action has already been applied.  If the action has already been applied, the button will be displayed as 'active' in the toolbar
+  * _Example_: For 'bold', if this is set to true, the code will call `document.queryCommandState('bold')` which will return true if the browser thinks the text is already bold, and false otherwise
+* __contentDefault__: Default `innerHTML` to put inside the button
+* __contentFA__: The `innerHTML` to use for the content of the button if the __buttonLabels__ option for MediumEditor is set to `'fontawesome'`
+* __classList__: An array of classNames (strings) to be added to the button
+* __attrs__: A set of key-value pairs to add to the button as custom attributes to the button element.
+
+Example of overriding buttons (here, the goal is to mimic medium by having <kbd>H1</kbd> and <kbd>H2</kbd> buttons which actually produce `<h2>` and `<h3>` tags respectively):
+```javascript
+var editor = new MediumEditor('.editable', {
+    toolbar: {
+        buttons: [
+            'bold', 
+            'italic',
+            {
+                name: 'h1',
+                action: 'append-h2',
+                aria: 'header type 1',
+                tagNames: ['h2'],
+                contentDefault: '<b>H1</b>',
+                classList: ['custom-class-h1'],
+                attrs: {
+                    'data-header-type': 'h1'
+                }
+            },
+            {
+                name: 'h2',
+                action: 'append-h3',
+                aria: 'header type 2',
+                tagNames: ['h3'],
+                contentDefault: '<b>H2</b>',
+                classList: ['custom-class-h2'],
+                attrs: {
+                    'data-header-type': 'h2'
+                }
+            },
+            'justifyCenter',
+            'quote',
+            'anchor'
+        ]
+    }
 });
 ```
 

--- a/demo/auto-link.html
+++ b/demo/auto-link.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <title>medium editor | demo</title>
     <link rel="stylesheet" href="css/demo.css">
-    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css">
+    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.css">
     <link rel="stylesheet" href="../dist/css/medium-editor.css">
     <link rel="stylesheet" href="../dist/css/themes/default.css" id="medium-editor-theme">
 </head>

--- a/demo/clean-paste.html
+++ b/demo/clean-paste.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <title>medium editor | demo</title>
     <link rel="stylesheet" href="css/demo.css">
-    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css">
+    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.css">
     <link rel="stylesheet" href="../dist/css/medium-editor.css">
     <link rel="stylesheet" href="../dist/css/themes/default.css">
 </head>

--- a/demo/css/demo.css
+++ b/demo/css/demo.css
@@ -36,14 +36,19 @@ h1 {
     border-bottom: 1px solid #dbdbdb;
 }
 
-h3 {
+h2 {
     font-size: 32px;
     line-height: 42px;
 }
 
-h4 {
+h3 {
     font-size: 26px;
     line-height: 32px;
+}
+
+h4 {
+    font-size: 24px;
+    line-height: 28px;
 }
 
 p {

--- a/demo/custom-toolbar.html
+++ b/demo/custom-toolbar.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <title>medium editor | demo</title>
     <link rel="stylesheet" href="css/demo.css">
-    <link href="http://netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet">
+    <link href="http://netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.css" rel="stylesheet">
     <link rel="stylesheet" href="../dist/css/medium-editor.css">
     <link rel="stylesheet" href="../dist/css/themes/flat.css">
 </head>
@@ -27,7 +27,7 @@
     <script>
         var editor = new MediumEditor('.editable', {
                 toolbar: {
-                    buttons: ['bold', 'italic', 'underline', 'strikethrough', 'quote', 'anchor', 'image', 'justifyLeft', 'justifyCenter', 'justifyRight', 'justifyFull', 'superscript', 'subscript', 'orderedlist', 'unorderedlist', 'pre', 'removeFormat', 'outdent', 'indent', 'header1', 'header2'],
+                    buttons: ['bold', 'italic', 'underline', 'strikethrough', 'quote', 'anchor', 'image', 'justifyLeft', 'justifyCenter', 'justifyRight', 'justifyFull', 'superscript', 'subscript', 'orderedlist', 'unorderedlist', 'pre', 'removeFormat', 'outdent', 'indent', 'h2', 'h3'],
                 },
                 buttonLabels: 'fontawesome',
                 anchor: {

--- a/demo/custom-toolbar.html
+++ b/demo/custom-toolbar.html
@@ -36,13 +36,23 @@
             });
         var editor2 = new MediumEditor('.secondEditable', {
                 toolbar: {
-                    buttons: ['bold', 'italic', 'underline', 'anchor']
-                },
-                buttonLabels: {
-                    'bold': 'bold',
-                    'italic': '<i>italic</i>',
-                    'underline': '<u>underline</u>',
-                    'anchor': 'link'
+                    buttons: [{
+                            name: 'bold',
+                            contentDefault: 'bold'
+                        },
+                        {
+                            name: 'italic',
+                            contentDefault: '<i>italic</i>'
+                        },
+                        {
+                            name: 'underline',
+                            contentDefault: '<u>underline</u>'
+                        },
+                        {
+                            name: 'anchor',
+                            contentDefault: 'link'
+                        }
+                    ]
                 }
             });
     </script>

--- a/demo/index.html
+++ b/demo/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <title>medium editor | demo</title>
     <link rel="stylesheet" href="css/demo.css">
-    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css">
+    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.css">
     <link rel="stylesheet" href="../dist/css/medium-editor.css">
     <link rel="stylesheet" href="../dist/css/themes/default.css" id="medium-editor-theme">
 </head>

--- a/demo/multi-paragraph.html
+++ b/demo/multi-paragraph.html
@@ -28,8 +28,6 @@
     <script>
         var editor = new MediumEditor('.editable', {
             allowMultiParagraphSelection: false,
-            firstHeader: 'h1',
-            secondHeader: 'h2',
             delay: 0,
             toolbar: {
                 diffTop: -12

--- a/demo/nested-editable.html
+++ b/demo/nested-editable.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <title>medium editor | demo</title>
     <link rel="stylesheet" href="css/demo.css">
-    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css">
+    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.css">
     <link rel="stylesheet" href="../dist/css/medium-editor.css">
     <link rel="stylesheet" href="../dist/css/themes/default.css" id="medium-editor-theme">
 </head>

--- a/demo/pass-instance.html
+++ b/demo/pass-instance.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <title>medium editor | demo</title>
     <link rel="stylesheet" href="css/demo.css">
-    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css">
+    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.css">
     <link rel="stylesheet" href="../dist/css/medium-editor.css">
     <link rel="stylesheet" href="../dist/css/themes/default.css">
 </head>

--- a/demo/static-toolbar.html
+++ b/demo/static-toolbar.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <title>medium editor | demo</title>
     <link rel="stylesheet" href="css/demo.css">
-    <link href="http://netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet">
+    <link href="http://netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.css" rel="stylesheet">
     <link rel="stylesheet" href="../dist/css/medium-editor.css">
     <link rel="stylesheet" href="../dist/css/themes/default.css">
 </head>
@@ -47,7 +47,7 @@
     <script>
         var editor = new MediumEditor('.editable', {
                 toolbar: {
-                    buttons: ['bold', 'italic', 'underline', 'strikethrough', 'quote', 'anchor', 'image', 'justifyLeft', 'justifyCenter', 'justifyRight', 'justifyFull', 'superscript', 'subscript', 'orderedlist', 'unorderedlist', 'pre', 'outdent', 'indent', 'header1', 'header2'],
+                    buttons: ['bold', 'italic', 'underline', 'strikethrough', 'quote', 'anchor', 'image', 'justifyLeft', 'justifyCenter', 'justifyRight', 'justifyFull', 'superscript', 'subscript', 'orderedlist', 'unorderedlist', 'pre', 'outdent', 'indent', 'h2', 'h3'],
                     static: true,
                     sticky: true
                 }
@@ -55,7 +55,7 @@
 
         var editorColOne = new MediumEditor('#column-one', {
                 toolbar: {
-                    buttons: ['bold', 'italic', 'underline', 'strikethrough', 'quote', 'anchor', 'image', 'justifyLeft', 'justifyCenter', 'justifyRight', 'justifyFull', 'superscript', 'subscript', 'orderedlist', 'unorderedlist', 'pre', 'outdent', 'indent', 'header1', 'header2'],
+                    buttons: ['bold', 'italic', 'underline', 'strikethrough', 'quote', 'anchor', 'image', 'justifyLeft', 'justifyCenter', 'justifyRight', 'justifyFull', 'superscript', 'subscript', 'orderedlist', 'unorderedlist', 'pre', 'outdent', 'indent', 'h2', 'h3'],
                     sticky: true,
                     static: true,
                     align: 'left',
@@ -66,7 +66,7 @@
 
         var editorColTwo = new MediumEditor('#column-two', {
                 toolbar: {
-                    buttons: ['bold', 'italic', 'underline', 'strikethrough', 'quote', 'anchor', 'image', 'justifyLeft', 'justifyCenter', 'justifyRight', 'justifyFull', 'superscript', 'subscript', 'orderedlist', 'unorderedlist', 'pre', 'outdent', 'indent', 'header1', 'header2'],
+                    buttons: ['bold', 'italic', 'underline', 'strikethrough', 'quote', 'anchor', 'image', 'justifyLeft', 'justifyCenter', 'justifyRight', 'justifyFull', 'superscript', 'subscript', 'orderedlist', 'unorderedlist', 'pre', 'outdent', 'indent', 'h2', 'h3'],
                     sticky: true,
                     static: true,
                     align: 'center',
@@ -77,7 +77,7 @@
 
         var editorColThree = new MediumEditor('#column-three', {
                 toolbar: {
-                    buttons: ['bold', 'italic', 'underline', 'strikethrough', 'quote', 'anchor', 'image', 'justifyLeft', 'justifyCenter', 'justifyRight', 'justifyFull', 'superscript', 'subscript', 'orderedlist', 'unorderedlist', 'pre', 'outdent', 'indent', 'header1', 'header2'],
+                    buttons: ['bold', 'italic', 'underline', 'strikethrough', 'quote', 'anchor', 'image', 'justifyLeft', 'justifyCenter', 'justifyRight', 'justifyFull', 'superscript', 'subscript', 'orderedlist', 'unorderedlist', 'pre', 'outdent', 'indent', 'h2', 'h3'],
                     sticky: true,
                     static: true,
                     align: 'right',

--- a/demo/table-extension.html
+++ b/demo/table-extension.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <title>medium editor | demo</title>
     <link rel="stylesheet" href="css/demo.css">
-    <link href="http://netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet">
+    <link href="http://netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.css" rel="stylesheet">
     <link rel="stylesheet" href="../dist/css/medium-editor.css">
     <link rel="stylesheet" href="../dist/css/themes/default.css">
 </head>

--- a/demo/textarea.html
+++ b/demo/textarea.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <title>medium editor | demo</title>
     <link rel="stylesheet" href="css/demo.css">
-    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css">
+    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.css">
     <link rel="stylesheet" href="../dist/css/medium-editor.css">
     <link rel="stylesheet" href="../dist/css/themes/default.css" id="medium-editor-theme">
 </head>

--- a/spec/buttons.spec.js
+++ b/spec/buttons.spec.js
@@ -99,6 +99,7 @@ describe('Buttons TestCase', function () {
             fontAwesomeLabels = {},
             customLabels = {},
             allButtons = [],
+            customButtons = [],
             buttonsData = MediumEditor.extensions.button.prototype.defaults,
             currButton,
             tempEl;
@@ -122,6 +123,10 @@ describe('Buttons TestCase', function () {
 
             // custom labels (using aria label as a test)
             customLabels[buttonName] = currButton.aria;
+            customButtons.push({
+                name: buttonName,
+                contentDefault: currButton.aria
+            });
         });
 
         it('should have aria-label and title attributes set', function () {
@@ -190,9 +195,8 @@ describe('Buttons TestCase', function () {
                 button,
                 editor = this.newMediumEditor('.editor', {
                     toolbar: {
-                        buttons: allButtons
-                    },
-                    buttonLabels: customLabels
+                        buttons: customButtons
+                    }
                 }),
                 toolbar = editor.getExtensionByName('toolbar');
             expect(toolbar.getToolbarElement().querySelectorAll('button').length).toBe(allButtons.length);

--- a/spec/buttons.spec.js
+++ b/spec/buttons.spec.js
@@ -129,6 +129,35 @@ describe('Buttons TestCase', function () {
             });
         });
 
+        // Add in anchor button
+        allButtons.push('anchor');
+        tempEl = document.createElement('div');
+        tempEl.innerHTML = MediumEditor.extensions.anchor.prototype.contentDefault;
+        defaultLabels['anchor'] = {
+            label: tempEl.innerHTML
+        };
+        tempEl.innerHTML = MediumEditor.extensions.anchor.prototype.contentFA;
+        fontAwesomeLabels['anchor'] = tempEl.innerHTML;
+        customLabels['anchor'] = MediumEditor.extensions.anchor.prototype.aria;
+        customButtons.push({
+            name: 'anchor',
+            contentDefault: customLabels['anchor']
+        });
+
+        // Add in fontsize button
+        allButtons.push('fontsize');
+        tempEl.innerHTML = MediumEditor.extensions.fontSize.prototype.contentDefault;
+        defaultLabels['fontsize'] = {
+            label: tempEl.innerHTML
+        };
+        tempEl.innerHTML = MediumEditor.extensions.fontSize.prototype.contentFA;
+        fontAwesomeLabels['fontsize'] = tempEl.innerHTML;
+        customLabels['fontsize'] = MediumEditor.extensions.fontSize.prototype.aria;
+        customButtons.push({
+            name: 'fontsize',
+            contentDefault: customLabels['fontsize']
+        });
+
         it('should have aria-label and title attributes set', function () {
             var button,
                 editor = this.newMediumEditor('.editor', {
@@ -184,7 +213,9 @@ describe('Buttons TestCase', function () {
                 button = toolbar.getToolbarElement().querySelector('.medium-editor-action-' + buttonName);
                 expect(button).not.toBeUndefined();
                 fireEvent(button, 'click');
-                expect(editor.execAction).toHaveBeenCalledWith(action);
+                if (action) {
+                    expect(editor.execAction).toHaveBeenCalledWith(action);
+                }
                 expect(button.innerHTML).toBe(fontAwesomeLabels[buttonName]);
             });
         });
@@ -208,7 +239,9 @@ describe('Buttons TestCase', function () {
                 button = toolbar.getToolbarElement().querySelector('.medium-editor-action-' + buttonName);
                 expect(button).not.toBeUndefined();
                 fireEvent(button, 'click');
-                expect(editor.execAction).toHaveBeenCalledWith(action);
+                if (action) {
+                    expect(editor.execAction).toHaveBeenCalledWith(action);
+                }
                 expect(button.innerHTML).toBe(customLabels[buttonName]);
             });
         });

--- a/spec/buttons.spec.js
+++ b/spec/buttons.spec.js
@@ -104,26 +104,24 @@ describe('Buttons TestCase', function () {
             tempEl;
 
         Object.keys(buttonsData).forEach(function (buttonName) {
-            if (buttonName !== 'header1' && buttonName !== 'header2') {
-                allButtons.push(buttonName);
-                currButton = buttonsData[buttonName];
-                // If the labels contain HTML entities, we need to escape them
-                tempEl = document.createElement('div');
+            allButtons.push(buttonName);
+            currButton = buttonsData[buttonName];
+            // If the labels contain HTML entities, we need to escape them
+            tempEl = document.createElement('div');
 
-                // Default Labels
-                tempEl.innerHTML = currButton.contentDefault;
-                defaultLabels[buttonName] = {
-                    action: currButton.action,
-                    label: tempEl.innerHTML
-                };
+            // Default Labels
+            tempEl.innerHTML = currButton.contentDefault;
+            defaultLabels[buttonName] = {
+                action: currButton.action,
+                label: tempEl.innerHTML
+            };
 
-                // fontawesome labels
-                tempEl.innerHTML = currButton.contentFA;
-                fontAwesomeLabels[buttonName] = tempEl.innerHTML;
+            // fontawesome labels
+            tempEl.innerHTML = currButton.contentFA;
+            fontAwesomeLabels[buttonName] = tempEl.innerHTML;
 
-                // custom labels (using aria label as a test)
-                customLabels[buttonName] = currButton.aria;
-            }
+            // custom labels (using aria label as a test)
+            customLabels[buttonName] = currButton.aria;
         });
 
         it('should have aria-label and title attributes set', function () {
@@ -229,7 +227,7 @@ describe('Buttons TestCase', function () {
             }
         });
 
-        it('should create an h3 element when header1 is clicked', function () {
+        it('should create an h3 element when h3 is clicked', function () {
             this.el.innerHTML = '<p><b>lorem ipsum</b></p>';
             var button,
                 editor = this.newMediumEditor('.editor'),
@@ -845,7 +843,7 @@ describe('Buttons TestCase', function () {
         it('buttons should be active if the selection already has the element', function () {
             var editor = this.newMediumEditor('.editor', {
                     toolbar: {
-                        buttons: ['header1', 'header2']
+                        buttons: ['h3', 'h4']
                     }
                 }),
                 toolbar = editor.getExtensionByName('toolbar'),
@@ -869,10 +867,8 @@ describe('Buttons TestCase', function () {
         it('buttons should be active if the selection already custom defined element types', function () {
             var editor = this.newMediumEditor('.editor', {
                     toolbar: {
-                        buttons: ['header1', 'header2']
-                    },
-                    firstHeader: 'h1',
-                    secondHeader: 'h5'
+                        buttons: ['h1', 'h5']
+                    }
                 }),
                 toolbar = editor.getExtensionByName('toolbar'),
                 buttonOne = toolbar.getToolbarElement().querySelector('[data-action="append-h1"]'),
@@ -898,9 +894,8 @@ describe('Buttons TestCase', function () {
         it('buttons should convert between element types and "undo" back to original type', function () {
             var editor = this.newMediumEditor('.editor', {
                     toolbar: {
-                        buttons: ['header1', 'header2']
-                    },
-                    firstHeader: 'h1'
+                        buttons: ['h1', 'h4']
+                    }
                 }),
                 toolbar = editor.getExtensionByName('toolbar'),
                 buttonOne = toolbar.getToolbarElement().querySelector('[data-action="append-h1"]'),

--- a/spec/buttons.spec.js
+++ b/spec/buttons.spec.js
@@ -106,7 +106,11 @@ describe('Buttons TestCase', function () {
                                 action: 'append-h2',
                                 aria: 'fake h1',
                                 tagNames: ['h2'],
-                                contentDefault: '<b>H1</b>'
+                                contentDefault: '<b>H1</b>',
+                                classList: ['customClassName'],
+                                attrs: {
+                                    'data-custom-attr': 'custom-value'
+                                }
                             },
                             {
                                 name: 'h2',
@@ -135,6 +139,8 @@ describe('Buttons TestCase', function () {
             expect(button).toBe(headerOneButton.getButton());
             expect(button.getAttribute('aria-label')).toBe('fake h1');
             expect(button.getAttribute('title')).toBe('fake h1');
+            expect(button.getAttribute('data-custom-attr')).toBe('custom-value');
+            expect(button.classList.contains('customClassName')).toBe(true);
             expect(button.innerHTML).toBe('<b>H1</b>');
 
             selectElementContentsAndFire(editor.elements[0].querySelector('h2').firstChild);

--- a/spec/buttons.spec.js
+++ b/spec/buttons.spec.js
@@ -94,6 +94,65 @@ describe('Buttons TestCase', function () {
         });
     });
 
+    describe('Button options', function () {
+        it('should support overriding defaults', function () {
+            this.el.innerHTML = '<h2>lorem</h2><h3>ipsum</h3>';
+            var editor = this.newMediumEditor('.editor', {
+                    toolbar: {
+                        buttons: [
+                            'bold',
+                            {
+                                name: 'h1',
+                                action: 'append-h2',
+                                aria: 'fake h1',
+                                tagNames: ['h2'],
+                                contentDefault: '<b>H1</b>'
+                            },
+                            {
+                                name: 'h2',
+                                getAction: function () {
+                                    return 'append-h3';
+                                },
+                                getAria: function () {
+                                    return 'fake h2';
+                                },
+                                getTagNames: function () {
+                                    return ['h3'];
+                                },
+                                contentDefault: '<b>H2</b>'
+                            }
+                        ]
+                    }
+                }),
+                headerOneButton = editor.getExtensionByName('h1'),
+                headerTwoButton = editor.getExtensionByName('h2'),
+                toolbar = editor.getExtensionByName('toolbar');
+
+            expect(toolbar.getToolbarElement().querySelectorAll('button').length).toBe(3);
+
+            var button = toolbar.getToolbarElement().querySelector('.medium-editor-action-h1'),
+                buttonTwo = toolbar.getToolbarElement().querySelector('.medium-editor-action-h2');
+            expect(button).toBe(headerOneButton.getButton());
+            expect(button.getAttribute('aria-label')).toBe('fake h1');
+            expect(button.getAttribute('title')).toBe('fake h1');
+            expect(button.innerHTML).toBe('<b>H1</b>');
+
+            selectElementContentsAndFire(editor.elements[0].querySelector('h2').firstChild);
+            jasmine.clock().tick(1);
+            expect(button.classList.contains('medium-editor-button-active')).toBe(true);
+            expect(buttonTwo.classList.contains('medium-editor-button-active')).toBe(false);
+
+            expect(buttonTwo).toBe(headerTwoButton.getButton());
+            expect(buttonTwo.getAttribute('aria-label')).toBe('fake h2');
+            expect(buttonTwo.getAttribute('title')).toBe('fake h2');
+            expect(buttonTwo.innerHTML).toBe('<b>H2</b>');
+
+            selectElementContentsAndFire(editor.elements[0].querySelector('h3'), { eventToFire: 'mouseup' });
+            expect(button.classList.contains('medium-editor-button-active')).toBe(false);
+            expect(buttonTwo.classList.contains('medium-editor-button-active')).toBe(true);
+        });
+    });
+
     describe('Buttons with various labels', function () {
         var defaultLabels = {},
             fontAwesomeLabels = {},

--- a/spec/init.spec.js
+++ b/spec/init.spec.js
@@ -107,9 +107,7 @@ describe('Initialization TestCase', function () {
                 elementsContainer: document.body,
                 contentWindow: window,
                 ownerDocument: document,
-                firstHeader: 'h3',
                 allowMultiParagraphSelection: true,
-                secondHeader: 'h4',
                 buttonLabels: false,
                 targetBlank: false,
                 extensions: {},
@@ -123,8 +121,6 @@ describe('Initialization TestCase', function () {
 
         it('should accept custom options values', function () {
             var options = {
-                firstHeader: 'h2',
-                secondHeader: 'h3',
                 delay: 300,
                 toolbar: {
                     diffLeft: 10,

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -602,14 +602,16 @@ function MediumEditor(elements, options) {
          * NOT DOCUMENTED - exposed as a helper for other extensions to use
          */
         addBuiltInExtension: function (name, opts) {
-            var extension = this.getExtensionByName(name);
+            var extension = this.getExtensionByName(name),
+                merged;
             if (extension) {
                 return extension;
             }
 
             switch (name) {
                 case 'anchor':
-                    extension = new MediumEditor.extensions.anchor(this.options.anchor);
+                    merged = Util.extend({}, this.options.anchor, opts);
+                    extension = new MediumEditor.extensions.anchor(merged);
                     break;
                 case 'anchorPreview':
                     extension = new MediumEditor.extensions.anchorPreview(this.options.anchorPreview);
@@ -618,7 +620,7 @@ function MediumEditor(elements, options) {
                     extension = new MediumEditor.extensions.autoLink();
                     break;
                 case 'fontsize':
-                    extension = new MediumEditor.extensions.fontSize();
+                    extension = new MediumEditor.extensions.fontSize(opts);
                     break;
                 case 'imageDragging':
                     extension = new MediumEditor.extensions.imageDragging();
@@ -637,7 +639,7 @@ function MediumEditor(elements, options) {
                     // so check to see if the extension we're creating is a built-in button
                     if (MediumEditor.extensions.button.isBuiltInButton(name)) {
                         if (opts) {
-                            var merged = Util.defaults({}, opts, MediumEditor.extensions.button.prototype.defaults[name]);
+                            merged = Util.defaults({}, opts, MediumEditor.extensions.button.prototype.defaults[name]);
                             extension = new MediumEditor.extensions.button(merged);
                         } else {
                             extension = new MediumEditor.extensions.button(name);

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -601,7 +601,7 @@ function MediumEditor(elements, options) {
         /**
          * NOT DOCUMENTED - exposed as a helper for other extensions to use
          */
-        addBuiltInExtension: function (name) {
+        addBuiltInExtension: function (name, opts) {
             var extension = this.getExtensionByName(name);
             if (extension) {
                 return extension;
@@ -636,7 +636,12 @@ function MediumEditor(elements, options) {
                     // All of the built-in buttons for MediumEditor are extensions
                     // so check to see if the extension we're creating is a built-in button
                     if (MediumEditor.extensions.button.isBuiltInButton(name)) {
-                        extension = new MediumEditor.extensions.button(name);
+                        if (opts) {
+                            var merged = Util.defaults({}, opts, MediumEditor.extensions.button.prototype.defaults[name]);
+                            extension = new MediumEditor.extensions.button(merged);
+                        } else {
+                            extension = new MediumEditor.extensions.button(name);
+                        }
                     }
                     break;
             }

--- a/src/js/defaults/buttons.js
+++ b/src/js/defaults/buttons.js
@@ -242,14 +242,6 @@ var buttonDefaults;
             tagNames: ['h6'],
             contentDefault: '<b>H6</b>',
             contentFA: '<i class="fa fa-header"><sup>6</sup>'
-        },
-        'p': {
-            name: 'p',
-            action: 'append-p',
-            aria: 'paragraph',
-            tagNames: ['p'],
-            contentDefault: '<b>&para;</b>',
-            contentFA: '<i class="fa fa-paragraph">'
         }
     };
 

--- a/src/js/defaults/buttons.js
+++ b/src/js/defaults/buttons.js
@@ -85,14 +85,6 @@ var buttonDefaults;
             contentDefault: '<b>image</b>',
             contentFA: '<i class="fa fa-picture-o"></i>'
         },
-        'quote': {
-            name: 'quote',
-            action: 'append-blockquote',
-            aria: 'blockquote',
-            tagNames: ['blockquote'],
-            contentDefault: '<b>&ldquo;</b>',
-            contentFA: '<i class="fa fa-quote-right"></i>'
-        },
         'orderedlist': {
             name: 'orderedlist',
             action: 'insertorderedlist',
@@ -110,14 +102,6 @@ var buttonDefaults;
             useQueryState: true,
             contentDefault: '<b>&bull;</b>',
             contentFA: '<i class="fa fa-list-ul"></i>'
-        },
-        'pre': {
-            name: 'pre',
-            action: 'append-pre',
-            aria: 'preformatted text',
-            tagNames: ['pre'],
-            contentDefault: '<b>0101</b>',
-            contentFA: '<i class="fa fa-code fa-lg"></i>'
         },
         'indent': {
             name: 'indent',
@@ -183,32 +167,6 @@ var buttonDefaults;
             contentDefault: '<b>R</b>',
             contentFA: '<i class="fa fa-align-right"></i>'
         },
-        'header1': {
-            name: 'header1',
-            action: function (options) {
-                return 'append-' + options.firstHeader;
-            },
-            aria: function (options) {
-                return options.firstHeader;
-            },
-            tagNames: function (options) {
-                return [options.firstHeader];
-            },
-            contentDefault: '<b>H1</b>'
-        },
-        'header2': {
-            name: 'header2',
-            action: function (options) {
-                return 'append-' + options.secondHeader;
-            },
-            aria: function (options) {
-                return options.secondHeader;
-            },
-            tagNames: function (options) {
-                return [options.secondHeader];
-            },
-            contentDefault: '<b>H2</b>'
-        },
         // Known inline elements that are not removed, or not removed consistantly across browsers:
         // <span>, <label>, <br>
         'removeFormat': {
@@ -217,6 +175,81 @@ var buttonDefaults;
             action: 'removeFormat',
             contentDefault: '<b>X</b>',
             contentFA: '<i class="fa fa-eraser"></i>'
+        },
+
+        /***** Buttons for appending block elements (append-<element> action) *****/
+
+        'quote': {
+            name: 'quote',
+            action: 'append-blockquote',
+            aria: 'blockquote',
+            tagNames: ['blockquote'],
+            contentDefault: '<b>&ldquo;</b>',
+            contentFA: '<i class="fa fa-quote-right"></i>'
+        },
+        'pre': {
+            name: 'pre',
+            action: 'append-pre',
+            aria: 'preformatted text',
+            tagNames: ['pre'],
+            contentDefault: '<b>0101</b>',
+            contentFA: '<i class="fa fa-code fa-lg"></i>'
+        },
+        'h1': {
+            name: 'h1',
+            action: 'append-h1',
+            aria: 'header type one',
+            tagNames: ['h1'],
+            contentDefault: '<b>H1</b>',
+            contentFA: '<i class="fa fa-header"><sup>1</sup>'
+        },
+        'h2': {
+            name: 'h2',
+            action: 'append-h2',
+            aria: 'header type two',
+            tagNames: ['h2'],
+            contentDefault: '<b>H2</b>',
+            contentFA: '<i class="fa fa-header"><sup>2</sup>'
+        },
+        'h3': {
+            name: 'h3',
+            action: 'append-h3',
+            aria: 'header type three',
+            tagNames: ['h3'],
+            contentDefault: '<b>H3</b>',
+            contentFA: '<i class="fa fa-header"><sup>3</sup>'
+        },
+        'h4': {
+            name: 'h4',
+            action: 'append-h4',
+            aria: 'header type four',
+            tagNames: ['h4'],
+            contentDefault: '<b>H4</b>',
+            contentFA: '<i class="fa fa-header"><sup>4</sup>'
+        },
+        'h5': {
+            name: 'h5',
+            action: 'append-h5',
+            aria: 'header type five',
+            tagNames: ['h5'],
+            contentDefault: '<b>H5</b>',
+            contentFA: '<i class="fa fa-header"><sup>5</sup>'
+        },
+        'h6': {
+            name: 'h6',
+            action: 'append-h6',
+            aria: 'header type six',
+            tagNames: ['h6'],
+            contentDefault: '<b>H6</b>',
+            contentFA: '<i class="fa fa-header"><sup>6</sup>'
+        },
+        'p': {
+            name: 'p',
+            action: 'append-p',
+            aria: 'paragraph',
+            tagNames: ['p'],
+            contentDefault: '<b>&para;</b>',
+            contentFA: '<i class="fa fa-paragraph">'
         }
     };
 

--- a/src/js/defaults/options.js
+++ b/src/js/defaults/options.js
@@ -14,8 +14,6 @@ var editorDefaults;
         elementsContainer: false,
         contentWindow: window,
         ownerDocument: document,
-        firstHeader: 'h3',
-        secondHeader: 'h4',
         targetBlank: false,
         extensions: {},
         spellcheck: true

--- a/src/js/extensions/button.js
+++ b/src/js/extensions/button.js
@@ -137,12 +137,8 @@ var Button;
                 button.setAttribute('title', ariaLabel);
                 button.setAttribute('aria-label', ariaLabel);
             }
-            if (buttonLabels) {
-                if (buttonLabels === 'fontawesome' && this.contentFA) {
-                    content = this.contentFA;
-                } else if (typeof buttonLabels === 'object' && buttonLabels[this.name]) {
-                    content = buttonLabels[this.name];
-                }
+            if (buttonLabels === 'fontawesome' && this.contentFA) {
+                content = this.contentFA;
             }
             button.innerHTML = content;
             return button;

--- a/src/js/extensions/button.js
+++ b/src/js/extensions/button.js
@@ -78,6 +78,16 @@ var Button;
          */
         contentFA: undefined,
 
+        /* classList: [Array]
+         * An array of classNames (strings) to be added to the button
+         */
+        classList: undefined,
+
+        /* attrs: [object]
+         * A set of key-value pairs to add to the button as custom attributes
+         */
+        attrs: undefined,
+
         /* buttonDefaults: [Object]
          * Set of default config options for all of the built-in MediumEditor buttons
          */
@@ -130,13 +140,27 @@ var Button;
                 content = this.contentDefault,
                 ariaLabel = this.getAria(),
                 buttonLabels = this.getEditorOption('buttonLabels');
+            // Add class names
             button.classList.add('medium-editor-action');
             button.classList.add('medium-editor-action-' + this.name);
+            if (this.classList) {
+                this.classList.forEach(function (className) {
+                    button.classList.add(className);
+                });
+            }
+
+            // Add attributes
             button.setAttribute('data-action', this.getAction());
             if (ariaLabel) {
                 button.setAttribute('title', ariaLabel);
                 button.setAttribute('aria-label', ariaLabel);
             }
+            if (this.attrs) {
+                Object.keys(this.attrs).forEach(function (attr) {
+                    button.setAttribute(attr, this.attrs[attr]);
+                }, this);
+            }
+
             if (buttonLabels === 'fontawesome' && this.contentFA) {
                 content = this.contentFA;
             }

--- a/src/js/extensions/toolbar.js
+++ b/src/js/extensions/toolbar.js
@@ -18,7 +18,7 @@ var Toolbar;
         /* buttons: [Array]
          * the names of the set of buttons to display on the toolbar.
          */
-        buttons: ['bold', 'italic', 'underline', 'anchor', 'header1', 'header2', 'quote'],
+        buttons: ['bold', 'italic', 'underline', 'anchor', 'h2', 'h3', 'quote'],
 
         /* diffLeft: [Number]
          * value in pixels to be added to the X axis positioning of the toolbar.
@@ -116,19 +116,26 @@ var Toolbar;
                 li,
                 btn,
                 buttons,
-                extension;
+                extension,
+                buttonName,
+                buttonOpts;
 
             ul.id = 'medium-editor-toolbar-actions' + this.getEditorId();
             ul.className = 'medium-editor-toolbar-actions';
             ul.style.display = 'block';
 
             this.buttons.forEach(function (button) {
-                extension = this.base.getExtensionByName(button);
-
-                if (!extension) {
-                    // If button hasn't been passed as an extension, create it
-                    extension = this.base.addBuiltInExtension(button);
+                if (typeof button === 'string') {
+                    buttonName = button;
+                    buttonOpts = null;
+                } else {
+                    buttonName = button.name;
+                    buttonOpts = button;
                 }
+
+                // If the button already exists as an extension, it'll be returned
+                // othwerise it'll create the default built-in button
+                extension = this.base.addBuiltInExtension(buttonName, buttonOpts);
 
                 if (extension && typeof extension.getButton === 'function') {
                     btn = extension.getButton(this.base);


### PR DESCRIPTION
This PR solves two button-related issues in one.

1. The `firstHeader` and `secondHeader` options were not ideal as options on MediumEditor.  They also restricted the amount of header buttons that could be easily configured.
2. Making small tweaks to existing buttons required the creation of a new Extension which would need to extend from `MediumEditor.extensions.button` and would need to know how to use the same set of default options that the built-in button would use.

Changes in this PR:
* Add built-in button support for all header types (`h1`, `h2`, `h3`, `h4`, `h5`, and `h6`)
* Remove support for the `firstHeader` and `secondHeader` options.
* Allow for overriding built-in button options by accepting both strings and objects into the `options.toolbar.buttons` array passed in during initialization
* Add `classList` property to button for adding custom classes to built-in button elements
* Add `attrs` property to button for adding custom attributes to built-in button elements

Example of usage:
```javascript
var editor = new MediumEditor('.editable', {
    toolbar: {
        buttons: [
            'bold', 
            'italic',
            {
                name: 'h1',
                action: 'append-h2',
                aria: 'header type 1',
                tagNames: ['h2'],
                contentDefault: '<b>H1</b>',
                classList: ['custom-class-h1'],
                attrs: {
                    'data-header-type': 'h1'
                }
            },
            {
                name: 'h2',
                action: 'append-h3',
                aria: 'header type 2',
                tagNames: ['h3'],
                contentDefault: '<b>H2</b>',
                classList: ['custom-class-h2'],
                attrs: {
                    'data-header-type': 'h2'
                }
            },
            'justifyCenter',
            'quote',
            'anchor'
        ]
    }
});
```

Should fix #69 