### PR TITLE
Use nodeName instead of tagName + Fix busted code in toolbar

### DIFF
--- a/spec/auto-link.spec.js
+++ b/spec/auto-link.spec.js
@@ -235,7 +235,7 @@ describe('Autolink', function () {
                 triggerAutolinking(this.el);
                 var links = this.el.getElementsByTagName('a');
                 expect(links.length).toBe(1);
-                expect(this.el.firstChild.tagName.toLowerCase()).toBe('span');
+                expect(this.el.firstChild.nodeName.toLowerCase()).toBe('span');
                 expect(this.el.firstChild.textContent).toBe('Text with http://www.example.com inside!');
                 expect(this.el.firstChild.getElementsByTagName('a').length).toBe(1);
                 expect(links[0].getAttribute('href')).toBe('http://www.example.com');

--- a/spec/content.spec.js
+++ b/spec/content.spec.js
@@ -301,7 +301,7 @@ describe('Content TestCase', function () {
             });
             expect(this.el.innerHTML).toBe('<p><br></p><ul><li>lorem ipsum</li></ul>');
             range = document.getSelection().getRangeAt(0);
-            expect(range.commonAncestorContainer.tagName.toLowerCase()).toBe('p');
+            expect(range.commonAncestorContainer.nodeName.toLowerCase()).toBe('p');
         });
 
         it('should not insert a paragraph before the list if it is NOT the first element in the editor', function () {

--- a/spec/fontsize.spec.js
+++ b/spec/fontsize.spec.js
@@ -10,7 +10,7 @@ describe('Font Size Button TestCase', function () {
     function testFontSizeContents(el, size) {
         expect(el.childNodes.length).toBe(1);
         var child = el.childNodes[0];
-        expect(child.tagName).toBe('FONT');
+        expect(child.nodeName.toLowerCase()).toBe('font');
         expect(child.getAttribute('size')).toBe(size);
         expect(child.innerHTML).toBe('lorem ipsum');
     }

--- a/spec/header-tags.spec.js
+++ b/spec/header-tags.spec.js
@@ -34,7 +34,7 @@ describe('Protect Header Tags TestCase', function () {
 
             el = document.getElementById('header');
             expect(el).toBeDefined();
-            expect(el.tagName).toBe('H2');
+            expect(el.nodeName.toLowerCase()).toBe('h2');
         });
 
         it('header leading return inserts paragraph, not additional header', function () {
@@ -54,7 +54,7 @@ describe('Protect Header Tags TestCase', function () {
             });
 
             el = document.getElementById('header');
-            expect(el.previousElementSibling.tagName).toBe('P');
+            expect(el.previousElementSibling.nodeName.toLowerCase()).toBe('p');
 
         });
 
@@ -71,13 +71,13 @@ describe('Protect Header Tags TestCase', function () {
             sel.addRange(range);
 
             // hit backspace
-            fireEvent(editor.elements[0].querySelector(el.tagName.toLowerCase()), 'keydown', {
+            fireEvent(editor.elements[0].querySelector(el.nodeName.toLowerCase()), 'keydown', {
                 keyCode: Util.keyCode.BACKSPACE
             });
 
             el = document.getElementById('header');
             expect(el).toBeDefined();
-            expect(el.tagName).toBe('H2');
+            expect(el.nodeName.toLowerCase()).toBe('h2');
 
             el = document.getElementById('editor');
             expect(el.innerHTML).not.toBe(originalHTML);

--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -440,7 +440,7 @@ describe('Selection TestCase', function () {
             elements = Selection.getSelectedElements(document);
 
             expect(elements.length).toBe(1);
-            expect(elements[0].tagName.toLowerCase()).toBe('i');
+            expect(elements[0].nodeName.toLowerCase()).toBe('i');
             expect(elements[0].innerHTML).toBe('ipsum');
         });
 
@@ -452,7 +452,7 @@ describe('Selection TestCase', function () {
             elements = Selection.getSelectedElements(document);
 
             expect(elements.length).toBe(1);
-            expect(elements[0].tagName.toLowerCase()).toBe('i');
+            expect(elements[0].nodeName.toLowerCase()).toBe('i');
             expect(elements[0].innerHTML).toBe('ipsum');
         });
     });

--- a/spec/textarea.spec.js
+++ b/spec/textarea.spec.js
@@ -26,7 +26,7 @@ describe('Textarea TestCase', function () {
     it('should accept a textarea element and "convert" it to a div, preserving important attributes', function () {
         var editor = this.newMediumEditor('.editor'),
             textarea = this.el;
-        expect(editor.elements[0].tagName.toLowerCase()).toBe('div');
+        expect(editor.elements[0].nodeName.toLowerCase()).toBe('div');
 
         var attributesToPreserve = ['data-disable-editing',
             'data-disable-toolbar',

--- a/spec/util.spec.js
+++ b/spec/util.spec.js
@@ -259,7 +259,7 @@ describe('Util', function () {
                 tag = el.querySelector('b').firstChild,
                 closestTag = Util.getClosestTag(tag, 'span');
 
-            expect(closestTag.tagName.toLowerCase()).toBe('span');
+            expect(closestTag.nodeName.toLowerCase()).toBe('span');
         });
 
         it('should not get closed tag with data-medium-editor-element', function () {

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -138,7 +138,7 @@ function MediumEditor(elements, options) {
             return;
         }
 
-        if (node.getAttribute('data-medium-editor-element') && node.children.length === 0) {
+        if (Util.isMediumEditorElement(node) && node.children.length === 0) {
             this.options.ownerDocument.execCommand('formatBlock', false, 'p');
         }
 

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -28,7 +28,7 @@ function MediumEditor(elements, options) {
     function handleTabKeydown(event) {
         // Override tab only for pre nodes
         var node = Selection.getSelectionStart(this.options.ownerDocument),
-            tag = node && node.tagName.toLowerCase();
+            tag = node && node.nodeName.toLowerCase();
 
         if (tag === 'pre') {
             event.preventDefault();
@@ -50,7 +50,7 @@ function MediumEditor(elements, options) {
 
     function handleBlockDeleteKeydowns(event) {
         var p, node = Selection.getSelectionStart(this.options.ownerDocument),
-            tagName = node.tagName.toLowerCase(),
+            tagName = node.nodeName.toLowerCase(),
             isEmpty = /^(\s+|<br\/?>)?$/i,
             isHeader = /h\d/i;
 
@@ -84,7 +84,7 @@ function MediumEditor(elements, options) {
                     // in an empty tag
                     isEmpty.test(node.innerHTML) &&
                     // when the next tag *is* a header
-                    isHeader.test(node.nextElementSibling.tagName)) {
+                    isHeader.test(node.nextElementSibling.nodeName.toLowerCase())) {
             // hitting delete in an empty element preceding a header, ex:
             //  <p>[CURSOR]</p><h1>Header</h1>
             // Will cause the h1 to become a paragraph.
@@ -106,7 +106,7 @@ function MediumEditor(elements, options) {
                 !node.parentElement.previousElementSibling &&
                 // is not the only li in a list
                 node.nextElementSibling &&
-                node.nextElementSibling.tagName.toLowerCase() === 'li') {
+                node.nextElementSibling.nodeName.toLowerCase() === 'li') {
             // backspacing in an empty first list element in the first list (with more elements) ex:
             //  <ul><li>[CURSOR]</li><li>List Item 2</li></ul>
             // will remove the first <li> but add some extra element before (varies based on browser)
@@ -143,7 +143,7 @@ function MediumEditor(elements, options) {
         }
 
         if (Util.isKey(event, Util.keyCode.ENTER) && !Util.isListItem(node)) {
-            tagName = node.tagName.toLowerCase();
+            tagName = node.nodeName.toLowerCase();
             // For anchor tags, unlink
             if (tagName === 'a') {
                 this.options.ownerDocument.execCommand('unlink', false, null);
@@ -207,7 +207,7 @@ function MediumEditor(elements, options) {
         // Loop through elements and convert textarea's into divs
         this.elements = [];
         elements.forEach(function (element) {
-            if (element.tagName.toLowerCase() === 'textarea') {
+            if (element.nodeName.toLowerCase() === 'textarea') {
                 this.elements.push(createContentEditable.call(this, element));
             } else {
                 this.elements.push(element);

--- a/src/js/extensions/button.js
+++ b/src/js/extensions/button.js
@@ -211,8 +211,8 @@ var Button;
                 return this.knownState;
             }
 
-            if (tagNames && tagNames.length > 0 && node.tagName) {
-                isMatch = tagNames.indexOf(node.tagName.toLowerCase()) !== -1;
+            if (tagNames && tagNames.length > 0) {
+                isMatch = tagNames.indexOf(node.nodeName.toLowerCase()) !== -1;
             }
 
             if (!isMatch && this.style) {

--- a/src/js/extensions/fontsize.js
+++ b/src/js/extensions/fontsize.js
@@ -143,7 +143,7 @@ var FontSizeForm;
 
         clearFontSize: function () {
             Selection.getSelectedElements(this.document).forEach(function (el) {
-                if (el.tagName === 'FONT' && el.hasAttribute('size')) {
+                if (el.nodeName.toLowerCase() === 'font' && el.hasAttribute('size')) {
                     el.removeAttribute('size');
                 }
             });

--- a/src/js/extensions/paste.js
+++ b/src/js/extensions/paste.js
@@ -170,7 +170,7 @@ var PasteHandler;
                 // elements are sometimes actually spaces.
                 workEl.innerHTML = workEl.innerHTML.replace(/\n/gi, ' ');
 
-                switch (workEl.tagName.toLowerCase()) {
+                switch (workEl.nodeName.toLowerCase()) {
                     case 'p':
                     case 'div':
                         this.filterCommonBlocks(workEl);
@@ -202,7 +202,7 @@ var PasteHandler;
             for (i = 0; i < elList.length; i += 1) {
                 workEl = elList[i];
 
-                if ('a' === workEl.tagName.toLowerCase() && this.getEditorOption('targetBlank')) {
+                if ('a' === workEl.nodeName.toLowerCase() && this.getEditorOption('targetBlank')) {
                     Util.setTargetBlank(workEl);
                 }
 
@@ -214,7 +214,7 @@ var PasteHandler;
         },
 
         isCommonBlock: function (el) {
-            return (el && (el.tagName.toLowerCase() === 'p' || el.tagName.toLowerCase() === 'div'));
+            return (el && (el.nodeName.toLowerCase() === 'p' || el.nodeName.toLowerCase() === 'div'));
         },
 
         filterCommonBlocks: function (el) {

--- a/src/js/extensions/toolbar.js
+++ b/src/js/extensions/toolbar.js
@@ -469,6 +469,13 @@ var Toolbar;
 
             parentNode = Selection.getSelectedParentElement(selectionRange);
 
+            // Make sure the selection parent isn't outside of the contenteditable
+            if (!this.getEditorElements().some(function (element) {
+                    return Util.isDescendant(element, parentNode, true);
+                })) {
+                return;
+            }
+
             // Climb up the DOM and do manual checks for whether a certain extension is currently enabled for this node
             while (parentNode) {
                 manualStateChecks.forEach(updateExtensionState);

--- a/src/js/extensions/toolbar.js
+++ b/src/js/extensions/toolbar.js
@@ -449,8 +449,6 @@ var Toolbar;
                 return;
             }
 
-            parentNode = Selection.getSelectedParentElement(selectionRange);
-
             // Loop through all extensions
             this.forEachExtension(function (extension) {
                 // For those extensions where we can use document.queryCommandState(), do so
@@ -469,12 +467,14 @@ var Toolbar;
                 manualStateChecks.push(extension);
             });
 
+            parentNode = Selection.getSelectedParentElement(selectionRange);
+
             // Climb up the DOM and do manual checks for whether a certain extension is currently enabled for this node
-            while (parentNode.tagName !== undefined && Util.parentElements.indexOf(parentNode.tagName.toLowerCase) === -1) {
+            while (parentNode) {
                 manualStateChecks.forEach(updateExtensionState);
 
                 // we can abort the search upwards if we leave the contentEditable element
-                if (this.getEditorElements().indexOf(parentNode) !== -1) {
+                if (Util.isMediumEditorElement(parentNode)) {
                     break;
                 }
                 parentNode = parentNode.parentNode;

--- a/src/js/selection.js
+++ b/src/js/selection.js
@@ -274,14 +274,14 @@ var Selection;
         getSelectionData: function (el) {
             var tagName;
 
-            if (el && el.tagName) {
-                tagName = el.tagName.toLowerCase();
+            if (el) {
+                tagName = el.nodeName.toLowerCase();
             }
 
             while (el && !Util.isBlockContainer(el)) {
                 el = el.parentNode;
-                if (el && el.tagName) {
-                    tagName = el.tagName.toLowerCase();
+                if (el) {
+                    tagName = el.nodeName.toLowerCase();
                 }
             }
 

--- a/src/js/selection.js
+++ b/src/js/selection.js
@@ -30,7 +30,7 @@ var Selection;
 
         getSelectionElement: function (contentWindow) {
             return this.findMatchingSelectionParent(function (el) {
-                return el.getAttribute('data-medium-editor-element');
+                return Util.isMediumEditorElement(el);
             }, contentWindow);
         },
 

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -278,7 +278,7 @@ var Util;
             // allowing nesting, we need to use outdent
             // https://developer.mozilla.org/en-US/docs/Rich-Text_Editing_in_Mozilla
             if (tagName === 'blockquote' && selectionData.el &&
-                    selectionData.el.parentNode.tagName.toLowerCase() === 'blockquote') {
+                    selectionData.el.parentNode.nodeName.toLowerCase() === 'blockquote') {
                 return doc.execCommand('outdent', false, null);
             }
             if (selectionData.tagName === tagName) {
@@ -309,7 +309,7 @@ var Util;
          */
         setTargetBlank: function (el, anchorUrl) {
             var i, url = anchorUrl || false;
-            if (el.tagName.toLowerCase() === 'a') {
+            if (el.nodeName.toLowerCase() === 'a') {
                 el.target = '_blank';
             } else {
                 el = el.getElementsByTagName('a');
@@ -326,7 +326,7 @@ var Util;
             var classes = buttonClass.split(' '),
                 i,
                 j;
-            if (el.tagName.toLowerCase() === 'a') {
+            if (el.nodeName.toLowerCase() === 'a') {
                 for (j = 0; j < classes.length; j += 1) {
                     el.classList.add(classes[j]);
                 }
@@ -344,19 +344,19 @@ var Util;
             if (!node) {
                 return false;
             }
-            if (node.tagName.toLowerCase() === 'li') {
+            if (node.nodeName.toLowerCase() === 'li') {
                 return true;
             }
 
             var parentNode = node.parentNode,
-                tagName = parentNode.tagName.toLowerCase();
+                tagName = parentNode.nodeName.toLowerCase();
             while (!this.isBlockContainer(parentNode) && tagName !== 'div') {
                 if (tagName === 'li') {
                     return true;
                 }
                 parentNode = parentNode.parentNode;
-                if (parentNode && parentNode.tagName) {
-                    tagName = parentNode.tagName.toLowerCase();
+                if (parentNode) {
+                    tagName = parentNode.nodeName.toLowerCase();
                 } else {
                     return false;
                 }
@@ -365,13 +365,13 @@ var Util;
         },
 
         cleanListDOM: function (ownerDocument, element) {
-            if (element.tagName.toLowerCase() !== 'li') {
+            if (element.nodeName.toLowerCase() !== 'li') {
                 return;
             }
 
             var list = element.parentElement;
 
-            if (list.parentElement.tagName.toLowerCase() === 'p') { // yes we need to clean up
+            if (list.parentElement.nodeName.toLowerCase() === 'p') { // yes we need to clean up
                 this.unwrap(list.parentElement, ownerDocument);
 
                 // move cursor at the end of the text inside the list
@@ -698,7 +698,7 @@ var Util;
 
         cleanupTags: function (el, tags) {
             tags.forEach(function (tag) {
-                if (el.tagName.toLowerCase() === tag) {
+                if (el.nodeName.toLowerCase() === tag) {
                     el.parentNode.removeChild(el);
                 }
             }, this);
@@ -707,7 +707,7 @@ var Util;
         // get the closest parent
         getClosestTag: function (el, tag) {
             return this.traverseUp(el, function (element) {
-                return element.tagName.toLowerCase() === tag.toLowerCase();
+                return element.nodeName.toLowerCase() === tag.toLowerCase();
             });
         },
 

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -614,7 +614,7 @@ var Util;
         },
 
         isMediumEditorElement: function (element) {
-            return element && element.nodeType !== 3 && !!element.getAttribute('data-medium-editor-element');
+            return element && element.getAttribute && !!element.getAttribute('data-medium-editor-element');
         },
 
         isBlockContainer: function (element) {

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -208,7 +208,7 @@ var Util;
                         return current;
                     }
                     // do not traverse upwards past the nearest containing editor
-                    if (current.getAttribute('data-medium-editor-element')) {
+                    if (Util.isMediumEditorElement(current)) {
                         return false;
                     }
                 }
@@ -245,7 +245,7 @@ var Util;
                         (toReplace.nodeType !== 3 && toReplace.innerHTML === range.toString())) {
                     while (toReplace.parentNode &&
                             toReplace.parentNode.childNodes.length === 1 &&
-                            !toReplace.parentNode.getAttribute('data-medium-editor-element')) {
+                            !Util.isMediumEditorElement(toReplace.parentNode)) {
                         toReplace = toReplace.parentNode;
                     }
                     range.selectNode(toReplace);


### PR DESCRIPTION
I propose we begin to use `nodeName` everywhere instead of `tagName`.  `nodeName` is defined on the `Node` class for all nodes, whereas `tagName` only exists on `Element`.  Thus, we can always use `nodeName` safely, whereas `tagName` might not exists.  This simplifies the code, avoids unnecessary exceptions, and since `nodeName` and `tagName` are identical on `Element`s, the behavior of our code should remain the same.

I've also fixed a line of code in toolbar that was broken and always returning true. I've also ensured that when we move up the DOM hierarchy while checking the state of elements, we're not bailing out early if we start at a text node (which I don't believe could have happened anyway).

Lastly, I've reused the new `Util.isMediumEditorElement()` helper everywhere in the code where it was explicitly checking for the `data-medium-editor-element` attribute.