### PR TITLE
Use uppercase version of shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,19 +274,19 @@ var editor = new MediumEditor('.editable', {
         commands: [
             {
                 command: 'bold',
-                key: 'b',
+                key: 'B',
                 meta: true,
                 shift: false
             },
             {
                 command: 'italic',
-                key: 'i',
+                key: 'I',
                 meta: true,
                 shift: false
             },
             {
                 command: 'underline',
-                key: 'u',
+                key: 'U',
                 meta: true,
                 shift: false
             }

--- a/spec/anchor.spec.js
+++ b/spec/anchor.spec.js
@@ -39,7 +39,7 @@ describe('Anchor Button TestCase', function () {
             var editor = this.newMediumEditor('.editor'),
                 anchorExtension = editor.getExtensionByName('anchor'),
                 toolbar = editor.getExtensionByName('toolbar'),
-                code = 'k'.charCodeAt(0);
+                code = 'K'.charCodeAt(0);
 
             selectElementContentsAndFire(editor.elements[0]);
             jasmine.clock().tick(1);

--- a/spec/keyboard-commands.spec.js
+++ b/spec/keyboard-commands.spec.js
@@ -22,7 +22,7 @@ describe('KeyboardCommands TestCase', function () {
             jasmine.clock().tick(1);
             // bold
             fireEvent(editor.elements[0], 'keydown', {
-                keyCode: 'b'.charCodeAt(0),
+                keyCode: 'B'.charCodeAt(0),
                 ctrlKey: true,
                 metaKey: true
             });
@@ -30,7 +30,7 @@ describe('KeyboardCommands TestCase', function () {
 
             // italics
             fireEvent(editor.elements[0], 'keydown', {
-                keyCode: 'i'.charCodeAt(0),
+                keyCode: 'I'.charCodeAt(0),
                 ctrlKey: true,
                 metaKey: true
             });
@@ -38,7 +38,7 @@ describe('KeyboardCommands TestCase', function () {
 
             // underline
             fireEvent(editor.elements[0], 'keydown', {
-                keyCode: 'u'.charCodeAt(0),
+                keyCode: 'U'.charCodeAt(0),
                 ctrlKey: true,
                 metaKey: true
             });
@@ -88,7 +88,7 @@ describe('KeyboardCommands TestCase', function () {
             selectElementContentsAndFire(editor.elements[0]);
             jasmine.clock().tick(1);
             fireEvent(editor.elements[0], 'keydown', {
-                keyCode: 'b'.charCodeAt(0),
+                keyCode: 'B'.charCodeAt(0),
                 ctrlKey: true,
                 metaKey: true,
                 shiftKey: true
@@ -104,7 +104,7 @@ describe('KeyboardCommands TestCase', function () {
             selectElementContentsAndFire(editor.elements[0]);
             jasmine.clock().tick(1);
             fireEvent(editor.elements[0], 'keydown', {
-                keyCode: 'b'.charCodeAt(0),
+                keyCode: 'B'.charCodeAt(0),
                 ctrlKey: true,
                 metaKey: true
             });

--- a/src/js/extensions/anchor.js
+++ b/src/js/extensions/anchor.js
@@ -61,8 +61,7 @@ var AnchorForm;
             event.stopPropagation();
 
             var selectedParentElement = Selection.getSelectedParentElement(Selection.getSelectionRange(this.document));
-            if (selectedParentElement.tagName &&
-                    selectedParentElement.tagName.toLowerCase() === 'a') {
+            if (selectedParentElement.tagName && selectedParentElement.tagName.toLowerCase() === 'a') {
                 return this.execAction('unlink');
             }
 

--- a/src/js/extensions/keyboard-commands.js
+++ b/src/js/extensions/keyboard-commands.js
@@ -20,19 +20,19 @@ var KeyboardCommands;
         commands: [
             {
                 command: 'bold',
-                key: 'b',
+                key: 'B',
                 meta: true,
                 shift: false
             },
             {
                 command: 'italic',
-                key: 'i',
+                key: 'I',
                 meta: true,
                 shift: false
             },
             {
                 command: 'underline',
-                key: 'u',
+                key: 'U',
                 meta: true,
                 shift: false
             }

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -41,7 +41,7 @@ var Util;
             ESCAPE: 27,
             SPACE: 32,
             DELETE: 46,
-            K: 107
+            K: 75 // K keycode, and not k
         },
 
         /**


### PR DESCRIPTION
We handle shortcut by listening to onKeyDown. There is also onKeyPress but it is only fired when something is inserted in the content. For example, when you hit the shift key, keyPress is never fired because it does not insert something in the content.

onKeyPress & onKeyDown doesn't handle the key code in the same way.
When you hit `b` letter, onKeyDown will receive 66 but onKeyPress will receive 98.
When you hit `B` letter, onKeyDown will receive 66 and onKeyPress will receive 66.
The way we transcript `b` shortcut to a number is by using: `'b'.charCodeAt(0)` which is 98

As you might guess, it can't work. Because we will receive 66 when we are waiting for 98 to bold the content;

Using uppercase letter fix the problem because `'B'.charCodeAt(0)` is equal to 66.

You can test that: http://www.asquare.net/javascript/tests/KeyCode.html