### PR TITLE
Make anchorPreview.positionPreview more reusable

### DIFF
--- a/src/js/extensions/anchor-preview.js
+++ b/src/js/extensions/anchor-preview.js
@@ -89,9 +89,10 @@ var AnchorPreview;
             return this;
         },
 
-        positionPreview: function () {
+        positionPreview: function (activeAnchor) {
+            activeAnchor = activeAnchor || this.activeAnchor;
             var buttonHeight = this.anchorPreview.offsetHeight,
-                boundary = this.activeAnchor.getBoundingClientRect(),
+                boundary = activeAnchor.getBoundingClientRect(),
                 middleBoundary = (boundary.left + boundary.right) / 2,
                 diffLeft = this.diffLeft,
                 diffTop = this.diffTop,


### PR DESCRIPTION
This PR allows the `.positionPreview()` method of the anchor-preview extension to take in an argument which represents the anchor to position the preview relative to.  If the argument is not passed, it defaults to the use of the `this.activeAnchor` member variable.

This makes the method more re-usable for custom extensions that are extending `anchorPreview`.