### PR TITLE
Add Meteor.js support, http://meteor.com

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -300,6 +300,29 @@ module.exports = function (grunt) {
         }
     };
 
+    gruntConfig.exec = {
+        'meteor-init': {
+            command: [
+                // Make sure Meteor is installed, per https://meteor.com/install.
+                // The curl'ed script is safe; takes 2 minutes to read source & check.
+                'type meteor >/dev/null 2>&1 || { curl https://install.meteor.com/ | sh; }',
+                // Meteor expects package.js to be in the root directory
+                // of the checkout, so copy it there temporarily
+                'cp meteor/package.js .'
+                ].join(';')
+        },
+        'meteor-cleanup': {
+            // remove build files and package.js
+            command: 'rm -rf .build.* versions.json package.js'
+        },
+        'meteor-test': {
+            command: 'node_modules/.bin/spacejam --mongo-url mongodb:// test-packages ./'
+        },
+        'meteor-publish': {
+            command: 'meteor publish'
+        }
+    };
+
     grunt.initConfig(gruntConfig);
 
     require('time-grunt')(grunt);
@@ -331,4 +354,9 @@ module.exports = function (grunt) {
     grunt.registerTask('patch', ['bump', 'css', 'js']);
     grunt.registerTask('minor', ['bump:minor', 'css', 'js']);
     grunt.registerTask('major', ['bump:major', 'css', 'js']);
+
+    // Meteor tasks
+    grunt.registerTask( 'meteor-test', ['exec:meteor-init', 'exec:meteor-test', 'exec:meteor-cleanup']);
+    grunt.registerTask( 'meteor-publish', ['exec:meteor-init', 'exec:meteor-publish', 'exec:meteor-cleanup']);
+    grunt.registerTask( 'meteor', ['exec:meteor-init', 'exec:meteor-test', 'exec:meteor-publish', 'exec:meteor-cleanup']);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -356,7 +356,7 @@ module.exports = function (grunt) {
     grunt.registerTask('major', ['bump:major', 'css', 'js']);
 
     // Meteor tasks
-    grunt.registerTask( 'meteor-test', ['exec:meteor-init', 'exec:meteor-test', 'exec:meteor-cleanup']);
-    grunt.registerTask( 'meteor-publish', ['exec:meteor-init', 'exec:meteor-publish', 'exec:meteor-cleanup']);
-    grunt.registerTask( 'meteor', ['exec:meteor-init', 'exec:meteor-test', 'exec:meteor-publish', 'exec:meteor-cleanup']);
+    grunt.registerTask('meteor-test', ['exec:meteor-init', 'exec:meteor-test', 'exec:meteor-cleanup']);
+    grunt.registerTask('meteor-publish', ['exec:meteor-init', 'exec:meteor-publish', 'exec:meteor-cleanup']);
+    grunt.registerTask('meteor', ['exec:meteor-init', 'exec:meteor-test', 'exec:meteor-publish', 'exec:meteor-cleanup']);
 };

--- a/meteor/README.md
+++ b/meteor/README.md
@@ -1,0 +1,27 @@
+[![Build Status](https://travis-ci.org/MeteorPackaging/medium-editor.js.svg?branch=master)](https://travis-ci.org/MeteorPackaging/medium-editor.js)
+
+Packaging [MediumEditor](https://github.com/yabwe/medium-editor/) for [Meteor.js](http://meteor.com).
+
+
+# Meteor
+
+If you're new to Meteor, here's what the excitement is all about -
+[watch the first two minutes](https://www.youtube.com/watch?v=fsi0aJ9yr2o); you'll be hooked by 1:28.
+
+That screencast is from 2012. In the meantime, Meteor has become a mature JavaScript-everywhere web
+development framework. Read more at [Why Meteor](http://www.meteorpedia.com/read/Why_Meteor).
+
+
+# Issues
+
+If you encounter an issue while using this package, please CC @djhi when you file it in this repo.
+
+
+# DONE
+
+* Instantiation test
+
+
+# TODO
+
+* Tests ensuring correct event handling on template re-rendering

--- a/meteor/export.js
+++ b/meteor/export.js
@@ -1,0 +1,3 @@
+/*global MediumEditor:true*/  // Meteor creates a file-scope global for exporting. This comment prevents a potential JSHint warning.
+MediumEditor = window.MediumEditor;
+delete window.MediumEditor;

--- a/meteor/package.js
+++ b/meteor/package.js
@@ -1,7 +1,7 @@
 // package metadata file for Meteor.js
 'use strict';
 
-var packageName = 'medium-editor:medium-editor';  // https://atmospherejs.com/medium-editor/medium-editor
+var packageName = 'mediumeditor:mediumeditor';  // https://atmospherejs.com/medium-editor/medium-editor
 var where = 'client';  // where to install: 'client' or 'server'. For both, pass nothing.
 
 var packageJson = JSON.parse(Npm.require("fs").readFileSync('package.json'));

--- a/meteor/package.js
+++ b/meteor/package.js
@@ -1,0 +1,33 @@
+// package metadata file for Meteor.js
+'use strict';
+
+var packageName = 'medium-editor:medium-editor';  // https://atmospherejs.com/medium-editor/medium-editor
+var where = 'client';  // where to install: 'client' or 'server'. For both, pass nothing.
+
+var packageJson = JSON.parse(Npm.require("fs").readFileSync('package.json'));
+
+Package.describe({
+  name: packageName,
+  summary: 'MediumEditor (official) - A clone of medium.com inline editor toolbar.',
+  version: packageJson.version,
+  git: 'https://github.com/yabwe/medium-editor.git'
+});
+
+Package.onUse(function (api) {
+  api.versionsFrom(['METEOR@0.9.0', 'METEOR@1.0']);
+  api.export('MediumEditor');
+  api.addFiles([
+    'dist/js/medium-editor.js',
+    'dist/css/medium-editor.css',
+    'dist/css/themes/default.css',
+    'meteor/export.js'
+  ], where
+  );
+});
+
+Package.onTest(function (api) {
+  api.use(packageName, where);
+  api.use('tinytest', where);
+
+  api.addFiles('meteor/test.js', where);
+});

--- a/meteor/test.js
+++ b/meteor/test.js
@@ -1,0 +1,11 @@
+'use strict';
+
+Tinytest.add('MediumEditor.is', function(test) {
+    var div = document.createElement('div');
+    div.className = '.editable';
+    document.body.appendChild(div);
+
+    var editor = new MediumEditor('.editable');
+
+    test.instanceOf(editor, MediumEditor, 'Instantiation OK');
+});

--- a/package.json
+++ b/package.json
@@ -60,7 +60,9 @@
     "jshint-stylish": "1.0.2",
     "load-grunt-tasks": "3.1.0",
     "lodash": "3.9.1",
-    "time-grunt": "1.2.0"
+    "time-grunt": "1.2.0",
+    "grunt-exec": "^0.4.6",
+    "spacejam": "^1.1.1"
   },
   "scripts": {
     "test": "grunt test --verbose",


### PR DESCRIPTION
Hi,

I'm a Meteor.js dev and volunteer package maintainer for Meteor. I've been using MediumEditor with Meteor and would like to add it to Meteor's ecosystem which will expose MediumEditor to many new devs (Meteor has 20k+ stars on GitHub), likely bringing in new testers and contributors.

This PR will let you directly publish updated versions of the library as they become available. All you have to do is create an account at https://meteor.com/ (click SIGN IN, then Create account). After you've done that, please let me know the name of the account, and I'll add you as a maintainer.

I've already published the current version of the package on Atmosphere (Meteor's package directory). You can see it at https://atmospherejs.com/mediumeditor/mediumeditor. When you release new versions, you can publish them to Atmosphere with `grunt meteor`.

Thanks & best regards,
Gildas