### PR TITLE
Fix issue with block-containers assumptions for selection

### DIFF
--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -214,6 +214,21 @@ describe('Selection TestCase', function () {
             expect(startParagraph).toBe(editor.elements[0].querySelector('h2'), 'block element after empty block element');
         });
 
+        it('should import a position with the cursor after an empty block element when there are nested block elements', function () {
+            this.el.innerHTML = '<blockquote><p><span>www.google.com</span></p></blockquote><h1><br /></h1><h2><br /></h2><p>Whatever</p>';
+            var editor = this.newMediumEditor('.editor', {
+                buttons: ['italic', 'underline', 'strikethrough']
+            });
+            editor.importSelection({
+                'start': 14,
+                'end': 14,
+                'emptyBlocksIndex': 2
+            });
+
+            var startParagraph = Util.getClosestTag(window.getSelection().getRangeAt(0).startContainer, 'h2');
+            expect(startParagraph).toBe(editor.elements[0].querySelector('h2'), 'block element after empty block element');
+        });
+
         it('should import a position with the cursor after an empty block element inside an element with various children', function () {
             this.el.innerHTML = '<p><span>www.google.com</span></p><h1><br /></h1><h2><br /></h2><p><b><i>Whatever</i></b></p>';
             var editor = this.newMediumEditor('.editor', {

--- a/src/js/selection.js
+++ b/src/js/selection.js
@@ -5,7 +5,7 @@ var Selection;
     'use strict';
 
     function filterOnlyParentElements(node) {
-        if (Util.parentElements.indexOf(node.nodeName.toLowerCase()) !== -1) {
+        if (Util.isBlockContainer(node)) {
             return NodeFilter.FILTER_ACCEPT;
         } else {
             return NodeFilter.FILTER_SKIP;
@@ -278,7 +278,7 @@ var Selection;
                 tagName = el.tagName.toLowerCase();
             }
 
-            while (el && Util.parentElements.indexOf(tagName) === -1) {
+            while (el && !Util.isBlockContainer(el)) {
                 el = el.parentNode;
                 if (el && el.tagName) {
                     tagName = el.tagName.toLowerCase();

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -396,7 +396,7 @@ var Util;
 
             var parentNode = node.parentNode,
                 tagName = parentNode.tagName.toLowerCase();
-            while (this.parentElements.indexOf(tagName) === -1 && tagName !== 'div') {
+            while (!this.isBlockContainer(parentNode) && tagName !== 'div') {
                 if (tagName === 'li') {
                     return true;
                 }
@@ -652,8 +652,7 @@ var Util;
         isElementAtBeginningOfBlock: function (node) {
             var textVal,
                 sibling;
-            while (node.nodeType === 3 ||
-                (this.parentElements.indexOf(node.tagName.toLowerCase()) === -1 && !node.getAttribute('data-medium-element'))) { // TODO: Change this in v5.0.0
+            while (!this.isBlockContainer(node) && !this.isMediumEditorElement(node)) {
                 sibling = node;
                 while (sibling = sibling.previousSibling) {
                     textVal = sibling.nodeType === 3 ? sibling.nodeValue : sibling.textContent;
@@ -666,9 +665,17 @@ var Util;
             return true;
         },
 
+        isMediumEditorElement: function (element) {
+            return element && element.nodeType !== 3 && !!element.getAttribute('data-medium-element');
+        },
+
+        isBlockContainer: function (element) {
+            return element && element.nodeType !== 3 && this.parentElements.indexOf(element.nodeName.toLowerCase()) !== -1;
+        },
+
         getBlockContainer: function (element) {
             return this.traverseUp(element, function (el) {
-                return Util.parentElements.indexOf(el.tagName.toLowerCase()) !== -1;
+                return Util.isBlockContainer(el) && !Util.isBlockContainer(el.parentNode);
             });
         },
 


### PR DESCRIPTION
Some of the auto-link code I modified assumed that blocks can't be inside blocks.  Apparently, in firefox, all `<blockquote>` elements have a `<p>` inside of them, so I was very wrong.

I've also added a helper function for checking whether an element is one of the things we consider a "block" element, and used this helper everywhere we were referencing `Util.parentElements`