### PR TITLE
Creating a link should create only one anchor if possible

### DIFF
--- a/spec/anchor.spec.js
+++ b/spec/anchor.spec.js
@@ -70,7 +70,8 @@ describe('Anchor Button TestCase', function () {
                 keyCode: Util.keyCode.ENTER
             });
             expect(editor.createLink).toHaveBeenCalled();
-            expect(this.el.innerHTML).toBe('<a href="test">lorem ipsum</a>');
+            // A trailing <br> may be added when insertHTML is used to add the link internally.
+            expect(this.el.innerHTML.indexOf('<a href="test">lorem ipsum</a>')).toBe(0);
         });
 
         it('should create only one anchor tag when the user selects across a boundary', function () {
@@ -95,8 +96,14 @@ describe('Anchor Button TestCase', function () {
                 keyCode: Util.keyCode.ENTER
             });
             expect(editor.createLink).toHaveBeenCalled();
+            var suffix;
+            if (this.el.innerHTML.indexOf('<br') !== -1) {
+                suffix = '<br>';
+            } else {
+                suffix = '<strong></strong>';
+            }
             expect(this.el.innerHTML).toBe('Hello world, <a href="test">this <strong>will become a link</strong></a>' +
-                '<strong>, but this part won\'t.</strong>');
+                '<strong>, but this part won\'t.</strong>' + suffix);
         });
 
         it('should create a link when the user selects text within two paragraphs', function () {

--- a/spec/anchor.spec.js
+++ b/spec/anchor.spec.js
@@ -1,7 +1,8 @@
 /*global MediumEditor, describe, it, expect, spyOn,
      afterEach, beforeEach, selectElementContents,
      jasmine, fireEvent, Util, setupTestHelpers,
-     selectElementContentsAndFire, AnchorForm */
+     selectElementContentsAndFire, AnchorForm,
+     Selection */
 
 describe('Anchor Button TestCase', function () {
     'use strict';
@@ -80,14 +81,10 @@ describe('Anchor Button TestCase', function () {
             spyOn(MediumEditor.prototype, 'createLink').and.callThrough();
             var editor = this.newMediumEditor('.editor'),
                 toolbar = editor.getExtensionByName('toolbar'),
-                selection = window.getSelection(),
-                newRange = document.createRange(),
                 button, input;
 
-            selection.removeAllRanges();
-            newRange.setStart(this.el.childNodes[0], 'Hello world, '.length);
-            newRange.setEnd(this.el.childNodes[1].childNodes[0], 'will become a link'.length);
-            selection.addRange(newRange);
+            Selection.select(document, this.el.childNodes[0], 'Hello world, '.length,
+                this.el.childNodes[1].childNodes[0], 'will become a link'.length);
             button = toolbar.getToolbarElement().querySelector('[data-action="createLink"]');
             fireEvent(button, 'click');
             input = editor.getExtensionByName('anchor').getInput();
@@ -113,14 +110,10 @@ describe('Anchor Button TestCase', function () {
             spyOn(MediumEditor.prototype, 'createLink').and.callThrough();
             var editor = this.newMediumEditor('.editor'),
                 toolbar = editor.getExtensionByName('toolbar'),
-                selection = window.getSelection(),
-                newRange = document.createRange(),
                 button, input;
 
-            selection.removeAllRanges();
-            newRange.setStart(this.el.querySelector('span'), 0);
-            newRange.setEnd(this.el.querySelector('strong'), 1);
-            selection.addRange(newRange);
+            Selection.select(document, this.el.querySelector('span'), 0,
+                this.el.querySelector('strong'), 1);
             button = toolbar.getToolbarElement().querySelector('[data-action="createLink"]');
             fireEvent(button, 'click');
             input = editor.getExtensionByName('anchor').getInput();

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -923,14 +923,38 @@ function MediumEditor(elements, options) {
                 i;
 
             if (opts.url && opts.url.trim().length > 0) {
-                this.options.ownerDocument.execCommand('createLink', false, opts.url);
+                var currentSelection = this.options.contentWindow.getSelection();
+                if (currentSelection) {
+                    var exportedSelection = this.exportSelection(),
+                        currentEditor,
+                        startContainerParentElement,
+                        endContainerParentElement,
+                        textNodes;
 
-                if (this.options.targetBlank || opts.target === '_blank') {
-                    Util.setTargetBlank(Selection.getSelectionStart(this.options.ownerDocument), opts.url);
-                }
+                    currentEditor = Util.traverseUp(currentSelection.getRangeAt(0).startContainer, function (node) {
+                        return node.getAttribute('data-medium-editor-element');
+                    });
+                    startContainerParentElement = Util.findParentBlockContainer(
+                        currentSelection.getRangeAt(0).startContainer);
+                    endContainerParentElement = Util.findParentBlockContainer(
+                        currentSelection.getRangeAt(0).endContainer);
 
-                if (opts.buttonClass) {
-                    Util.addClassToAnchors(Selection.getSelectionStart(this.options.ownerDocument), opts.buttonClass);
+                    if (startContainerParentElement === endContainerParentElement) {
+                        textNodes = Util.findOrCreateMatchingTextNodes(this.options.ownerDocument,
+                                currentEditor,
+                                exportedSelection);
+                        Util.createLink(this.options.ownerDocument, textNodes, opts.url.trim());
+                        this.restoreSelection();
+                    } else {
+                        this.options.ownerDocument.execCommand('createLink', false, opts.url);
+                    }
+                    if (this.options.targetBlank || opts.target === '_blank') {
+                        Util.setTargetBlank(Selection.getSelectionStart(this.options.ownerDocument), opts.url);
+                    }
+
+                    if (opts.buttonClass) {
+                        Util.addClassToAnchors(Selection.getSelectionStart(this.options.ownerDocument), opts.buttonClass);
+                    }
                 }
             }
 

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -941,8 +941,6 @@ function MediumEditor(elements, options) {
                             fragment = this.options.ownerDocument.createDocumentFragment();
                         exportedSelection = this.exportSelection();
                         fragment.appendChild(parentElement.cloneNode(true));
-                        this.options.contentWindow.getSelection().removeAllRanges();
-                        var range = this.options.ownerDocument.createRange();
                         if (currentEditor === parentElement) {
                             // We have to avoid the editor itself being wiped out when it's the only block element,
                             // as our reference inside this.elements gets detached from the page when insertHTML runs.
@@ -955,14 +953,15 @@ function MediumEditor(elements, options) {
                             // In WebKit:
                             // an invented <br /> tag at the end in the same situation
 
-                            range.setStart(parentElement.firstChild, 0);
-                            range.setEnd(parentElement.lastChild, parentElement.lastChild.nodeType === 3 ?
+                            Selection.select(this.options.ownerDocument,
+                                parentElement.firstChild, 0,
+                                parentElement.lastChild, parentElement.lastChild.nodeType === 3 ?
                                 parentElement.lastChild.nodeValue.length : parentElement.lastChild.childNodes.length);
                         } else {
-                            range.setStart(parentElement, 0);
-                            range.setEnd(parentElement, parentElement.childNodes.length);
+                            Selection.select(this.options.ownerDocument,
+                                parentElement, 0,
+                                parentElement, parentElement.childNodes.length);
                         }
-                        this.options.contentWindow.getSelection().addRange(range);
                         var modifiedExportedSelection = this.exportSelection();
 
                         textNodes = Util.findOrCreateMatchingTextNodes(this.options.ownerDocument,

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -925,21 +925,20 @@ function MediumEditor(elements, options) {
             if (opts.url && opts.url.trim().length > 0) {
                 var currentSelection = this.options.contentWindow.getSelection();
                 if (currentSelection) {
-                    var exportedSelection = this.exportSelection(),
+                    var exportedSelection,
                         currentEditor,
                         startContainerParentElement,
                         endContainerParentElement,
                         textNodes;
 
-                    currentEditor = Util.traverseUp(currentSelection.getRangeAt(0).startContainer, function (node) {
-                        return node.getAttribute('data-medium-editor-element');
-                    });
-                    startContainerParentElement = Util.findParentBlockContainer(
+                    startContainerParentElement = Util.getClosestBlockContainer(
                         currentSelection.getRangeAt(0).startContainer);
-                    endContainerParentElement = Util.findParentBlockContainer(
+                    endContainerParentElement = Util.getClosestBlockContainer(
                         currentSelection.getRangeAt(0).endContainer);
 
                     if (startContainerParentElement === endContainerParentElement) {
+                        currentEditor = Selection.getSelectionElement(this.options.contentWindow);
+                        exportedSelection = this.exportSelection();
                         textNodes = Util.findOrCreateMatchingTextNodes(this.options.ownerDocument,
                                 currentEditor,
                                 exportedSelection);

--- a/src/js/extensions/toolbar.js
+++ b/src/js/extensions/toolbar.js
@@ -359,12 +359,8 @@ var Toolbar;
                     while (adjacentNode.nodeValue.substr(offset, 1).trim().length === 0) {
                         offset = offset + 1;
                     }
-                    var newRange = this.document.createRange();
-                    newRange.setStart(adjacentNode, offset);
-                    newRange.setEnd(selectionRange.endContainer, selectionRange.endOffset);
-                    selection.removeAllRanges();
-                    selection.addRange(newRange);
-                    selectionRange = newRange;
+                    selectionRange = Selection.select(this.document, adjacentNode, offset,
+                        selectionRange.endContainer, selectionRange.offset);
                 }
             }
         },

--- a/src/js/selection.js
+++ b/src/js/selection.js
@@ -243,6 +243,7 @@ var Selection;
                 range.collapse(true);
             }
             doc.getSelection().addRange(range);
+            return range;
         },
 
         /**
@@ -253,17 +254,7 @@ var Selection;
          * @param  {integer}     offset  Where in the element should we jump, 0 by default
          */
         moveCursor: function (doc, node, offset) {
-            var range, sel,
-                startOffset = offset || 0;
-
-            range = doc.createRange();
-            sel = doc.getSelection();
-
-            range.setStart(node, startOffset);
-            range.collapse(true);
-
-            sel.removeAllRanges();
-            sel.addRange(range);
+            this.select(doc, node, offset);
         },
 
         getSelectionRange: function (ownerDocument) {

--- a/src/js/selection.js
+++ b/src/js/selection.js
@@ -233,6 +233,18 @@ var Selection;
             sel.addRange(range);
         },
 
+        select: function (doc, startNode, startOffset, endNode, endOffset) {
+            doc.getSelection().removeAllRanges();
+            var range = doc.createRange();
+            range.setStart(startNode, startOffset);
+            if (endNode) {
+                range.setEnd(endNode, endOffset);
+            } else {
+                range.collapse(true);
+            }
+            doc.getSelection().addRange(range);
+        },
+
         /**
          * Move cursor to the given node with the given offset.
          *

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -101,6 +101,11 @@ var Util;
             return copyInto.apply(this, args);
         },
 
+        /*
+         * Create a link around the provided text nodes which must be adjacent to each other and all be
+         * descendants of the same closest block container. If the preconditions are not met, unexpected
+         * behavior will result.
+         */
         createLink: function (document, textNodes, href) {
             var anchor = document.createElement('a');
             Util.moveTextRangeIntoElement(textNodes[0], textNodes[textNodes.length - 1], anchor);
@@ -108,6 +113,15 @@ var Util;
             return anchor;
         },
 
+        /*
+         * Given the provided match in the format {start: 1, end: 2} where start and end are indices into the
+         * textContent of the provided element argument, modify the DOM inside element to ensure that the text
+         * identified by the provided match can be returned as text nodes that contain exactly that text, without
+         * any additional text at the beginning or end of the returned array of adjacent text nodes.
+         *
+         * The only DOM manipulation performed by this function is splitting the text nodes, non-text nodes are
+         * not affected in any way.
+         */
         findOrCreateMatchingTextNodes: function (document, element, match) {
             var treeWalker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT, null, false),
                 matchedNodes = [],
@@ -145,6 +159,12 @@ var Util;
             return matchedNodes;
         },
 
+        /*
+         * Given the provided text node and text coordinates, split the text node if needed to make it align
+         * precisely with the coordinates.
+         *
+         * This function is intended to be called from Util.findOrCreateMatchingTextNodes.
+         */
         splitStartNodeIfNeeded: function (currentNode, matchStartIndex, currentTextIndex) {
             if (matchStartIndex !== currentTextIndex) {
                 return currentNode.splitText(matchStartIndex - currentTextIndex);
@@ -152,6 +172,13 @@ var Util;
             return null;
         },
 
+        /*
+         * Given the provided text node and text coordinates, split the text node if needed to make it align
+         * precisely with the coordinates. The newNode argument should from the result of Util.splitStartNodeIfNeeded,
+         * if that function has been called on the same currentNode.
+         *
+         * This function is intended to be called from Util.findOrCreateMatchingTextNodes.
+         */
         splitEndNodeIfNeeded: function (currentNode, newNode, matchEndIndex, currentTextIndex) {
             var textIndexOfEndOfFarthestNode,
                 endSplitPoint;
@@ -282,12 +309,6 @@ var Util;
             } while (current);
 
             return false;
-        },
-
-        findParentBlockContainer: function (node) {
-            return Util.traverseUp(node, function (node) {
-                return Util.blockContainerElementNames.indexOf(node.nodeName.toLowerCase()) !== -1;
-            });
         },
 
         htmlEntities: function (str) {
@@ -705,6 +726,12 @@ var Util;
 
         isBlockContainer: function (element) {
             return element && element.nodeType !== 3 && this.blockContainerElementNames.indexOf(element.nodeName.toLowerCase()) !== -1;
+        },
+
+        getClosestBlockContainer: function (node) {
+            return Util.traverseUp(node, function (node) {
+                return Util.isBlockContainer(node);
+            });
         },
 
         getTopBlockContainer: function (element) {


### PR DESCRIPTION
When selecting text across inline element boundaries, the built-in
browser createLink command will create 2 or more anchor tags. This is a
weird behavior that the user will find strange when they go to delete or
modify one of the anchor tags and find that their changes don't affect
the other adjacent tags that appear to be part of a single link.

This fixes this problem for selections within a single paragraph or
other parent (block-level) element. If the user has selected text across
multiple parent elements, we fall back to the built-in browser behavior
as there is no way to ensure only a single link is created in this
situation.