### PR TITLE
Util cleanup

### DIFF
--- a/spec/util.spec.js
+++ b/spec/util.spec.js
@@ -1,5 +1,5 @@
 /*global MediumEditor, Util, describe, it, expect, spyOn,
-         afterEach, beforeEach, setupTestHelpers */
+         afterEach, beforeEach, setupTestHelpers, selectElementContents */
 
 describe('Util', function () {
     'use strict';
@@ -352,6 +352,32 @@ describe('Util', function () {
             expect(Util.isKey(event, 65)).toBeFalsy();
             expect(Util.isKey(event, [65])).toBeFalsy();
             expect(Util.isKey(event, [65, 66])).toBeFalsy();
+        });
+    });
+
+    describe('execFormatBlock', function () {
+        it('should execute indent command when called with blockquote when selection is inside a nested block element within a blockquote', function () {
+            var el = this.createElement('div', '', '<blockquote><p>Some <b>Text</b></p></blockquote>');
+            el.setAttribute('contenteditable', true);
+            selectElementContents(el.querySelector('b'));
+            spyOn(document, 'execCommand');
+
+            Util.execFormatBlock(document, 'blockquote');
+            expect(document.execCommand).toHaveBeenCalledWith('outdent', false, null);
+        });
+
+        it('should execute indent command when called with blockquote when isIE is true', function () {
+            var origIsIE = Util.isIE,
+                el = this.createElement('div', '', '<p>Some <b>Text</b></p>');
+            Util.isIE = true;
+            el.setAttribute('contenteditable', true);
+            selectElementContents(el.querySelector('b'));
+            spyOn(document, 'execCommand');
+
+            Util.execFormatBlock(document, 'blockquote');
+            expect(document.execCommand).toHaveBeenCalledWith('indent', false, 'blockquote');
+
+            Util.isIE = origIsIE;
         });
     });
 });

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -888,7 +888,7 @@ function MediumEditor(elements, options) {
             }
 
             if (inSelectionState.emptyBlocksIndex && selectionState.end === nextCharIndex) {
-                var targetNode = Util.getBlockContainer(range.startContainer),
+                var targetNode = Util.getTopBlockContainer(range.startContainer),
                     index = 0;
                 // Skip over empty blocks until we hit the block we want the selection to be in
                 while (index < inSelectionState.emptyBlocksIndex && targetNode.nextSibling) {

--- a/src/js/selection.js
+++ b/src/js/selection.js
@@ -269,26 +269,6 @@ var Selection;
                 startNode = (node && node.nodeType === 3 ? node.parentNode : node);
 
             return startNode;
-        },
-
-        getSelectionData: function (el) {
-            var tagName;
-
-            if (el) {
-                tagName = el.nodeName.toLowerCase();
-            }
-
-            while (el && !Util.isBlockContainer(el)) {
-                el = el.parentNode;
-                if (el) {
-                    tagName = el.nodeName.toLowerCase();
-                }
-            }
-
-            return {
-                el: el,
-                tagName: tagName
-            };
         }
     };
 }());

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -151,8 +151,6 @@ var Util;
             return !!(obj && obj.nodeType === 1);
         },
 
-        now: Date.now,
-
         // https://github.com/jashkenas/underscore
         throttle: function (func, wait) {
             var THROTTLE_INTERVAL = 50,

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -89,6 +89,7 @@ var Util;
         },
 
         blockContainerElementNames: ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'pre'],
+        emptyElementNames: ['br', 'col', 'colgroup', 'hr', 'img', 'input', 'source', 'wbr'],
 
         extend: function extend(/* dest, source1, source2, ...*/) {
             var args = [true].concat(Array.prototype.slice.call(arguments));
@@ -649,11 +650,10 @@ var Util;
             while (element && element.firstChild) {
                 element = element.firstChild;
             }
-            var emptyElements = ['br', 'col', 'colgroup', 'hr', 'img', 'input', 'source', 'wbr'];
-            while (emptyElements.indexOf(element.nodeName.toLowerCase()) !== -1) {
-                // We don't want to set the selection to an element that can't have children, this messes up Gecko.
-                element = element.parentNode;
-            }
+            // We don't want to set the selection to an element that can't have children, this messes up Gecko.
+            element = this.traverseUp(element, function (el) {
+                return Util.emptyElementNames.indexOf(el.nodeName.toLowerCase()) === -1;
+            });
             // Selecting at the beginning of a table doesn't work in PhantomJS.
             if (element.nodeName.toLowerCase() === 'table') {
                 var firstCell = element.querySelector('th, td');

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -88,7 +88,7 @@ var Util;
             return keyCode;
         },
 
-        blockElementNames: ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'pre'],
+        blockContainerElementNames: ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'pre'],
 
         extend: function extend(/* dest, source1, source2, ...*/) {
             var args = [true].concat(Array.prototype.slice.call(arguments));
@@ -631,7 +631,7 @@ var Util;
         },
 
         isBlockContainer: function (element) {
-            return element && element.nodeType !== 3 && this.blockElementNames.indexOf(element.nodeName.toLowerCase()) !== -1;
+            return element && element.nodeType !== 3 && this.blockContainerElementNames.indexOf(element.nodeName.toLowerCase()) !== -1;
         },
 
         getTopBlockContainer: function (element) {

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -621,7 +621,7 @@ var Util;
             return element && element.nodeType !== 3 && this.parentElements.indexOf(element.nodeName.toLowerCase()) !== -1;
         },
 
-        getBlockContainer: function (element) {
+        getTopBlockContainer: function (element) {
             return this.traverseUp(element, function (el) {
                 return Util.isBlockContainer(el) && !Util.isBlockContainer(el.parentNode);
             });

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -635,9 +635,14 @@ var Util;
         },
 
         getTopBlockContainer: function (element) {
-            return this.traverseUp(element, function (el) {
-                return Util.isBlockContainer(el) && !Util.isBlockContainer(el.parentNode);
+            var topBlock = element;
+            this.traverseUp(element, function (el) {
+                if (Util.isBlockContainer(el)) {
+                    topBlock = el;
+                }
+                return false;
             });
+            return topBlock;
         },
 
         getFirstSelectableLeafNode: function (element) {

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -88,7 +88,7 @@ var Util;
             return keyCode;
         },
 
-        parentElements: ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'pre'],
+        blockElementNames: ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'pre'],
 
         extend: function extend(/* dest, source1, source2, ...*/) {
             var args = [true].concat(Array.prototype.slice.call(arguments));
@@ -631,7 +631,7 @@ var Util;
         },
 
         isBlockContainer: function (element) {
-            return element && element.nodeType !== 3 && this.parentElements.indexOf(element.nodeName.toLowerCase()) !== -1;
+            return element && element.nodeType !== 3 && this.blockElementNames.indexOf(element.nodeName.toLowerCase()) !== -1;
         },
 
         getTopBlockContainer: function (element) {


### PR DESCRIPTION
This proposes some lingering cleanup to some Utility methods:

In `Util`:
* Rename `getBlockContainer()` to `getTopBlockContainer()`
  * Also add a fix to ensure the method does what it's supposed to
* Remove `now()` function
* Rename `.parentElements` to `.blockContainerElementNames`
* Expose `.emptyElementNames`
* Reuse `traverseUp()` in `getFirstSelectableLeafNode()`

In `Selection`:
* Remove uneeded `getSelectionData()`
  * `Util.getTopBlockContainer()` can replace what the previous function was doing