### PR TITLE
Auto-link: never import selection to focus on a BR or IMG

### DIFF
--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -249,6 +249,29 @@ describe('Selection TestCase', function () {
             });
         });
 
+        it('should not import a selection into focusing on an empty element in a table', function () {
+            this.el.innerHTML = '<p>Hello</p><table><colgroup><col /></colgroup>' +
+                '<thead><tr><th>Head</th></tr></thead>' +
+                '<tbody><tr><td>Body</td></tr></tbody></table><p>World<p>';
+            var editor = this.newMediumEditor('.editor', {
+                buttons: ['italic', 'underline', 'strikethrough']
+            });
+            editor.importSelection({
+                'start': 5,
+                'end': 5,
+                'emptyBlocksIndex': 1
+            });
+
+            var innerElement = window.getSelection().getRangeAt(0).startContainer;
+            // The behavior varies from browser to browser for this case.
+            if (innerElement.nodeType === 3) {
+                expect(innerElement.nodeValue).toBe('Head');
+            } else {
+                expect(innerElement.nodeName.toLowerCase()).toBe('th', 'focused element nodeName');
+            }
+            expect(innerElement).toBe(window.getSelection().getRangeAt(0).endContainer);
+        });
+
         it('should not import a selection beyond any block elements that have text, even when emptyBlocksIndex indicates it should ', function () {
             this.el.innerHTML = '<p><span>www.google.com</span></p><h1><br /></h1><h2>Not Empty</h2><p><b><i>Whatever</i></b></p>';
             var editor = this.newMediumEditor('.editor', {

--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -263,12 +263,9 @@ describe('Selection TestCase', function () {
             });
 
             var innerElement = window.getSelection().getRangeAt(0).startContainer;
-            // The behavior varies from browser to browser for this case.
-            if (innerElement.nodeType === 3) {
-                expect(innerElement.nodeValue).toBe('Head');
-            } else {
-                expect(innerElement.nodeName.toLowerCase()).toBe('th', 'focused element nodeName');
-            }
+            // The behavior varies from browser to browser for this case, some select TH, some #textNode
+            expect(Util.isDescendant(editor.elements[0].querySelector('th'), innerElement, true))
+                .toBe(true, 'expect selection to be of TH or a descendant');
             expect(innerElement).toBe(window.getSelection().getRangeAt(0).endContainer);
         });
 

--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -109,6 +109,7 @@ describe('Selection TestCase', function () {
             var exportedSelection = editor.exportSelection();
             expect(exportedSelection.emptyBlocksIndex).toEqual(undefined);
         });
+
         it('should not export a position indicating the cursor is after an empty paragraph ' +
                 '(in a complicated markup with selection on the element)', function () {
             this.el.innerHTML = '<p><span>www.google.com</span></p><p><br /></p>' +
@@ -228,7 +229,27 @@ describe('Selection TestCase', function () {
             expect(Util.isDescendant(editor.elements[0].querySelector('i'), innerElement, true)).toBe(true, 'nested inline elment inside block element after empty block element');
         });
 
-        it('should import not import a selection beyond any block elements that have text, even when emptyBlocksIndex indicates it should ', function () {
+        ['br', 'img'].forEach(function (tagName) {
+            it('should not import a selection into focusing on the element \'' + tagName + '\' that cannot have children', function () {
+                this.el.innerHTML = '<p>Hello</p><p><' + tagName + ' /></p><p>World<p>';
+                var editor = this.newMediumEditor('.editor', {
+                    buttons: ['italic', 'underline', 'strikethrough']
+                });
+                editor.importSelection({
+                    'start': 5,
+                    'end': 5,
+                    'emptyBlocksIndex': 1
+                });
+
+                var innerElement = window.getSelection().getRangeAt(0).startContainer;
+                expect(innerElement.nodeName.toLowerCase()).toBe('p', 'focused element nodeName');
+                expect(innerElement).toBe(window.getSelection().getRangeAt(0).endContainer);
+                expect(innerElement.previousSibling.nodeName.toLowerCase()).toBe('p', 'previous sibling name');
+                expect(innerElement.nextSibling.nodeName.toLowerCase()).toBe('p', 'next sibling name');
+            });
+        });
+
+        it('should not import a selection beyond any block elements that have text, even when emptyBlocksIndex indicates it should ', function () {
             this.el.innerHTML = '<p><span>www.google.com</span></p><h1><br /></h1><h2>Not Empty</h2><p><b><i>Whatever</i></b></p>';
             var editor = this.newMediumEditor('.editor', {
                 buttons: ['italic', 'underline', 'strikethrough']

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -1014,10 +1014,18 @@ function MediumEditor(elements, options) {
 
                 // We're selecting a high-level block node, so make sure the cursor gets moved into the deepest
                 // element at the beginning of the block
-                var firstLeafNode = Util.getFirstLeafNode(targetNode);
-                if (['br', 'img', 'input'].indexOf(firstLeafNode.nodeName.toLowerCase()) !== -1) {
+                var firstLeafNode = Util.getFirstLeafNode(targetNode),
+                    emptyElements = ['br', 'col', 'colgroup', 'hr', 'img', 'input', 'source', 'wbr'];
+                while (emptyElements.indexOf(firstLeafNode.nodeName.toLowerCase()) !== -1) {
                     // We don't want to set the selection to an element that can't have children, this messes up Gecko.
                     firstLeafNode = firstLeafNode.parentNode;
+                }
+                // Selecting at the beginning of a table doesn't work in PhantomJS.
+                if (firstLeafNode.nodeName.toLowerCase() === 'table') {
+                    var firstCell = firstLeafNode.querySelector('th, td');
+                    if (firstCell) {
+                        firstLeafNode = firstCell;
+                    }
                 }
                 range.setStart(firstLeafNode, 0);
                 range.collapse(true);

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -1014,7 +1014,12 @@ function MediumEditor(elements, options) {
 
                 // We're selecting a high-level block node, so make sure the cursor gets moved into the deepest
                 // element at the beginning of the block
-                range.setStart(Util.getFirstLeafNode(targetNode), 0);
+                var firstLeafNode = Util.getFirstLeafNode(targetNode);
+                if (['br', 'img', 'input'].indexOf(firstLeafNode.nodeName.toLowerCase()) !== -1) {
+                    // We don't want to set the selection to an element that can't have children, this messes up Gecko.
+                    firstLeafNode = firstLeafNode.parentNode;
+                }
+                range.setStart(firstLeafNode, 0);
                 range.collapse(true);
             }
 

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -1014,20 +1014,7 @@ function MediumEditor(elements, options) {
 
                 // We're selecting a high-level block node, so make sure the cursor gets moved into the deepest
                 // element at the beginning of the block
-                var firstLeafNode = Util.getFirstLeafNode(targetNode),
-                    emptyElements = ['br', 'col', 'colgroup', 'hr', 'img', 'input', 'source', 'wbr'];
-                while (emptyElements.indexOf(firstLeafNode.nodeName.toLowerCase()) !== -1) {
-                    // We don't want to set the selection to an element that can't have children, this messes up Gecko.
-                    firstLeafNode = firstLeafNode.parentNode;
-                }
-                // Selecting at the beginning of a table doesn't work in PhantomJS.
-                if (firstLeafNode.nodeName.toLowerCase() === 'table') {
-                    var firstCell = firstLeafNode.querySelector('th, td');
-                    if (firstCell) {
-                        firstLeafNode = firstCell;
-                    }
-                }
-                range.setStart(firstLeafNode, 0);
+                range.setStart(Util.getFirstSelectableLeafNode(targetNode), 0);
                 range.collapse(true);
             }
 

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -672,9 +672,21 @@ var Util;
             });
         },
 
-        getFirstLeafNode: function (element) {
+        getFirstSelectableLeafNode: function (element) {
             while (element && element.firstChild) {
                 element = element.firstChild;
+            }
+            var emptyElements = ['br', 'col', 'colgroup', 'hr', 'img', 'input', 'source', 'wbr'];
+            while (emptyElements.indexOf(element.nodeName.toLowerCase()) !== -1) {
+                // We don't want to set the selection to an element that can't have children, this messes up Gecko.
+                element = element.parentNode;
+            }
+            // Selecting at the beginning of a table doesn't work in PhantomJS.
+            if (element.nodeName.toLowerCase() === 'table') {
+                var firstCell = element.querySelector('th, td');
+                if (firstCell) {
+                    element = firstCell;
+                }
             }
             return element;
         },


### PR DESCRIPTION
In Gecko, importing the selection when the cursor was in an empty
paragraph such as `<p><br /></p>` or `<p><img /></p>` would set the BR
or IMG to be the start and end container of the selected range. The
cursor would get 'stuck' and nothing happened when the user typed.

An example demonstrating this issue in Gecko is here:
http://jsbin.com/kaduwanego/edit?html,js,output