### PR TITLE
Fix allowMultiParagraphSelection option

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@ var editor = new MediumEditor('.editor', {
 
 ### Core options
 * __activeButtonClass__: CSS class added to active buttons in the toolbar. Default: `'medium-editor-button-active'`
-* __allowMultiParagraphSelection__: enables the toolbar when selecting multiple paragraphs/block elements. Default: `true`
 * __buttonLabels__: type of labels on the buttons. Values: `false` | 'fontawesome'.  Default: `false`
 
 #### NOTE:
@@ -131,6 +130,7 @@ var editor = new MediumEditor('.editable', {
     toolbar: {
         /* These are the default options for the toolbar,
            if nothing is passed this is what is used */
+        allowMultiParagraphSelection: true,
         buttons: ['bold', 'italic', 'underline', 'anchor', 'h2', 'h3', 'quote'],
         diffLeft: 0,
         diffTop: -10,
@@ -147,6 +147,7 @@ var editor = new MediumEditor('.editable', {
 });
 ```
 
+* __allowMultiParagraphSelection__: enables/disables whether the toolbar should be displayed when selecting multiple paragraphs/block elements. Default: `true`
 * __buttons__: the set of buttons to display on the toolbar. Default: `['bold', 'italic', 'underline', 'anchor', 'h2', 'h3', 'quote']`
   * See [Button Options](#button-options) for details on more button options
 * __diffLeft__: value in pixels to be added to the X axis positioning of the toolbar. Default: `0`

--- a/demo/multi-paragraph.html
+++ b/demo/multi-paragraph.html
@@ -27,10 +27,10 @@
     <script src="../dist/js/medium-editor.js"></script>
     <script>
         var editor = new MediumEditor('.editable', {
-            allowMultiParagraphSelection: false,
             delay: 0,
             toolbar: {
-                diffTop: -12
+                diffTop: -12,
+                allowMultiParagraphSelection: false
             },
             anchor: {
                 placeholderText: 'Type a link'

--- a/spec/init.spec.js
+++ b/spec/init.spec.js
@@ -107,7 +107,6 @@ describe('Initialization TestCase', function () {
                 elementsContainer: document.body,
                 contentWindow: window,
                 ownerDocument: document,
-                allowMultiParagraphSelection: true,
                 buttonLabels: false,
                 targetBlank: false,
                 extensions: {},

--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -373,7 +373,7 @@ describe('Selection TestCase', function () {
             expect(toolbar.showAndUpdateToolbar).not.toHaveBeenCalled();
         });
 
-        it('should hide the toolbar when selecting multiple paragraphs and the allowMultiParagraphSelection option is false', function () {
+        it('should hide the toolbar when selecting multiple paragraphs and the deprecated allowMultiParagraphSelection option is false', function () {
             this.el.innerHTML = '<p id="p-one">lorem ipsum</p><p id="p-two">lorem ipsum</p>';
             var editor = this.newMediumEditor('.editor', {
                     allowMultiParagraphSelection: false

--- a/spec/toolbar.spec.js
+++ b/spec/toolbar.spec.js
@@ -203,6 +203,20 @@ describe('Toolbar TestCase', function () {
             expect(document.getSelection().rangeCount).toBe(1);
             expect(toolbar.isDisplayed()).toBe(false);
         });
+
+        it('should hide the toolbar when selecting multiple paragraphs and the allowMultiParagraphSelection option is false', function () {
+            this.el.innerHTML = '<p id="p-one">lorem ipsum</p><p id="p-two">lorem ipsum</p>';
+            var editor = this.newMediumEditor('.editor', {
+                    toolbar: {
+                        allowMultiParagraphSelection: false
+                    }
+                }),
+                toolbar = editor.getExtensionByName('toolbar');
+            selectElementContentsAndFire(document.getElementById('p-one'), { eventToFire: 'focus' });
+            expect(toolbar.getToolbarElement().classList.contains('medium-editor-toolbar-active')).toBe(true);
+            selectElementContentsAndFire(this.el, { eventToFire: 'mouseup' });
+            expect(toolbar.getToolbarElement().classList.contains('medium-editor-toolbar-active')).toBe(false);
+        });
     });
 
     describe('Static Toolbars', function () {

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -404,7 +404,11 @@ function MediumEditor(elements, options) {
         // just create the default toolbar
         var toolbarExtension = this.options.extensions['toolbar'];
         if (!toolbarExtension && isToolbarEnabled.call(this)) {
-            toolbarExtension = new MediumEditor.extensions.toolbar(this.options.toolbar);
+            // Backwards compatability
+            var toolbarOptions = Util.extend({}, this.options.toolbar, {
+                allowMultiParagraphSelection: this.options.allowMultiParagraphSelection // deprecated
+            });
+            toolbarExtension = new MediumEditor.extensions.toolbar(toolbarOptions);
         }
 
         // If the toolbar is not disabled, so we actually have an extension
@@ -416,7 +420,7 @@ function MediumEditor(elements, options) {
 
     function mergeOptions(defaults, options) {
         var deprecatedProperties = [
-            // ['forcePlainText', 'paste.forcePlainText'],
+            ['allowMultiParagraphSelection', 'toolbar.allowMultiParagraphSelection']
         ];
         // warn about using deprecated properties
         if (options) {

--- a/src/js/defaults/options.js
+++ b/src/js/defaults/options.js
@@ -4,7 +4,6 @@ var editorDefaults;
 
     editorDefaults = {
         activeButtonClass: 'medium-editor-button-active',
-        allowMultiParagraphSelection: true,
         buttonLabels: false,
         delay: 0,
         disableReturn: false,

--- a/src/js/extensions/toolbar.js
+++ b/src/js/extensions/toolbar.js
@@ -328,10 +328,10 @@ var Toolbar;
 
         // Checks for existance of multiple block elements in the current selection
         multipleBlockElementsSelected: function () {
-            /*jslint regexp: true*/
-            var selectionHtml = Selection.getSelectionHtml(this.document).replace(/<[\S]+><\/[\S]+>/gim, ''),
-                hasMultiParagraphs = selectionHtml.match(/<(p|h[1-6]|blockquote)[^>]*>/g);
-            /*jslint regexp: false*/
+            var regexEmptyHTMLTags = /<[^\/>][^>]*><\/[^>]+>/gim, // http://stackoverflow.com/questions/3129738/remove-empty-tags-using-regex
+                regexBlockElements = new RegExp('<(' + Util.blockContainerElementNames.join('|') + ')[^>]*>', 'g'),
+                selectionHTML = Selection.getSelectionHtml(this.document).replace(regexEmptyHTMLTags, ''), // Filter out empty blocks from selection
+                hasMultiParagraphs = selectionHTML.match(regexBlockElements); // Find how many block elements are within the html
 
             return !!hasMultiParagraphs && hasMultiParagraphs.length > 1;
         },

--- a/src/js/extensions/toolbar.js
+++ b/src/js/extensions/toolbar.js
@@ -15,6 +15,12 @@ var Toolbar;
          */
         align: 'center',
 
+        /* allowMultiParagraphSelection: [boolean]
+         * enables/disables whether the toolbar should be displayed when
+         * selecting multiple paragraphs/block elements
+         */
+        allowMultiParagraphSelection: true,
+
         /* buttons: [Array]
          * the names of the set of buttons to display on the toolbar.
          */
@@ -396,7 +402,7 @@ var Toolbar;
 
             // If we don't have a 'valid' selection -> hide toolbar
             if (this.window.getSelection().toString().trim() === '' ||
-                (this.getEditorOption('allowMultiParagraphSelection') === false && this.multipleBlockElementsSelected())) {
+                (this.allowMultiParagraphSelection === false && this.multipleBlockElementsSelected())) {
                 return this.hideToolbar();
             }
 


### PR DESCRIPTION
This PR covers two issues with the `allowMultiParagraphSelection` option.

1. When determining whether the selection spanned multiple block elements, the regular expression used to remove empty elements would remove multiple valid blocks if it found any empty ones: http://stackoverflow.com/questions/3129738/remove-empty-tags-using-regex

2. The `allowMultiParagraphSelection` option should have been moved into the toolbar options for v5.0 but it was missed.  The option has now been moved into the toolbar options, and the `allowMultiParagraphSelection` option on the global options is deprecated and will be removed in v6.0.0