### PR TITLE
Documentation

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,0 +1,315 @@
+# MediumEditor Object API (v5.0.0)
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Initialization Functions](#initialization-functions)
+  - [`MediumEditor(elements, options)`](#mediumeditorelements-options)
+  - [`destroy()`](#destroy)
+  - [`setup()`](#setup)
+- [Event Functions](#event-functions)
+  - [`on(target, event, listener, useCapture)`](#ontarget-event-listener-usecapture)
+  - [`off(target, event, listener, useCapture)`](#offtarget-event-listener-usecapture)
+  - [`subscribe(name, listener)`](#subscribename-listener)
+  - [`unsubscribe(name, listener)`](#unsubscribename-listener)
+  - [`trigger(name, data, editable)`](#triggername-data-editable)
+- [Selection Functions](#selection-functions)
+  - [`checkSelection()`](#checkselection)
+  - [`exportSelection()`](#exportselection)
+  - [`importSelection(selectionState, favorLaterSelectionAnchor)`](#importselectionselectionstate-favorlaterselectionanchor)
+  - [`getFocusedElement()`](#getfocusedelement)
+  - [`getSelectedParentElement(range)`](#getselectedparentelementrange)
+  - [`restoreSelection()`](#restoreselection)
+  - [`saveSelection()`](#saveselection)
+  - [`selectAllContents()`](#selectallcontents)
+  - [`selectElement(element)`](#selectelementelement)
+  - [`stopSelectionUpdates()`](#stopselectionupdates)
+  - [`startSelectionUpdates()`](#startselectionupdates)
+- [Editor Action Functions](#editor-action-functions)
+  - [`createLink(opts)`](#createlinkopts)
+  - [`cleanPaste(text)`](#cleanpastetext)
+  - [`execAction(action, opts)`](#execactionaction-opts)
+  - [`pasteHTML(html, options)`](#pastehtmlhtml-options)
+  - [`queryCommandState(action)`](#querycommandstateaction)
+- [Helper Functions](#helper-functions)
+  - [`delay(fn)`](#delayfn)
+  - [`getExtensionByName(name)`](#getextensionbynamename)
+  - [`serialize()`](#serialize)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Initialization Functions
+
+### `MediumEditor(elements, options)`
+
+Creating an instance of MediumEditor will:
+* Convert all passed in elements into `contenteditable` elements.
+* For any `<textarea>` elements, hide the `<textarea>`, create a new `<div contenteditable=true>` element, and ensure the 2 elements remain sync'd.
+* Initialize any custom extensions or buttons passed in.
+* Create any additional elements needed.
+* Setup all event handling needed to monitor the editable elements.
+
+**Arguments**
+
+_**elements** (`String` | `HTMLElement` | `Array`)_:
+
+1. `String`: If passed as a string, this is used as a selector in a call to `document.querySelectorAll()` to find elements on the page.  All results are stored in the internal list of **elements**.
+
+2. `HTMLElement`: If passed as a single element, this will be the only element in the internal list of **elements**.
+
+3. `Array`: If passed as an `Array` of `HTMLElement`s, this will be used as the internal list of **elements**.
+
+_**options** (`Object`)_: 
+
+Set of [custom options](https://github.com/yabwe/medium-editor/wiki/Options) used to initialize `MediumEditor`.
+
+***
+### `destroy()`
+
+Tear down the editor if already setup by doing the following:
+* Calling the `destroy()` method on each extension within the editor. This should allow all extension to be torn down and cleaned up, including the toolbar and its elements.
+* Detaching all event listeners from the DOM
+* Detaching all references to custom event listeners
+* Remove any custom attributes from the editor **elements**
+* Unhide any `<textarea>` elements and remove any created `<div>` elements created for `<textarea>` elements.
+
+***
+### `setup()`
+
+Initialize this instance of the editor if it has been destroyed.  This will reuse the `elements` selector and `options` object passed in when the editor was instantiated.
+
+***
+## Event Functions
+
+### `on(target, event, listener, useCapture)`
+
+Attaches an event listener to specific element via the browser's built-in `addEventListener(type, listener, useCapture)` API.  However, this helper method also ensures that when MediumEditor is destroyed, this event listener will be automatically be detached from the DOM.
+
+**Arguments**
+
+1. _**target** (`HTMLElement`)_:
+
+  * Element to attach listener to via `addEventListener(type, listener, useCapture)`
+
+2. _**event** (`String`)_: 
+
+  * type argument for `addEventListener(type, listener, useCapture)`
+
+3. _**listener** (`function`)_:
+
+   * listener argument for `addEventListener(type, listener, useCapture)`
+
+4. _**useCapture** (`boolean`)_:
+
+   * useCapture argument for `addEventListener(type, listener, useCapture)`
+
+***
+### `off(target, event, listener, useCapture)`
+
+Detach an event listener from a specific element via the browser's built-in `removeEventListener(type, listener, useCapture)` API.
+
+**Arguments**
+
+1. _**target** (`HTMLElement`)_:
+
+  * Element to detach listener from via `removeEventListener(type, listener, useCapture)`
+
+2. _**event** (`String`)_: 
+
+  * type argument for `removeEventListener(type, listener, useCapture)`
+
+3. _**listener** (`function`)_:
+
+   * listener argument for `removeEventListener(type, listener, useCapture)`
+
+4. _**useCapture** (`boolean`)_:
+
+   * useCapture argument for `removeEventListener(type, listener, useCapture)`
+
+***
+### `subscribe(name, listener)`
+
+Attaches a listener for the specified custom event name.
+
+**Arguments**
+
+1. _**name** (`String`)_:
+
+  * Name of the event to listen to.  See the list of built-in [Custom Events](#custom-events) below.
+
+2. _**listener(data, editable)** (`function`)_: 
+
+  * Listener method that will be called whenever the custom event is triggered.
+
+**Arguments to listener**
+
+  1. _**data** (`Event` | `object`)_
+    * For most custom events, this will be the browser's native `Event` object for the event that triggered the custom event to fire.
+    * For some custom events, this will be an object containing information describing the event (depending on which custom event it is)
+  2. _**editable** (`HTMLElement`)_
+    * A reference to the contenteditable container element that this custom event corresponds to.  This is especially useful for instances where one instance of MediumEditor contains multiple elements, or there are multiple instances of MediumEditor on the page.
+    * For example, when `blur` fires, this argument will be the `<div contenteditable=true></div>` element that is about to receive focus.
+
+***
+### `unsubscribe(name, listener)`
+
+Detaches a custom event listener for the specified custom event name.
+
+**Arguments**
+
+1. _**name** (`String`)_:
+
+  * Name of the event to detach the listener for.
+
+2. _**listener** (`function`)_: 
+
+  * A reference to the listener to detach.  This must be a match by-reference and not a copy.
+
+**NOTE**
+
+  * Calling [destroy()](#destroy) on the MediumEditor object will automatically remove all custom event listeners.
+
+***
+### `trigger(name, data, editable)`
+
+Manually triggers a custom event.
+
+**Arguments**
+
+1. _**name** (`String`)_:
+
+  * Name of the custom event to trigger.
+
+2. _**data** (`Event` | `object`)_:
+
+  * Native `Event` object or custom data object to pass to all the listeners to this custom event.
+
+3. _**editable** (`HTMLElement`)_:
+
+  * The `<div contenteditable=true></div>` element to pass to all of the listeners to this custom event.
+
+***
+## Selection Functions
+
+### `checkSelection()`
+
+If the toolbar is enabled, manually forces the toolbar to update based on the user's current selection.  This includes hiding/showing the toolbar, positioning the toolbar, and updating the enabled/disable state of the toolbar buttons.
+
+***
+### `exportSelection()`
+
+Returns a data representation of the selected text, which can be applied via `importSelection(selectionState)`.  This data will include the beginning and end of the selection, as well as which of the editor **elements** the selection was within.
+
+***
+### `importSelection(selectionState, favorLaterSelectionAnchor)`
+
+Restores the selection using a data representation of previously selected text (ie value returned by `exportSelection()`).
+
+**Arguments**
+
+1. _**selectionState** (`Object`)_:
+
+  * Data representing the state of the selection to restore.
+
+2. _**favorLaterSelectionAnchor** (`boolen`)_: 
+
+  * If `true`, import the cursor immediately subsequent to an anchor tag if it would otherwise be placed right at the trailing edge inside the anchor. THis cursor positioning, even though visually equivalent to the user, can affect behavior in Internet Explorer.
+
+***
+### `getFocusedElement()`
+
+Returns a reference to the editor **element** that currently has focus (if the editor has focus).
+
+***
+### `getSelectedParentElement(range)`
+
+Returns a reference to the editor **element** that the user's selection is currently within.
+
+***
+### `restoreSelection()`
+
+Restores the selection to what was selected the last time `saveSelection()` was called.
+
+***
+### `saveSelection()`
+
+Internally stores the user's current selection.  This can be restored by calling `restoreSelection()`.
+
+***
+### `selectAllContents()`
+
+Expands the selection to contain all text within the focused editor **element**.
+
+***
+### `selectElement(element)`
+
+Change the user's selection to select the contents of the provided element and update the toolbar to reflect this change.
+
+**Arguments**
+
+1. _**element** (`HTMLElement`)_:
+
+  * DOM Element -- which is a descendant of one of the editor's **elements** -- to select.
+
+***
+### `stopSelectionUpdates()`
+
+Stop the toolbar from updating to reflect changes in the user's selection.
+
+***
+### `startSelectionUpdates()`
+
+Enable the toolbar to start updating based on the user's selection, after a call to `stopSelectionUpdates()`
+
+***
+## Editor Action Functions
+
+### `cleanPaste(text)`
+_convert text to plaintext and replace current selection with result_
+
+***
+### `createLink(opts)`
+_creates a link via the native `document.execCommand('createLink')` command_
+
+***
+### `execAction(action, opts)`
+_executes an built-in action via document.execCommand_
+
+***
+### `pasteHTML(html, options)`
+_replace the current selection with html_
+
+***
+### `queryCommandState(action)`
+_wrapper around the browser's built in `document.queryCommandState(action)` for checking whether a specific action has already been applied to the selection._
+
+***
+## Helper Functions
+
+### `delay(fn)` 
+
+Delay any function from being executed by the amount of time passed as the **delay** option.
+
+**Arguments**
+
+1. _**fn** (`function`)_:
+
+  * Function to delay execution for.
+
+***
+### `getExtensionByName(name)`
+
+Get a reference to an extension with the specified name.
+
+**Arguments**
+
+1. _**name** (`String`)_:
+
+  * The name of the extension to retrieve (ie `toolbar`).
+
+***
+### `serialize()`
+
+Returns a JSON object including the content of each of the **elements** inside the editor.
+
+***

--- a/API.md
+++ b/API.md
@@ -26,8 +26,8 @@
   - [`stopSelectionUpdates()`](#stopselectionupdates)
   - [`startSelectionUpdates()`](#startselectionupdates)
 - [Editor Action Functions](#editor-action-functions)
-  - [`createLink(opts)`](#createlinkopts)
   - [`cleanPaste(text)`](#cleanpastetext)
+  - [`createLink(opts)`](#createlinkopts)
   - [`execAction(action, opts)`](#execactionaction-opts)
   - [`pasteHTML(html, options)`](#pastehtmlhtml-options)
   - [`queryCommandState(action)`](#querycommandstateaction)
@@ -61,7 +61,7 @@ _**elements** (`String` | `HTMLElement` | `Array`)_:
 
 _**options** (`Object`)_: 
 
-Set of [custom options](https://github.com/yabwe/medium-editor/wiki/Options) used to initialize `MediumEditor`.
+Set of [custom options](OPTIONS.md) used to initialize `MediumEditor`.
 
 ***
 ### `destroy()`
@@ -135,7 +135,7 @@ Attaches a listener for the specified custom event name.
 
 1. _**name** (`String`)_:
 
-  * Name of the event to listen to.  See the list of built-in [Custom Events](#custom-events) below.
+  * Name of the event to listen to.  See the list of built-in [Custom Events](CUSTOM-EVENTS.md).
 
 2. _**listener(data, editable)** (`function`)_: 
 

--- a/CUSTOM-EVENTS.md
+++ b/CUSTOM-EVENTS.md
@@ -1,0 +1,186 @@
+# MediumEditor Custom Events (v5.0.0)
+
+MediumEditor exposes a variety of custom events for convienience when using the editor with your web application.  You can attach and detach listeners to these custom events, as well as manually trigger any custom events including your own custom events.
+
+**NOTE:**
+
+Custom event listeners are triggered in the order that they were 'subscribed' to.  Most functionality within medium-editor uses these custom events to trigger updates, so in general, it can be assumed that most of the built-in functionality has already been completed before any of your custom event listeners will be called.
+
+If you need to override the editor's bult-in behavior, try overriding the built-in extensions with your own [custom extension](https://github.com/yabwe/medium-editor/wiki/Creating-Custom-Extensions-%26-Buttons).
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [API Methods](#api-methods)
+  - [`MediumEditor.subscribe(name, listener)`](#mediumeditorsubscribename-listener)
+  - [`MediumEditor.unsubscribe(name, listener)`](#mediumeditorunsubscribename-listener)
+  - [`MediumEditor.trigger(name, data, editable)`](#mediumeditortriggername-data-editable)
+- [Custom Events](#custom-events)
+  - [`blur`](#blur)
+  - [`editableInput`](#editableinput)
+  - [`externalInteraction`](#externalinteraction)
+  - [`focus`](#focus)
+- [Toolbar Custom Evenst](#toolbar-custom-evenst)
+  - [`hideToolbar`](#hidetoolbar)
+  - [`positionToolbar`](#positiontoolbar)
+  - [`showToolbar`](#showtoolbar)
+- [Proxied Custom Events](#proxied-custom-events)
+      - [`editableClick`](#editableclick)
+      - [`editableBlur`](#editableblur)
+      - [`editableKeypress`](#editablekeypress)
+      - [`editableKeyup`](#editablekeyup)
+      - [`editableKeydown`](#editablekeydown)
+      - [`editableKeydownEnter`](#editablekeydownenter)
+      - [`editableKeydownTab`](#editablekeydowntab)
+      - [`editableKeydownDelete`](#editablekeydowndelete)
+      - [`editableMouseover`](#editablemouseover)
+      - [`editableDrag`](#editabledrag)
+      - [`editableDrop`](#editabledrop)
+      - [`editablePaste`](#editablepaste)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## API Methods
+
+Use the following methods of [MediumEditor](https://github.com/yabwe/medium-editor/wiki/MediumEditor-Object-API) for custom event interaction:
+
+### `MediumEditor.subscribe(name, listener)`
+
+Attaches a listener for the specified custom event name.
+
+**Arguments**
+
+1. _**name** (`String`)_:
+
+  * Name of the event to listen to.  See the list of built-in [Custom Events](#custom-events) below.
+
+2. _**listener(data, editable)** (`function`)_: 
+
+  * Listener method that will be called whenever the custom event is triggered.
+
+**Arguments to listener**
+
+  1. _**data** (`Event` | `object`)_
+    * For most custom events, this will be the browser's native `Event` object for the event that triggered the custom event to fire.
+    * For some custom events, this will be an object containing information describing the event (depending on which custom event it is)
+  2. _**editable** (`HTMLElement`)_
+    * A reference to the contenteditable container element that this custom event corresponds to.  This is especially useful for instances where one instance of MediumEditor contains multiple elements, or there are multiple instances of MediumEditor on the page.
+    * For example, when `blur` fires, this argument will be the `<div contenteditable=true></div>` element that is about to receive focus.
+
+***
+### `MediumEditor.unsubscribe(name, listener)`
+
+Detaches a custom event listener for the specified custom event name.
+
+**Arguments**
+
+1. _**name** (`String`)_:
+
+  * Name of the event to detach the listener for.
+
+2. _**listener** (`function`)_: 
+
+  * A reference to the listener to detach.  This must be a match by-reference and not a copy.
+
+**NOTE**
+
+  * Calling [destroy()](#destroy) on the MediumEditor object will automatically remove all custom event listeners.
+
+***
+### `MediumEditor.trigger(name, data, editable)`
+
+Manually triggers a custom event.
+
+1. _**name** (`String`)_:
+
+  * Name of the custom event to trigger.
+
+2. _**data** (`Event` | `object`)_:
+
+  * Native `Event` object or custom data object to pass to all the listeners to this custom event.
+
+3. _**editable** (`HTMLElement`)_:
+
+  * The `<div contenteditable=true></div>` element to pass to all of the listeners to this custom event.
+
+## Custom Events
+
+These events are custom to MediumEditor so there may be one or more native events that can trigger them.
+
+### `blur`
+
+`blur` is triggered whenever a `contenteditable` element within an editor has lost focus to an element other than an editor maintained element (ie Toolbar, Anchor Preview, etc).
+
+Example:
+
+1. User selects text within an editor element, causing the toolbar to appear
+2. User clicks on a toolbar button
+  * Technically focus may have been lost on the editor element, but since the user is interacting with the toolbar, `blur` is NOT fired.
+3. User hovers over a link, anchor-preview is displayed
+4. User clicks link to edit it, and the toolbar now displays a textbox to edit the url
+  * Focus will have lost here since focus is now in the url editing textbox, but again since it's within the toolbar, `blur` is NOT fired.
+5. User clicks on another part of the page which hides the toolbar and focus is no longer in the `contenteditable`
+6. `blur` is triggered
+
+***
+### `editableInput`
+
+`editableInput` is triggered whenever the content of a `contenteditable` changes, including keypresses, toolbar actions, or any other user interaction that changes the html within the element.  For non-IE browsers, this is just a proxied version of the native `input` event.  However, Internet Explorer has never supported the `input` event on `contenteditable` elements so for these browsers the `editableInput` event is triggered through a combination of:
+* native `keypress` event on the element
+* native `selectionchange` event on the document
+* monitoring calls the `document.execCommand()`
+
+***
+### `externalInteraction`
+
+`externalInteraction` is triggered whenever the user interact with any element outside of the `contenteditable` element or the other elements maintained by the editor (ie Toolbar, Anchor Preview, etc.).  This event trigger regardless of whether an existing `contenteditable` element had focus or not.
+
+***
+### `focus`
+
+`focus` is triggered whenver a `contentedtiable` element within an editor receives focus. If the user interacts with any editor maintained elements (ie toolbar), `blur` is NOT triggered because focus has not been lost.  Thus, `focus` will only be triggered when an `contenteditable` element (or the editor that contains it) is first interacted with.
+
+## Toolbar Custom Evenst
+
+These events are triggered by the toolbar when the toolbar extension has not been disabled.
+
+### `hideToolbar`
+
+`hideToolbar` is triggered whenever the toolbar was visible and has just been hidden.
+
+### `positionToolbar`
+`positionToolbar` is triggered each time the current selection is checked and the toolbar's position is about to be updated. This event is triggered after all of the buttons have had their state updated, but before the toolbar is moved to the correct location.  This event will be triggered even if nothing will be changed about the toolbar's appearance.
+
+### `showToolbar`
+`showToolbar` is triggered whenever the toolbar was hidden and has just been displayed.
+
+## Proxied Custom Events
+
+These events are triggered whenever a native browser event is triggered for any of the `contenteditable` elements monitored by this instnace of MediumEditor.
+
+For example, the `editableClick` custom event will be triggered when a native `click` event is fired on any of the `contenteditable` elements. This provides a single event listener that can get fired for all elements, and also allows for the `contenteditable` element that triggered the event to be passed to the listener.
+
+##### `editableClick`
+native `click` event for each element
+##### `editableBlur`
+native `blur` event for each element.
+##### `editableKeypress`
+native `keypress` event for each element.
+##### `editableKeyup`
+native `keyup` event for each element.
+##### `editableKeydown`
+native `keydown` event for each element.
+##### `editableKeydownEnter`
+native `keydown` event for each element, but only triggered if the key is `ENTER` (keycode 13).
+##### `editableKeydownTab`
+native `keydown` event for each element, but only triggered if the key is `TAB` (keycode 9).
+##### `editableKeydownDelete`
+native `keydown` event for each element, but only triggered if the key is `DELETE` (keycode 46).
+##### `editableMouseover`
+native `mouseover` event for each element.
+##### `editableDrag`
+native `drag` event for each element.
+##### `editableDrop`
+native `drop` event for each element.
+##### `editablePaste`
+native `paste` event for each element.

--- a/CUSTOM-EVENTS.md
+++ b/CUSTOM-EVENTS.md
@@ -6,7 +6,7 @@ MediumEditor exposes a variety of custom events for convienience when using the 
 
 Custom event listeners are triggered in the order that they were 'subscribed' to.  Most functionality within medium-editor uses these custom events to trigger updates, so in general, it can be assumed that most of the built-in functionality has already been completed before any of your custom event listeners will be called.
 
-If you need to override the editor's bult-in behavior, try overriding the built-in extensions with your own [custom extension](https://github.com/yabwe/medium-editor/wiki/Creating-Custom-Extensions-%26-Buttons).
+If you need to override the editor's bult-in behavior, try overriding the built-in extensions with your own [custom extension](src/js/extensions/README.md).
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -42,7 +42,7 @@ If you need to override the editor's bult-in behavior, try overriding the built-
 
 ## API Methods
 
-Use the following methods of [MediumEditor](https://github.com/yabwe/medium-editor/wiki/MediumEditor-Object-API) for custom event interaction:
+Use the following methods of [MediumEditor](API.md) for custom event interaction:
 
 ### `MediumEditor.subscribe(name, listener)`
 
@@ -84,7 +84,7 @@ Detaches a custom event listener for the specified custom event name.
 
 **NOTE**
 
-  * Calling [destroy()](#destroy) on the MediumEditor object will automatically remove all custom event listeners.
+  * Calling [destroy()](API.md#destroy) on the MediumEditor object will automatically remove all custom event listeners.
 
 ***
 ### `MediumEditor.trigger(name, data, editable)`

--- a/CUSTOM-EVENTS.md
+++ b/CUSTOM-EVENTS.md
@@ -6,7 +6,7 @@ MediumEditor exposes a variety of custom events for convienience when using the 
 
 Custom event listeners are triggered in the order that they were 'subscribed' to.  Most functionality within medium-editor uses these custom events to trigger updates, so in general, it can be assumed that most of the built-in functionality has already been completed before any of your custom event listeners will be called.
 
-If you need to override the editor's bult-in behavior, try overriding the built-in extensions with your own [custom extension](src/js/extensions/README.md).
+If you need to override the editor's bult-in behavior, try overriding the built-in extensions with your own [custom extension](src/js/extensions).
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->

--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -1,6 +1,6 @@
 # MediumEditor Options (v5.0.0)
 
-Options to customize medium-editor are passed as the second argument to the [MediumEditor constructor](https://github.com/yabwe/medium-editor/wiki/MediumEditor-Object-API#mediumeditorelements-options).  Example:
+Options to customize medium-editor are passed as the second argument to the [MediumEditor constructor](API.md#mediumeditorelements-options).  Example:
 
 ```js
 var editor = new MediumEditor('.editor', {
@@ -157,7 +157,7 @@ Specifies a DOM node to contain MediumEditor's toolbar and anchor preview elemen
 #### `extensions`
 **Default:** `{}`
 
-Custom extensions to use. See [Custom Buttons and Extensions](https://github.com/yabwe/medium-editor/wiki/Custom-Buttons-and-Extensions) for more details on extensions.
+Custom extensions to use. See [Custom Buttons and Extensions](src/js/extensions) for more details on extensions.
 
 ***
 #### `ownerDocument`

--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -1,0 +1,605 @@
+# MediumEditor Options (v5.0.0)
+
+Options to customize medium-editor are passed as the second argument to the [MediumEditor constructor](https://github.com/yabwe/medium-editor/wiki/MediumEditor-Object-API#mediumeditorelements-options).  Example:
+
+```js
+var editor = new MediumEditor('.editor', {
+    // options go here
+});
+```
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Core Options](#core-options)
+    - [`activeButtonClass`](#activebuttonclass)
+    - [`buttonLabels`](#buttonlabels)
+    - [`contentWindow`](#contentwindow)
+    - [`delay`](#delay)
+    - [`disableReturn`](#disablereturn)
+    - [`disableDoubleReturn`](#disabledoublereturn)
+    - [`disableEditing`](#disableediting)
+    - [`elementsContainer`](#elementscontainer)
+    - [`extensions`](#extensions)
+    - [`ownerDocument`](#ownerdocument)
+    - [`spellcheck`](#spellcheck)
+    - [`targetBlank`](#targetblank)
+- [Toolbar options](#toolbar-options)
+    - [`allowMultiParagraphSelection`](#allowmultiparagraphselection)
+    - [`buttons`](#buttons)
+    - [`diffLeft`](#diffleft)
+    - [`diffTop`](#difftop)
+    - [`firstButtonClass`](#firstbuttonclass)
+    - [`lastButtonClass`](#lastbuttonclass)
+    - [`standardizeSelectionStart`](#standardizeselectionstart)
+    - [`static`](#static)
+  - ['static' Toolbar Options](#static-toolbar-options)
+    - [`align`](#align)
+    - [`sticky`](#sticky)
+    - [`updateOnEmptySelection`](#updateonemptyselection)
+  - [Disabling Toolbar](#disabling-toolbar)
+- [Anchor Preview options](#anchor-preview-options)
+    - [`hideDelay`](#hidedelay)
+    - [`previewValueSelector`](#previewvalueselector)
+  - [Disabling Anchor Preview](#disabling-anchor-preview)
+- [Placeholder Options](#placeholder-options)
+    - [`text`](#text)
+  - [Disabling Placeholders](#disabling-placeholders)
+- [Anchor Form options](#anchor-form-options)
+    - [`customClassOption`](#customclassoption)
+    - [`customClassOptionText`](#customclassoptiontext)
+    - [`linkValidation`](#linkvalidation)
+    - [`placeholderText`](#placeholdertext)
+    - [`targetCheckbox`](#targetcheckbox)
+    - [`targetCheckboxText`](#targetcheckboxtext)
+- [Paste Options](#paste-options)
+    - [`forcePlainText`](#forceplaintext)
+    - [`cleanPastedHTML`](#cleanpastedhtml)
+    - [`cleanReplacements`](#cleanreplacements)
+    - [`cleanAttrs`](#cleanattrs)
+    - [`cleanTags`](#cleantags)
+  - [Disabling Paste Handling](#disabling-paste-handling)
+- [KeyboardCommands Options](#keyboardcommands-options)
+    - [`commands`](#commands)
+  - [Disabling Keyboard Commands](#disabling-keyboard-commands)
+- [Auto Link Options](#auto-link-options)
+    - [`autoLink`](#autolink)
+  - [Enabling Auto Link](#enabling-auto-link)
+- [Image Dragging Options](#image-dragging-options)
+    - [`imageDragging`](#imagedragging)
+  - [Disabling Image Dragging](#disabling-image-dragging)
+- [Options Example:](#options-example)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Core Options
+
+These are global options that apply to the entire editor. Example:
+
+```js
+var editor = new MediumEditor('.editable', {
+    /* These are the default options for the editor,
+        if nothing is passed this is what is used */
+    activeButtonClass: 'medium-editor-button-active',
+    allowMultiParagraphSelection: true,
+    buttonLabels: false,
+    contentWindow: window,
+    delay: 0,
+    disableReturn: false,
+    disableDoubleReturn: false,
+    disableEditing: false,
+    elementsContainer: false,
+    extensions: {},
+    ownerDocument: document,
+    spellcheck: true,
+    targetBlank: false
+});
+```
+
+#### `activeButtonClass`
+**Default:** `'medium-editor-button-active'`
+
+CSS class added to active buttons in the toolbar.
+
+***
+#### `buttonLabels`
+**Default:** `false`
+
+Custom content for the toolbar buttons. 
+
+**Valid Values:**
+* `false`
+  * Use default button labels
+* `'fontawesome'`
+  * Uses fontawesome icon set for all toolbar icons
+
+**NOTE**:
+
+Using `'fontawesome'` as the buttonLabels requires version 4.1.0 of the fontawesome css to be on the page to ensure all icons will be displayed correctly.
+
+***
+#### `contentWindow`
+**Default:** `window`
+
+The contentWindow object that contains the contenteditable element. MediumEditor will use this for attaching events, getting selection, etc.
+
+***
+#### `delay`
+**Default:** `0`
+
+Time in milliseconds to show the toolbar or anchor tag preview.
+
+***
+#### `disableReturn`
+**Default:** `false`
+
+Enables/disables the use of the return-key. You can also set specific element behavior by using setting a data-disable-return attribute.
+
+***
+#### `disableDoubleReturn`
+**Default:** `false`
+
+Allows/disallows two (or more) empty new lines. You can also set specific element behavior by using setting a data-disable-double-return attribute.
+
+***
+#### `disableEditing`
+**Default:** `false`
+
+Enables/disables adding the contenteditable behavior. Useful for using the toolbar with customized buttons/actions. You can also set specific element behavior by using setting a data-disable-editing attribute.
+
+***
+#### `elementsContainer`
+**Default:** `ownerDocument.body`
+
+Specifies a DOM node to contain MediumEditor's toolbar and anchor preview elements.
+
+***
+#### `extensions`
+**Default:** `{}`
+
+Custom extensions to use. See [Custom Buttons and Extensions](https://github.com/yabwe/medium-editor/wiki/Custom-Buttons-and-Extensions) for more details on extensions.
+
+***
+#### `ownerDocument`
+**Default:** `window.document`
+
+The ownerDocument object for the contenteditable element.  MediumEditor will use this for creating elements, getting selection, attaching events, etc.
+
+***
+#### `spellcheck`
+**Default:** `true`
+
+Enable/disable native contentEditable automatic spellcheck.
+
+***
+#### `targetBlank`
+**Default:** `false`
+
+Enables/disables automatically adding the `target="_blank"` attribute to anchor tags.
+
+## Toolbar options
+
+The toolbar for MediumEditor is implemented as a built-in extension which automatically displays whenever the user selects some text.  The toolbar can hold any set of defined built-in buttons, but can also hold any custom buttons passed in as extensions.
+
+Options for the toolbar are passed as an object taht is a member of the outer options object. Example:
+```js
+var editor = new MediumEditor('.editable', {
+    toolbar: {
+        /* These are the default options for the toolbar,
+           if nothing is passed this is what is used */
+        allowMultiParagraphSelection: true,
+        buttons: ['bold', 'italic', 'underline', 'anchor', 'h2', 'h3', 'quote'],
+        diffLeft: 0,
+        diffTop: -10,
+        firstButtonClass: 'medium-editor-button-first',
+        lastButtonClass: 'medium-editor-button-last',
+        standardizeSelectionStart: false,
+        static: false,
+
+        /* options which only apply when static is true */
+        align: 'center',
+        sticky: false,
+        updateOnEmptySelection: false
+    }
+});
+```
+
+***
+#### `allowMultiParagraphSelection`
+**Default:** `true`
+
+enables/disables whether the toolbar should be displayed when selecting multiple paragraphs/block elements.
+
+***
+#### `buttons`
+**Default:** `['bold', 'italic', 'underline', 'anchor', 'h2', 'h3', 'quote']`
+
+The set of buttons to display on the toolbar.
+
+***
+#### `diffLeft`
+**Default:** `0`
+
+Value in pixels to be added to the X axis positioning of the toolbar.
+
+***
+#### `diffTop`
+**Default:** `-10`
+
+Value in pixels to be added to the Y axis positioning of the toolbar.
+
+***
+#### `firstButtonClass`
+**Default:** `'medium-editor-button-first'`
+
+CSS class added to the first button in the toolbar.
+
+***
+#### `lastButtonClass`
+**Default:** `'medium-editor-button-last'`
+
+CSS class added to the last button in the toolbar.
+
+***
+#### `standardizeSelectionStart`
+**Default:** `false`
+
+Enables/disables standardizing how the beginning of a range is decided between browsers whenever the selected text is analyzed for updating toolbar buttons status.
+
+***
+#### `static`
+**Default:** `false`
+
+Enable/disable the toolbar always displaying in the same location relative to the medium-editor element.
+
+
+### 'static' Toolbar Options
+
+These options only apply when the `static` option is being used.
+
+***
+#### `align`
+**Default:** `center`
+
+When the __static__ option is `true`, this aligns the static toolbar relative to the medium-editor element.
+
+**Valid Values**
+
+`'left'` | `'center'` | `'right'`
+
+***
+#### `sticky`
+**Default:** `false`
+
+When the __static__ option is `true`, this enables/disables the toolbar "sticking" to the viewport and staying visible on the screen while the page scrolls.
+
+***
+#### `updateOnEmptySelection`
+**Default:** `false`
+
+When the __static__ option is `true`, this enables/disables updating the state of the toolbar buttons even when the selection is collapsed (there is no selection, just a cursor).
+
+### Disabling Toolbar
+
+To disable the toolbar (which also disables the anchor-preview extension), set the value of the `toolbar` option to `false`:
+```javascript
+var editor = new MediumEditor('.editable', {
+    toolbar: false
+});
+```
+
+
+## Anchor Preview options
+
+The anchor preview is a built-in extension which automatically displays a 'tooltip' when the user is hovering over a link in the editor.  The tooltip will display the `href` of the link, and when click, will open the anchor editing form in the toolbar.
+
+Options for the anchor preview 'tooltip' are passed as an object that is a member of the outer options object. Example:
+```javascript
+var editor = new MediumEditor('.editable', {
+    anchorPreview: {
+        /* These are the default options for anchor preview,
+           if nothing is passed this is what it used */
+        hideDelay: 500,
+        previewValueSelector: 'a'
+    }
+}
+});
+```
+
+
+***
+#### `hideDelay`
+**Default:** `500`
+
+Time in milliseconds to show the anchor tag preview after the mouse has left the anchor tag.
+
+***
+#### `previewValueSelector`
+**Default:** `'a'`
+
+The default selector to locate where to put the activeAnchor value in the preview. You should only need to override this if you've modified the way in which the anchor-preview extension renders.
+
+### Disabling Anchor Preview
+
+To disable the anchor preview, set the value of the `anchorPreview` option to `false`:
+```javascript
+var editor = new MediumEditor('.editable', {
+    anchorPreview: false
+});
+```
+
+**NOTE:**
+
+* If the toolbar is disabled (via `toolbar: false` option or `data-disable-toolbar` attribute) the anchor-preview is automatically disabled.
+* If the anchor editing form is not enabled, clicking on the anchor-preview will not allow the href of the link to be edited
+
+## Placeholder Options
+
+The placeholder handler is a built-in extension which displays placeholder text when the editor is empty.
+
+Options for placeholder are passed as an object that is a member of the outer options object. Example:
+```javascript
+var editor = new MediumEditor('.editable', {
+    placeholder: {
+        /* This example includes the default options for placeholder,
+           if nothing is passed this is what it used */
+        text: 'Type your text'
+    }
+});
+```
+
+
+***
+#### `text`
+**Default:** `'Type your text'`
+
+Defines the default placeholder for empty contenteditables when __placeholder__ is not set to false. You can overwrite it by setting a `data-placeholder` attribute on the editor elements.
+
+### Disabling Placeholders
+
+To disable the placeholder, set the value of the `placeholder` option to `false`:
+```javascript
+var editor = new MediumEditor('.editable', {
+    placeholder: false
+});
+```
+
+## Anchor Form options
+
+The anchor form is a built-in button extension which allows the user to add/edit/remove links from within the editor.  When 'anchor' is passed in as a button in the list of buttons, this extension will be enabled and can be triggered by clicking the corresponding button in the toolbar.
+
+Options for the anchor form are passed as an object that is a member of the outer options object. Example:
+```javascript
+var editor = new MediumEditor('.editable', {
+    toolbar: {
+        buttons: ['bold', 'italic', 'underline', 'anchor']
+    },
+    anchor: {
+        /* These are the default options for anchor form,
+           if nothing is passed this is what it used */
+        customClassOption: null,
+        customClassOptionText: 'Button',
+        linkValidation: false,
+        placeholderText: 'Paste or type a link',
+        targetCheckbox: false,
+        targetCheckboxText: 'Open in new window'
+    }
+}
+});
+```
+
+
+***
+#### `customClassOption`
+**Default:** `null`
+
+Custom class name the user can optionally have added to their created links (ie 'button').  If passed as a non-empty string, a checkbox will be displayed allowing the user to choose whether to have the class added to the created link or not.
+
+***
+#### `customClassOptionText`
+**Default:** `'Button'`
+
+Text to be shown in the checkbox when the __customClassOption__ is being used.
+
+***
+#### `linkValidation`
+**Default:** `false`
+
+Enables/disables check for common URL protocols on anchor links.
+
+***
+#### `placeholderText`
+**Default:** `'Paste or type a link'`
+
+Text to be shown as placeholder of the anchor input.
+
+***
+#### `targetCheckbox`
+**Default:** `false`
+
+Enables/disables displaying a "Open in new window" checkbox, which when checked changes the `target` attribute of the created link.
+
+***
+#### `targetCheckboxText`
+**Default:** `'Open in new window'`
+
+Text to be shown in the checkbox enabled via the __targetCheckbox__ option.
+
+## Paste Options
+
+The paste handler is a built-in extension which attempts to filter the content when the user pastes.  How the paste handler filters is configurable via specific options.
+
+Options for paste handling are passed as an object that is a member of the outer options object. Example:
+```javascript
+var editor = new MediumEditor('.editable', {
+    paste: {
+        /* This example includes the default options for paste,
+           if nothing is passed this is what it used */
+        forcePlainText: true,
+        cleanPastedHTML: false,
+        cleanReplacements: [],
+        cleanAttrs: ['class', 'style', 'dir'],
+        cleanTags: ['meta']
+    }
+});
+```
+
+
+***
+#### `forcePlainText`
+**Default:** `true`
+
+Forces pasting as plain text.
+
+***
+#### `cleanPastedHTML`
+**Default:** `false`
+
+Cleans pasted content from different sources, like google docs etc.
+
+***
+#### `cleanReplacements`
+**Default:** `[]`
+
+Custom pairs (2 element arrays) of RegExp and replacement text to use during paste when __forcePlainText__ or __cleanPastedHTML__ are `true` OR when calling `cleanPaste(text)` helper method.
+
+***
+#### `cleanAttrs`
+**Default:** `['class', 'style', 'dir']`
+
+List of element attributes to remove during paste when __cleanPastedHTML__ is `true` or when calling `cleanPaste(text)` or `pasteHTML(html,options)` helper methods.
+
+***
+#### `cleanTags`
+**Default:** `['meta']`
+
+List of element tag names to remove during paste when __cleanPastedHTML__ is `true` or when calling `cleanPaste(text)` or `pasteHTML(html,options)` helper methods.
+
+### Disabling Paste Handling
+
+To disable MediumEditor manipulating pasted content, set the both the `forcePlainText` and `cleanPastedHTML` options to `false`:
+```javascript
+var editor = new MediumEditor('.editable', {
+    paste: {
+        forcePlainText: false,
+        cleanPastedHTML: false
+    }
+});
+```
+
+## KeyboardCommands Options
+
+The keyboard commands handler is a built-in extension for mapping key-combinations to actions to execute in the editor.
+
+Options for KeyboardCommands are passed as an object that is a member of the outer options object. Example:
+```javascript
+var editor = new MediumEditor('.editable', {
+    keyboardCommands: {
+        /* This example includes the default options for keyboardCommands,
+           if nothing is passed this is what it used */
+        commands: [
+            {
+                command: 'bold',
+                key: 'b',
+                meta: true,
+                shift: false
+            },
+            {
+                command: 'italic',
+                key: 'i',
+                meta: true,
+                shift: false
+            },
+            {
+                command: 'underline',
+                key: 'u',
+                meta: true,
+                shift: false
+            }
+        ],
+    }
+});
+```
+
+
+***
+#### `commands`
+**Default:** shortcuts for `bold`, `italic`, and `underline` (See above example)
+
+Array of objects describing each command and the combination of keys that will trigger it.  Required for each object:
+  * _command_: argument passed to `editor.execAction()` when key-combination is used
+  * _key_: keyboard character that triggers this command
+  * _meta_: whether the ctrl/meta key has to be active or inactive
+  * _shift_: whether the shift key has to be active or inactive
+
+### Disabling Keyboard Commands
+
+To disable the keyboard commands, set the value of the `keyboardCommands` option to `false`:
+```javascript
+var editor = new MediumEditor('.editable', {
+    keyboardCommands: false
+});
+```
+
+## Auto Link Options
+
+#### `autoLink`
+**Default:** `false`
+
+The auto-link handler is a built-in extension which automatically turns URLs entered into the text field into HTML anchor tags (similar to the functionality of Markdown).  This feature is OFF by default.
+
+### Enabling Auto Link
+
+To enable built-in auto-link support, set the value of the `autoLink` option to `true`:
+
+```javascript
+var editor = new MediumEditor('.editable', {
+    autoLink: true
+});
+```
+
+## Image Dragging Options
+
+#### `imageDragging`
+**Default:** `true`
+
+The image dragging handler is a built-in extenson for handling dragging & dropping images into the contenteditable.  This feature is ON by default.
+
+### Disabling Image Dragging
+
+To disable built-in image dragging, set the value of the `imageDragging` option to `false`:
+```javascript
+var editor = new MediumEditor('.editable', {
+    imageDragging: false
+});
+```
+
+## Options Example:
+
+```javascript
+var editor = new MediumEditor('.editable', {
+    delay: 1000,
+    targetBlank: true,
+    toolbar: {
+        buttons: ['bold', 'italic', 'quote'],
+        diffLeft: 25,
+        diffTop: 10,
+    },
+    anchor: {
+        placeholderText: 'Type a link',
+        customClassOption: 'btn',
+        customClassOptionText: 'Create Button'
+    },
+    paste: {
+        cleanPastedHTML: true,
+        cleanAttrs: ['style', 'dir'],
+        cleanTags: ['label', 'meta']
+    },
+    anchorPreview: {
+        hideDelay: 300
+    },
+    placeholder: {
+        text: 'Click to edit'
+    }
+});
+```

--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ People have contributed wrappers around MediumEditor for integrating with differ
 
 ## MediumEditor Options
 
-View the [MediumEditor Options documentation](https://github.com/yabwe/medium-editor/wiki/Options) on the Wiki for details on all the various options for MediumEditor.
+View the [MediumEditor Options documentation](OPTIONS.md) on all the various options for MediumEditor.
 
-Options to customize medium-editor are passed as the second argument to the [MediumEditor constructor](https://github.com/yabwe/medium-editor/wiki/MediumEditor-Object-API#mediumeditorelements-options).  Example:
+Options to customize medium-editor are passed as the second argument to the [MediumEditor constructor](API.md#mediumeditorelements-options).  Example:
 
 ```js
 var editor = new MediumEditor('.editor', {
@@ -116,7 +116,7 @@ Using `'fontawesome'` as the buttonLabels requires version 4.1.0 of the fontawes
 * __disableDoubleReturn__:  allows/disallows two (or more) empty new lines. You can also set specific element behavior by using setting a data-disable-double-return attribute. Default: `false`
 * __disableEditing__: enables/disables adding the contenteditable behavior. Useful for using the toolbar with customized buttons/actions. You can also set specific element behavior by using setting a data-disable-editing attribute. Default: `false`
 * __elementsContainer__: specifies a DOM node to contain MediumEditor's toolbar and anchor preview elements. Default: `document.body`
-* __extensions__: extension to use (see [Custom Buttons and Extensions](https://github.com/yabwe/medium-editor/wiki/Custom-Buttons-and-Extensions)) for more. Default: `{}`
+* __extensions__: extension to use (see [Custom Buttons and Extensions](src/js/extensions)) for more. Default: `{}`
 * __spellcheck__: Enable/disable native contentEditable automatic spellcheck. Default: `true`
 * __targetBlank__: enables/disables target="\_blank" for anchor tags. Default: `false`
 
@@ -171,7 +171,7 @@ var editor = new MediumEditor('.editable', {
 
 #### Button Options
 
-Button behavior can be modified by passing an object into the buttons array instead of a string. This allow for overriding some of the default behavior of buttons. The following options are some of the basic parts of buttons that you may override, but any part of the `MediumEditor.extension.prototype` can be overriden via these button options. (Check out the [source code for buttons](https://github.com/yabwe/medium-editor/blob/master/src/js/extensions/button.js) to see what all can be overriden).
+Button behavior can be modified by passing an object into the buttons array instead of a string. This allow for overriding some of the default behavior of buttons. The following options are some of the basic parts of buttons that you may override, but any part of the `MediumEditor.extension.prototype` can be overriden via these button options. (Check out the [source code for buttons](src/js/extensions/button.js) to see what all can be overriden).
 
 * __name__: name of the button being overriden
 * __action__: argument to pass to `MediumEditor.execAction()` when the button is clicked.
@@ -497,7 +497,7 @@ Check out the Wiki page for a list of available themes: [https://github.com/yabw
 
 ## API
 
-View the [MediumEditor Object API documentation](https://github.com/yabwe/medium-editor/wiki/MediumEditor-Object-API) on the Wiki for details on all the methods supported on the MediumEditor object.
+View the [MediumEditor Object API documentation](API.md) on the Wiki for details on all the methods supported on the MediumEditor object.
 
 ### Initialization methods
 * __MediumEditor(elements, options)__:  Creates an instance of MediumEditor
@@ -563,7 +563,7 @@ So, to properly support the `editableInput` event in Internet Explorer, MediumEd
 
 ## Extensions & Plugins
 
-Check the [documentation](https://github.com/yabwe/medium-editor/wiki/Custom-Buttons-and-Extensions) in order to learn how to develop extensions for MediumEditor.
+Check the [documentation](src/js/extensions) in order to learn how to develop extensions for MediumEditor.
 
 A list of existing extensions and plugins, such as [Images and Media embeds](http://orthes.github.io/medium-editor-insert-plugin/), [Tables](https://github.com/yabwe/medium-editor-tables) and [Markdown](https://github.com/IonicaBizau/medium-editor-markdown) can be found [here](https://github.com/yabwe/medium-editor/wiki/Extensions-Plugins).
 

--- a/src/js/extensions/README.md
+++ b/src/js/extensions/README.md
@@ -150,7 +150,7 @@ var editor = new MediumEditor('.editor', {
 ***
 ### `destroy()`
 
-If implemented, this method will be called whenever the MediumEditor is being destroyed (via a call to [`MediumEditor.destroy()](https://github.com/yabwe/medium-editor/wiki/MediumEditor-Object-API#destroy)).
+If implemented, this method will be called whenever the MediumEditor is being destroyed (via a call to [`MediumEditor.destroy()`](../../../API.md#destroy)).
 
 This gives the extensions the chance to remove any created html, custom event handlers or execute any other cleanup tasks that should be performed.
 
@@ -226,7 +226,7 @@ this.base.saveSelection();
 ***
 ### `window` _(Window)_
 
-A reference to the content window to be used by this instance of MediumEditor.  This maps to the value of the [`contentWindow`](https://github.com/yabwe/medium-editor/wiki/Options#contentwindow) option that is passed into MediumEditor.
+A reference to the content window to be used by this instance of MediumEditor.  This maps to the value of the [`contentWindow`](../../../OPTIONS.md#contentwindow) option that is passed into MediumEditor.
 
 For example, if you wanted to get the width of the window that contains this instance of MediumEditor, you could call the following within your extension:
 
@@ -237,7 +237,7 @@ var windowWidth = this.window.innerWidth;
 ***
 ### `document` _(Document)_
 
-A reference to the owner document to be used by this instance of MediumEditor.  This maps to the value of the [`ownerDocument`](https://github.com/yabwe/medium-editor/wiki/Options#ownerdocument) option that is passed into MediumEditor.
+A reference to the owner document to be used by this instance of MediumEditor.  This maps to the value of the [`ownerDocument`](../../../OPTIONS.md#ownerdocument) option that is passed into MediumEditor.
 
 For example, to create an element in the current document corresponding to this instance of MediumEditor, you would call the following within your extension:
 
@@ -307,7 +307,7 @@ Returns the value of a specific option used to initialize the MediumEditor objec
 
 **Returns:** Value of the MediumEditor option
 
-For example, the following is an excerpt from the `getTemplate()` method of the Anchor extension, which checks the [`buttonLabels`](https://github.com/yabwe/medium-editor/wiki/Options#buttonlabels) option MediumEditor to decide the appearance of the 'save' button in the form:
+For example, the following is an excerpt from the `getTemplate()` method of the Anchor extension, which checks the [`buttonLabels`](../../../OPTIONS.md#buttonlabels) option MediumEditor to decide the appearance of the 'save' button in the form:
 
 ```javascript
 AnchorForm = FormExtension.extend({
@@ -335,7 +335,7 @@ AnchorForm = FormExtension.extend({
 
 ### `execAction(action, opts)`
 
-Calls [`MediumEditor.execAction(action, opts)`](https://github.com/yabwe/medium-editor/wiki/MediumEditor-Object-API#execactionaction-opts)
+Calls [`MediumEditor.execAction(action, opts)`](../../../API.md#execactionaction-opts)
 
 For example, the Button Extension will - by default - call `execAction()` each time a button is clicked, to trigger a command:
 
@@ -359,7 +359,7 @@ Button = Extension.extend({
 ***
 ### `on(target, event, listener, useCapture)`
 
-Calls [`MediumEditor.on(target, event, listener, useCapture)`](https://github.com/yabwe/medium-editor/wiki/MediumEditor-Object-API#ontarget-event-listener-usecapture)
+Calls [`MediumEditor.on(target, event, listener, useCapture)`](../../../API.md#ontarget-event-listener-usecapture)
 
 This allows extensions to easily attach event handlers to the DOM which will automatically be detached when MediumEditor is destroyed.
 
@@ -381,7 +381,7 @@ AnchorPreview = Extension.extend({
 ***
 ### `off(target, event, listener, useCapture)`
 
-Calls [`MediumEditor.off(target, event, listener, useCapture)`](https://github.com/yabwe/medium-editor/wiki/MediumEditor-Object-API#offtarget-event-listener-usecapture)
+Calls [`MediumEditor.off(target, event, listener, useCapture)`](../../../API.md#offtarget-event-listener-usecapture)
 
 To compliment the above example for `on(target, event, listener, useCapture)`, when the Anchor Preview Extension detects a `mouseout` event for a link, it will detach the the event handler for `mouseout` until the next time the mouse hovers over the link:
 
@@ -400,7 +400,7 @@ AnchorPreview = Extension.extend({
 ***
 ### `subscribe(name, listener)`
 
-Calls [`MediumEditor.subscribe(name, listener)`](https://github.com/yabwe/medium-editor/wiki/MediumEditor-Object-API#subscribename-listener)
+Calls [`MediumEditor.subscribe(name, listener)`](../../../API.md#subscribename-listener)
 
 For example, the Keyboard Commands Extension will subscribe to the `editableKeydown` custom event during `init()`, to monitor when keys are pressed while any of the editor **elements** are focused:
 
@@ -420,7 +420,7 @@ KeyboardCommands = Extension.extend({
 ***
 ### `trigger(name, data, editable)`
 
-Calls [`MediumEditor.trigger(name, data, editable)`](https://github.com/yabwe/medium-editor/wiki/MediumEditor-Object-API#triggername-data-editable)
+Calls [`MediumEditor.trigger(name, data, editable)`](../../../API.md#triggername-data-editable)
 
 For example, the Toolbar Extension triggers the `hideToolbar` custom event whenever the toolbar is being hidden:
 

--- a/src/js/extensions/README.md
+++ b/src/js/extensions/README.md
@@ -1,0 +1,674 @@
+# Extensions
+
+## What is an Extension?
+
+**Extensions** are custom actions or commands that can be passed in via the `extensions` option to medium-editor.  They can replace existing buttons if they share the same name, or can add additional custom functionality into the editor.  Extensions can be implemented in any way, and just provide a way to hook into medium-editor.  New extensions can be created by extending the exposed `MediumEditor.Extension` object via `MediumEditor.Extension.extend()`.
+
+
+#### Examples of functionality that are implemented via built-in extensions:
+* [The MediumEditor Toolbar](https://github.com/yabwe/medium-editor/blob/toolbar-extension/src/js/extensions/toolbar.js)
+  * The entire toolbar which contains all of the MediumEditor buttons is implemented as an extension!
+* [Auto-Link Detection](https://github.com/yabwe/medium-editor/blob/master/src/js/extensions/auto-link.js)
+  * Automatically detecting when a url has been added and converting it into an anchor tag
+* [Anchor Preview Tooltip](https://github.com/yabwe/medium-editor/blob/master/src/js/extensions/anchor-preview.js)
+  * When a user hovers over a link a tooltip is displayed showing the href of the anchor tag
+* [Image Drag & Drop](https://github.com/yabwe/medium-editor/blob/master/src/js/extensions/image-dragging.js)
+  * Allows users to drag and drop images into the editor
+* [Keyboard Commands](https://github.com/yabwe/medium-editor/blob/master/src/js/extensions/keyboard-commands.js)
+  * Mapping keyboard shortcuts to various commands
+* [Placeholder Text](https://github.com/yabwe/medium-editor/blob/master/src/js/extensions/placeholder.js)
+  * Shows placeholder text when the editor is empty
+* [Paste Handling](https://github.com/yabwe/medium-editor/blob/master/src/js/extensions/paste.js)
+  * Handles filtering and modifying text that is pasted into the editor
+
+#### Examples of custom built external extensions:
+* [MediumEditor markdown](https://github.com/IonicaBizau/medium-editor-markdown)
+  * A Medium Editor extension to add markdown support.
+* [MediumEditor Insert Plugin](https://github.com/orthes/medium-editor-insert-plugin)
+  * Enables users to insert into the editor various types of content like images or embeds.
+
+
+## What is a Button?
+**Buttons** are a specific type of Extension which have a contract with the MediumEditor toolbar.  Buttons have specific lifecycle methods that MediumEditor and the toolbar use to interact with these specific types of Extensions.  These contract create easy hooks, allowing custom buttons to:
+* Display an element in the toolbar _(ie a clickable button/link)_
+* Execute an action on the editor text when clicked _(ie bold, underline, blockquote, etc.)_
+* Update the appearance of the element based on the user selection _(ie the bold button looks 'active' if the selected text is already bold, 'inactive' if the text is not bold)_
+
+#### All of the built-in MediumEditor buttons are just Button Extensions with different [configuration](https://github.com/yabwe/medium-editor/blob/master/src/js/defaults/buttons.js):
+* bold, italic, underline, strikethrough
+* subscript, superscript
+* image
+* quote, pre
+* orderedlist, unorderedlist
+* indent, outdent
+* justifyLeft, justifyCenter, justifyRight, justifyFull
+* h1, h2, h3, h4, h5, h6
+* removeFormat
+
+#### Examples of custom built external buttons:
+* [MediumEditor tables](https://github.com/yabwe/medium-editor-tables)
+  * Extension to add a table button/behavior to MediumEditor
+* [MediumEditor Custom HTML](https://github.com/jillix/medium-editor-custom-html)
+  * An extension that inserts custom HTML using a new button in the Medium Editor toolbar
+* [MediumButton](https://github.com/arcs-/MediumButton)
+  * Extends your Medium Editor with the possibility add buttons.
+
+
+## What is a Form Extension?
+**Form Extensions** are a specific type of Button Extension which collect input from the user via the toolbar.  Form Extensions extend from Button, and thus inherit all of the lifecycle methods of a Button.  In addition, Form Extensions have some additional methods exposed to interact with MediumEditor and provide some common functionality.
+
+#### Built-in Form Extensions
+* [Anchor Button](https://github.com/yabwe/medium-editor/blob/master/src/js/extensions/anchor.js)
+  * The `'anchor'` Button is actually a form extension, which when clicked, prompts the the user for a url (as well as some optional checkboxes) via a control in the toolbar and converts the selected text into a link.  If the selection is already a link, clicking the button unwraps text within the anchor tag.
+* [FontSize Button (beta)](https://github.com/yabwe/medium-editor/blob/master/src/js/extensions/fontsize.js)
+  * The `'fontsize'` Button is a form extension, which when clicked, allows the user to modify the size of the existing text via a control in the toolbar.
+
+
+# Extension
+
+## Extension Interface
+
+The following are properties and method that MediumEditor will attempt to use / call to interact with the extension internally.
+
+### `name` _(string)_
+
+The name to identify the extension by.  This is used for calls to [`MediumEditor.getExtensionByName(name)`](https://github.com/yabwe/medium-editor/wiki/MediumEditor-Object-API#getextensionbynamename) to retrieve the extension.  If not defined, this will be set to whatever identifier was used when passing the extension into MediumEditor via the `extensions` option.
+
+```javascript
+var MyExtension = MediumEditor.Extension.extend({
+  name: 'myextension'
+});
+
+var myExt = new MyExtension();
+
+var editor = new MediumEditor('.editor', {
+  extensions: {
+    'myextension': myExt
+  }
+});
+
+editor.getExtensionByName(`myextension`) === myExt //true
+```
+
+***
+### `init()`
+
+Called by MediumEditor during initialization.  The `.base` property will already have been set to current instance of MediumEditor when this is called. All helper methods will exist as well.
+
+See the [code above](#attaching-to-click) for an example of implementing the `init()` method.
+
+***
+### `checkState(node)`
+
+If implemented, this method will be called one or more times after the state of the editor & toolbar are updated. When the state is updated, the editor does the following:
+
+1. Find the parent node containing the current selection
+2. Call `checkState(node)` on each extension, passing the node as an argument
+3. Get the parent node of the previous node
+4. Repeat steps #2 and #3 until we move outside the parent contenteditable
+
+**Arguments**
+
+1. _**node** (`Node`)_:
+
+  * Current node, within the ancestors of the selection, that is being checked whenever a selection change occurred.
+
+Here's an example of an extension that will add/remove a class to editor elements depending on whether or the current selection is within an element with a custom data attribute:
+
+```javascript
+var EditedExtension = MediumEditor.Extension.extend({
+  name: 'edited',
+  checkState: function (node) {
+    // checkState is called multiple times for each selection change
+    // so only store a value if the attribute was found
+    if (!this.foundAttribute && node.getAttribute('data-edited')) {
+      this.foundAttribute = true;
+    }
+
+    // Once we've moved up the ancestors to the container element
+    // we know we're done iterating up and can add/remove the css class
+    if (MediumEditor.util.isMediumEditorElement(node)) {
+      if (this.foundAttribute) {
+        node.classList.add('edited-text');
+      } else {
+        node.classList.remove('edited-text');
+      }
+      // Make sure the property is not persisted for the next time
+      // selection is updated
+      delete this.foundAttribute;
+    }
+  }
+});
+
+var editedExt = new EditedExtension();
+
+var editor = new MediumEditor('.editor', {
+  extensions: {
+    'edited': editedExt
+  }
+});
+```
+
+***
+### `destroy()`
+
+If implemented, this method will be called whenever the MediumEditor is being destroyed (via a call to [`MediumEditor.destroy()](https://github.com/yabwe/medium-editor/wiki/MediumEditor-Object-API#destroy)).
+
+This gives the extensions the chance to remove any created html, custom event handlers or execute any other cleanup tasks that should be performed.
+
+***
+### `queryCommandState()`
+
+If implemented, this method will be called once on each extension when the state of the editor/toolbar is being updated.
+
+If this method returns a non-null value, the extension will be ignored as the code climbs the dom tree.
+
+If this method returns `true`, and the `setActive()` method is defined on the extension, the `setActive()` method will be called by MediumEditor.
+
+**Returns:** `boolean` OR `null`
+
+***
+### `isActive()`
+
+If implemented, this method will be called from MediumEditor to determine whether the button has already been set as 'active'. 
+
+If it returns `true`, this extension/button will be skipped for checking its active state as MediumEditor responds to the change in selection.
+
+If it returns `false`, `isAlreadyApplied()` will still be passed each ancestor element as the MediumEditor code climbs the DOM hierarchy to respond to the change in selection.
+
+
+**Returns:** `boolean`
+
+***
+### `isAlreadyApplied(node)`
+
+If implemented, this method is similar to `checkState()` in that it will be called repeatedly as MediumEditor moves up the DOM to update the editor & toolbar after a state change.
+
+**NOTE:**
+
+* This method will NOT be called if `checkState()` has been implemented. 
+* This method will NOT be called if `queryCommandState()` is implemented and returns a non-null value when called.
+
+**Arguments**
+
+1. _**node** (`Node`)_:
+
+  * Node to check for whether the current extension has already been applied.
+
+**Returns:** `boolean`
+
+***
+### `setActive()`
+
+If implemented, this method is called when MediumEditor knows that this extension is currently enabled.
+
+Currently, this method is called when updating the editor & toolbar, and if `queryCommandState()` or `isAlreadyApplied(node)` return true when called.
+
+***
+### `setInactive()`
+
+If implemented, this method is called when MediumEditor knows that this extension has not been applied to the current selection. Curently, this is called at the beginning of each state change for the editor & toolbar. 
+
+After calling this, MediumEditor will attempt to update the extension, either via `checkState()` or the combination of `queryCommandState()`, `isAlreadyApplied(node)`, `isActive()`, and `setActive()`
+
+## Extension Helpers
+
+The following are helpers that are either set by MediumEditor during initialization, or are helper methods which either route calls to the MediumEditor instance or provide common functionality for all extensions.
+
+### `base` _(MediumEditor)_
+
+A reference to the instance of MediumEditor that this extension is part of.
+
+For example, if you wanted to save the current selection within MediumEditor to be used later, you could call the following within your extension:
+
+```javascript
+this.base.saveSelection();
+```
+
+***
+### `window` _(Window)_
+
+A reference to the content window to be used by this instance of MediumEditor.  This maps to the value of the [`contentWindow`](https://github.com/yabwe/medium-editor/wiki/Options#contentwindow) option that is passed into MediumEditor.
+
+For example, if you wanted to get the width of the window that contains this instance of MediumEditor, you could call the following within your extension:
+
+```javascript
+var windowWidth = this.window.innerWidth;
+```
+
+***
+### `document` _(Document)_
+
+A reference to the owner document to be used by this instance of MediumEditor.  This maps to the value of the [`ownerDocument`](https://github.com/yabwe/medium-editor/wiki/Options#ownerdocument) option that is passed into MediumEditor.
+
+For example, to create an element in the current document corresponding to this instance of MediumEditor, you would call the following within your extension:
+
+```javascript
+var button = this.document.createElement('button');
+```
+
+***
+### `getEditorElements()`
+
+Returns a reference to the array of **elements** monitored by this instance of MediumEditor.
+
+**Returns:** `Array` of `HTMLElement`s
+
+For example, the following is the destroy method of the Placeholder Extension, which removes an attribute from all editor **elements**:
+
+```javascript
+Placeholder = Extension.extend({
+  // ...
+  destroy: function () {
+    this.getEditorElements().forEach(function (el) {
+      if (el.getAttribute('data-placeholder') === this.text) {
+        el.removeAttribute('data-placeholder');
+      }
+    }, this);
+  },
+  // ...
+});
+```
+
+***
+### `getEditorId()`
+
+Returns the unique identifier for this instance of MediumEditor
+
+**Returns:** `Number`
+
+For example, the following is an excerpt from the `createToolbar()` method of the Toolbar extension, which creates the toolbar element and gives it a unique id tied to the editor's unique id:
+
+```javascript
+Placeholder = Extension.extend({
+  // ...
+  createToolbar: function () {
+    var toolbar = this.document.createElement('div');
+
+    toolbar.id = 'medium-editor-toolbar-' + this.getEditorId();
+    toolbar.className = 'medium-editor-toolbar';
+
+    // ...
+
+    return toolbar;
+  },
+  // ...
+});
+```
+
+***
+### `getEditorOption(option)`
+
+Returns the value of a specific option used to initialize the MediumEditor object.
+
+**Arguments**
+
+1. _**option** ('String')_
+
+  * Name of the MediumEditor option to retrieve.
+
+**Returns:** Value of the MediumEditor option
+
+For example, the following is an excerpt from the `getTemplate()` method of the Anchor extension, which checks the [`buttonLabels`](https://github.com/yabwe/medium-editor/wiki/Options#buttonlabels) option MediumEditor to decide the appearance of the 'save' button in the form:
+
+```javascript
+AnchorForm = FormExtension.extend({
+  // ...
+  getTemplate: function () {
+    var template = [
+      '<input type="text" class="medium-editor-toolbar-input" placeholder="', this.placeholderText, '">'
+    ];
+
+    template.push(
+      '<a href="#" class="medium-editor-toolbar-save">',
+      this.getEditorOption('buttonLabels') === 'fontawesome' ? '<i class="fa fa-check"></i>' : this.formSaveLabel,
+      '</a>'
+    );
+
+    // ...
+  },
+  // ...
+});
+```
+
+## Extension Proxy Methods
+
+* These are methods that are just proxied calls into existing MediumEditor functions:
+
+### `execAction(action, opts)`
+
+Calls [`MediumEditor.execAction(action, opts)`](https://github.com/yabwe/medium-editor/wiki/MediumEditor-Object-API#execactionaction-opts)
+
+For example, the Button Extension will - by default - call `execAction()` each time a button is clicked, to trigger a command:
+
+```javascript
+Button = Extension.extend({
+  // ...
+  handleClick: function (event) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    var action = this.getAction(); // 'bold', 'italic', etc.
+
+    if (action) {
+      this.execAction(action);
+    }
+  },
+  // ...
+});
+```
+
+***
+### `on(target, event, listener, useCapture)`
+
+Calls [`MediumEditor.on(target, event, listener, useCapture)`](https://github.com/yabwe/medium-editor/wiki/MediumEditor-Object-API#ontarget-event-listener-usecapture)
+
+This allows extensions to easily attach event handlers to the DOM which will automatically be detached when MediumEditor is destroyed.
+
+For example, when the Anchor Preview Extension detects a `mouseover` event for a link, it will attach to the `mouseout` event for the same link so it can hide the anchor preview:
+
+```javascript
+AnchorPreview = Extension.extend({
+  // ...
+  handleEditableMouseover: function (event) {
+    // ...
+    this.instanceHandleAnchorMouseout = this.handleAnchorMouseout.bind(this);
+    this.on(this.anchorToPreview, 'mouseout', this.instanceHandleAnchorMouseout);
+    // ...
+  },
+  // ...
+});
+```
+
+***
+### `off(target, event, listener, useCapture)`
+
+Calls [`MediumEditor.off(target, event, listener, useCapture)`](https://github.com/yabwe/medium-editor/wiki/MediumEditor-Object-API#offtarget-event-listener-usecapture)
+
+To compliment the above example for `on(target, event, listener, useCapture)`, when the Anchor Preview Extension detects a `mouseout` event for a link, it will detach the the event handler for `mouseout` until the next time the mouse hovers over the link:
+
+```javascript
+AnchorPreview = Extension.extend({
+  // ...
+  handleAnchorMouseout: function () {
+    this.anchorToPreview = null;
+    this.off(this.activeAnchor, 'mouseout', this.instanceHandleAnchorMouseout);
+    this.instanceHandleAnchorMouseout = null;
+  },
+  // ...
+});
+```
+
+***
+### `subscribe(name, listener)`
+
+Calls [`MediumEditor.subscribe(name, listener)`](https://github.com/yabwe/medium-editor/wiki/MediumEditor-Object-API#subscribename-listener)
+
+For example, the Keyboard Commands Extension will subscribe to the `editableKeydown` custom event during `init()`, to monitor when keys are pressed while any of the editor **elements** are focused:
+
+```javascript
+KeyboardCommands = Extension.extend({
+  // ...
+  init: function () {
+    Extension.prototype.init.apply(this, arguments);
+
+    this.subscribe('editableKeydown', this.handleKeydown.bind(this));
+    // ...
+  },
+  // ...
+});
+```
+
+***
+### `trigger(name, data, editable)`
+
+Calls [`MediumEditor.trigger(name, data, editable)`](https://github.com/yabwe/medium-editor/wiki/MediumEditor-Object-API#triggername-data-editable)
+
+For example, the Toolbar Extension triggers the `hideToolbar` custom event whenever the toolbar is being hidden:
+
+```javascript
+Toolbar = Extension.extend({
+  // ...
+  hideToolbar: function () {
+    if (this.isDisplayed()) {
+      this.getToolbarElement().classList.remove('medium-editor-toolbar-active');
+      this.trigger('hideToolbar', {}, this.base.getFocusedElement());
+    }
+  },
+  // ...
+});
+```
+
+# Button
+
+Buttons are a specific type of extension which will render a button into the toolbar, allowing for custom logic to run whenever the button is clicked.  The extension framework also allows the button extension to respond to the user's selection each time the selection changes to do things such as 'activate/deactivate' the button.  This allows for things like having the Bold button be 'activated' whenever the user's selection includes already bold text, or 'inactive' if the selection is not already bold.
+
+***
+## Button Interface
+
+The only method that defines an extension as a **Button Extension** is the `getButton()` method. As long as the name of the **Button Extension** is passed via the `toolbar.buttons` option, and the `getButton()` method is implemented, then the toolbar will treat the extension as a **Button Extension**
+
+### `getButton()`
+
+If the name of an extension appears in the `toolbar.buttons` option, the MediumEditor toolbar will attempt to call this `getButton()` method on the extension. The `HTMLElement` returned by this method will be appended to the toolbar.
+
+The `getButton()` method on each button will be called and appended to the toolbar in the order that they were specified in the `toolbar.buttons` option.
+
+***
+## Button Helpers
+
+The following are properties and methods of the built-in button extension implementation (`MediumEditor.extensions.button`) that can be reused and/or overriden to make custom button extensions easier to create.
+
+### `action` _(string)_
+
+By default, the action argument to pass to MediumEditor.execAction() when the button is clicked.
+
+The value of this will also be set as the value of the `data-action` attribute which will be set on the button.
+
+**Example:**
+
+The following would create a custom button extension which would 'bold' text via the built-in 'bold' support in the browser:
+
+```js
+var CustomButtonExtension = MediumEditor.extensions.button.extend({
+  name: 'custom-button-extension',
+
+  action: 'bold'
+  
+  // ... other properties/methods ...
+})
+```
+
+***
+### `aria` _(string)_
+
+The value to add as both the `aria-label` and `title` attributes of the button.
+
+**Example:**
+
+The following would create a custom button extension which would have `'bold text'` as both the `aria-label` and the `title` attribute of the button in the toolbar:
+
+```js
+var CustomButtonExtension = MediumEditor.extensions.button.extend({
+  name: 'custom-button-extension',
+
+  aria: 'bold text'
+  
+  // ... other properties/methods ...
+})
+```
+
+***
+### `tagNames` _(Array)_
+        
+Array of element tag names that would indicate that this button has already been applied. If this action has already been applied, the button will be displayed as 'active' in the toolbar.
+
+**NOTE:** 
+
+`tagNames` is not used if `useQueryState` is set to `true`.
+
+**Example:**
+
+The following would create a custom button extension which would be 'active' in the toolbar if the selection is within a `<b>` or a `<strong>` tag:
+      
+```js
+var CustomButtonExtension = MediumEditor.extensions.button.extend({
+  name: 'custom-button-extension',
+
+  useQueryState: false,
+
+  tagNames: ['b', 'strong'],
+  
+  // ... other properties/methods ...
+})
+```
+
+***
+### `style` _(Object)_
+
+A pair of css property & value(s) that indicate that this button has already been applied. If this action has already been applied, the button will be displayed as 'active' in the toolbar.
+
+**Properties of this object:**
+
+* **prop** *[String]*: name of the css property
+* **value** *[String]*: value(s) of the css property (multiple values can be separated by a '|')
+
+**NOTE:** 
+
+`style` is not used if `useQueryState` is set to `true`.
+
+**Example:**
+
+The following would create a custom button extension which would be 'active' in the toolbar if the `font-weight` was either `700` of `'bold'`:
+
+```js
+var CustomButtonExtension = MediumEditor.extensions.button.extend({
+  name: 'custom-button-extension',
+
+  useQueryState: false,
+
+  style: {
+    prop: 'font-weight',
+    value: '700|bold'
+  },
+  
+  // ... other properties/methods ...
+})
+```
+
+***
+### `useQueryState` _(boolean)_
+
+Enables/disables whether this button should use the built-in `document.queryCommandState()` method to determine whether the action has already been applied.  If the action has already been applied, the button will be displayed as 'active' in the toolbar.
+
+**Example:**
+
+The following would create a custom button extension which would be enabled if the browser decided the text was 'bold':
+
+```js
+var CustomButtonExtension = MediumEditor.extensions.button.extend({
+  name: 'custom-button-extension',
+
+  action: 'bold',
+  useQueryState: true,
+
+  // ... other properties/methods ...
+})
+```
+
+For Example: For 'bold', if this is set to true, the code will call `document.queryCommandState('bold')` which will return `true` if the browser thinks the text is already bold, and `false` otherwise.
+
+***
+### `contentDefault` _(string)_
+
+Default innerHTML to put inside the button
+
+***
+### `contentFA` _(string)_
+
+The innerHTML to use for the content of the button if the `buttonLabels` option for MediumEditor is set to `'fontawesome'`
+
+**Example:**
+
+The following is pulled from the HighlightButton example, which defines a button for both the default case, and when `fontawesome` icons are being used.
+
+```js
+var CustomButtonExtension = MediumEditor.extensions.button.extend({
+  name: 'custom-button-extension',
+
+  contentDefault: '<b>H</b>',
+  contentFA: '<i class="fa fa-paint-brush"></i>',
+
+  // ... other properties/methods ...
+})
+```
+
+***
+### `classList` _(Array)_
+
+An array of classNames (strings) to be added to the button.
+
+**Example:**
+
+The following would create a custom button extension where the button element in the toolbar would have both a `custom-button` and a `custom-extension` class:
+
+```js
+var CustomButtonExtension = MediumEditor.extensions.button.extend({
+  name: 'custom-button-extension',
+
+  classList: ['custom-button', 'custom-extension'],
+
+  // ... other properties/methods ...
+})
+```
+
+***
+### `attrs` _(Object)_
+
+A set of key-value pairs to add to the button as custom attributes.
+
+**Example:**
+
+The following would create a custom button extension where the button element in the toolbar would have a `data-is-custom` attribute set to `true`:
+
+```js
+var CustomButtonExtension = MediumEditor.extensions.button.extend({
+  name: 'custom-button-extension',
+
+  attrs: {
+    'data-is-custom': 'true'
+  },
+
+  // ... other properties/methods ...
+})
+```
+
+***
+### `handleClick(event)` _(function)_
+
+The event listener called when the button is clicked.  The default built-in button will call `this.execAction(action)` when the button is clicked.
+
+**Example:**
+
+The following would create a custom button extension where the button would prompt the user for an action to execute:
+
+```js
+var CustomButtonExtension = MediumEditor.extensions.button.extend({
+  name: 'custom-button-extension',
+
+  handleClick: function (event) {
+    var action = prompt("Please enter an action", "bold");
+    if (action) {
+      this.execAction(action);
+    }
+  },
+
+  // ... other properties/methods ...
+})
+```
+
+# Form Button
+
+## Form Button Interface
+
+## Form Button Helpers

--- a/src/js/extensions/README.md
+++ b/src/js/extensions/README.md
@@ -72,7 +72,7 @@ The following are properties and method that MediumEditor will attempt to use / 
 
 ### `name` _(string)_
 
-The name to identify the extension by.  This is used for calls to [`MediumEditor.getExtensionByName(name)`](https://github.com/yabwe/medium-editor/wiki/MediumEditor-Object-API#getextensionbynamename) to retrieve the extension.  If not defined, this will be set to whatever identifier was used when passing the extension into MediumEditor via the `extensions` option.
+The name to identify the extension by.  This is used for calls to [`MediumEditor.getExtensionByName(name)`](../../../API.md#getextensionbynamename) to retrieve the extension.  If not defined, this will be set to whatever identifier was used when passing the extension into MediumEditor via the `extensions` option.
 
 ```javascript
 var MyExtension = MediumEditor.Extension.extend({
@@ -94,8 +94,6 @@ editor.getExtensionByName(`myextension`) === myExt //true
 ### `init()`
 
 Called by MediumEditor during initialization.  The `.base` property will already have been set to current instance of MediumEditor when this is called. All helper methods will exist as well.
-
-See the [code above](#attaching-to-click) for an example of implementing the `init()` method.
 
 ***
 ### `checkState(node)`

--- a/src/js/extensions/README.md
+++ b/src/js/extensions/README.md
@@ -2,7 +2,6 @@
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**
 
   - [What is an Extension?](#what-is-an-extension)
       - [Examples of functionality that are implemented via built-in extensions:](#examples-of-functionality-that-are-implemented-via-built-in-extensions)

--- a/src/js/extensions/README.md
+++ b/src/js/extensions/README.md
@@ -1,5 +1,64 @@
 # Extensions
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**
+
+  - [What is an Extension?](#what-is-an-extension)
+      - [Examples of functionality that are implemented via built-in extensions:](#examples-of-functionality-that-are-implemented-via-built-in-extensions)
+      - [Examples of custom built external extensions:](#examples-of-custom-built-external-extensions)
+  - [What is a Button?](#what-is-a-button)
+      - [All of the built-in MediumEditor buttons are just Button Extensions with different [configuration](https://github.com/yabwe/medium-editor/blob/master/src/js/defaults/buttons.js):](#all-of-the-built-in-mediumeditor-buttons-are-just-button-extensions-with-different-configurationhttpsgithubcomyabwemedium-editorblobmastersrcjsdefaultsbuttonsjs)
+      - [Examples of custom built external buttons:](#examples-of-custom-built-external-buttons)
+  - [What is a Form Extension?](#what-is-a-form-extension)
+      - [Built-in Form Extensions](#built-in-form-extensions)
+
+- [Extension](#extension)
+  - [Extension Interface](#extension-interface)
+    - [`name` _(string)_](#name-_string_)
+    - [`init()`](#init)
+    - [`checkState(node)`](#checkstatenode)
+    - [`destroy()`](#destroy)
+    - [`queryCommandState()`](#querycommandstate)
+    - [`isActive()`](#isactive)
+    - [`isAlreadyApplied(node)`](#isalreadyappliednode)
+    - [`setActive()`](#setactive)
+    - [`setInactive()`](#setinactive)
+  - [Extension Helpers](#extension-helpers)
+    - [`base` _(MediumEditor)_](#base-_mediumeditor_)
+    - [`window` _(Window)_](#window-_window_)
+    - [`document` _(Document)_](#document-_document_)
+    - [`getEditorElements()`](#geteditorelements)
+    - [`getEditorId()`](#geteditorid)
+    - [`getEditorOption(option)`](#geteditoroptionoption)
+  - [Extension Proxy Methods](#extension-proxy-methods)
+    - [`execAction(action, opts)`](#execactionaction-opts)
+    - [`on(target, event, listener, useCapture)`](#ontarget-event-listener-usecapture)
+    - [`off(target, event, listener, useCapture)`](#offtarget-event-listener-usecapture)
+    - [`subscribe(name, listener)`](#subscribename-listener)
+    - [`trigger(name, data, editable)`](#triggername-data-editable)
+
+- [Button](#button)
+  - [Button Interface](#button-interface)
+    - [`getButton()`](#getbutton)
+  - [Button Helpers](#button-helpers)
+    - [`action` _(string)_](#action-_string_)
+    - [`aria` _(string)_](#aria-_string_)
+    - [`tagNames` _(Array)_](#tagnames-_array_)
+    - [`style` _(Object)_](#style-_object_)
+    - [`useQueryState` _(boolean)_](#usequerystate-_boolean_)
+    - [`contentDefault` _(string)_](#contentdefault-_string_)
+    - [`contentFA` _(string)_](#contentfa-_string_)
+    - [`classList` _(Array)_](#classlist-_array_)
+    - [`attrs` _(Object)_](#attrs-_object_)
+    - [`handleClick(event)` _(function)_](#handleclickevent-_function_)
+
+- [Form Button](#form-button)
+  - [Form Button Interface](#form-button-interface)
+  - [Form Button Helpers](#form-button-helpers)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ## What is an Extension?
 
 **Extensions** are custom actions or commands that can be passed in via the `extensions` option to medium-editor.  They can replace existing buttons if they share the same name, or can add additional custom functionality into the editor.  Extensions can be implemented in any way, and just provide a way to hook into medium-editor.  New extensions can be created by extending the exposed `MediumEditor.Extension` object via `MediumEditor.Extension.extend()`.

--- a/src/js/extensions/WALKTHROUGH-BUTTON.md
+++ b/src/js/extensions/WALKTHROUGH-BUTTON.md
@@ -1,0 +1,299 @@
+# Walkthrough - Building a Button
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [HighlighterButton](#highlighterbutton)
+  - [1. Define the Extension](#1-define-the-extension)
+  - [2. Create and Display a Button](#2-create-and-display-a-button)
+  - [3. Improve Appearance](#3-improve-appearance)
+  - [4. Handle Button Click](#4-handle-button-click)
+  - [5. Respond to Selection](#5-respond-to-selection)
+  - [6. Leverage Existing Button Code](#6-leverage-existing-button-code)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## HighlighterButton
+
+You can find a demo of this example in the source code via [button-example.html](../../../demo/button-example.html).
+
+To interact with the demo, load the page from your fork in a browser via: 
+
+`file://[Medium Editor Source Root]/demo/button-example.html`
+
+### 1. Define the Extension
+
+As a simple example, let's create a button extension that will highlight the selected text by wrapping the selection in a `<mark>` element.  Whenever the user selects text which is already within a `<mark>` tag, the button should appear as 'active'.  If the text is already wrapped within a `<mark>` element, clicking the 'active' button will 'un-highlight' the text by removing the wrapping `<mark>` tag.
+
+To start, we need to define the new extension and create a button which can appear in the toolbar:
+
+```js
+var HighlighterButton = MediumEditor.Extension.extend({
+  name: 'highlighter'
+});
+```
+
+We now have an extension named `'highlighter'` which we can pass into MediumEditor like this.
+
+```js
+var editor = new MediumEditor('.editable', {
+  toolbar: {
+    buttons: ['bold', 'italic', 'underline', 'highlighter']
+  },
+  extensions: {
+    'highlighter': new HighlighterButton()
+  }
+});
+```
+
+**NOTE:** 
+
+In order for the toolbar to look for a button to add to the toolbar, the name of the extension must be passed in the `toolbar.buttons` array.
+
+***
+### 2. Create and Display a Button
+
+Now that we have a base extension, we need to create an actual button element which can appear in the toolbar.
+
+**CODE:**
+```js
+var HighlighterButton = MediumEditor.Extension.extend({
+  name: 'highlighter',
+
+  init: function () {
+    this.button = this.document.createElement('button');
+    this.button.classList.add('medium-editor-action');
+    this.button.innerHTML = '<b>H</b>';
+  },
+
+  getButton: function () {
+    return this.button;
+  }
+});
+```
+
+**PREVIEW:**
+<p align="center"><img src="http://yabwe.github.io/medium-editor/img/button-example-01.png" /></p>
+
+Here, we're implementing the the `init()` method to create our button, and then implementing the `getButton()` method as an accessor for our created button element.
+
+After all the extensions are created, the toolbar will loop through the list of the `buttons` passed in via the `toolbar.buttons` option.  For each button name in that list, it will retrieve the extension with that name and see if it has implemented a `getButton()` method.  If it has, it will take the element returned by this and append it to the toolbar.
+
+As a result, whenever we run our code and highlight some text, we now have 4 buttons: Bold, Italic, Underline, and our custom Highlighter button.
+
+***
+### 3. Improve Appearance
+
+Since all of MediumEditor's built-in buttons have font-awesome icons, let's enable font-awesome icons and update our button to use a font-awesome icon as well as have a tooltip on hover.
+
+**CODE:**
+```js
+var HighlighterButton = MediumEditor.Extension.extend({
+  name: 'highlighter',
+
+  init: function () {
+    this.button = this.document.createElement('button');
+    this.button.classList.add('medium-editor-action');
+    this.button.innerHTML = '<i class="fa fa-paint-brush"></i>';
+    this.button.title = 'Highlight';
+  },
+
+  getButton: function () {
+    return this.button;
+  }
+});
+
+// Code for initializing MediumEditor
+var editor = new MediumEditor('.editable', {
+  toolbar: {
+    buttons: ['bold', 'italic', 'underline', 'highlighter']
+  },
+  buttonLabels: 'fontawesome', // use font-awesome icons for other buttons
+  extensions: {
+    'highlighter': new HighlighterButton()
+  }
+});
+```
+
+**PREVIEW:**
+<p align="center"><img src="http://yabwe.github.io/medium-editor/img/button-example-02.png" /></p>
+
+To change the apperances, we have:
+
+1. Changed the `innerHTML` of our button to be `<i class="fa fa-paint-brush"></i>` in the `init()` method
+1. Added 'Highlight' as a title attribute to enable the tooltip
+1. Passed the `buttonLabels: 'fontawesome'` option when initializing MediumEditor to enable font-awesome icons for all buttons in the toolbar
+
+***
+### 4. Handle Button Click
+
+Now let's make the button actually do something.  To do this, we'll be using a great open source library called [rangy](https://github.com/timdown/rangy) created by [Tim Down](https://github.com/timdown).  We'll be using the [CSS Class Applier Module](https://github.com/timdown/rangy/wiki/Class-Applier-Module) which allows us to wrap the selection in a specific element type.
+
+**CODE:**
+```js
+rangy.init();
+
+var HighlighterButton = MediumEditor.Extension.extend({
+  name: 'highlighter',
+
+  init: function () {
+    this.classApplier = rangy.createCssClassApplier('highlight', {
+        elementTagName: 'mark',
+        normalize: true
+    });
+    
+    this.button = this.document.createElement('button');
+    this.button.classList.add('medium-editor-action');
+    this.button.innerHTML = '<i class="fa fa-paint-brush"></i>';
+    this.button.title = 'Highlight';
+
+    this.on(this.button, 'click', this.handleClick.bind(this));
+  },
+
+  getButton: function () {
+    return this.button;
+  },
+
+  handleClick: function (event) {
+    this.classApplier.toggleSelection();
+  }
+});
+```
+
+**BEFORE:**
+<p align="center"><img src="http://yabwe.github.io/medium-editor/img/button-example-02.png" /></p>
+
+**AFTER:**
+<p align="center"><img src="http://yabwe.github.io/medium-editor/img/button-example-03.png" /></p>
+
+In order to initialize **rangy**, we've added a call to `rangy.init()` before the definition of our button extension, and we've also created an instance of the **CSS Class Applier** in the `init()` method.  We're creating a **CSS Class Applier** which will create a `<mark>` element with a `'highlight'` class on it.
+
+In addition to initializing **rangy**, we've attached an event listener for the 'click' event of the button via the `this.on()` helper which we get by extending `MediumEditor.Extension`.  Our 'click' handler will then call the `toggleSelection()` method of the **CSS Class Applier**, which will then wrap the selection in a `<mark>` element.
+
+After highlighting the text and clicking the button, the text now appears highlighted (see above).  You can see the resulting HTML below:
+
+**HTML:**
+<p align="center"><img src="http://yabwe.github.io/medium-editor/img/button-example-04.png" /></p>
+
+**NOTE:** 
+
+A great convienience of using the `toggleSelection()` method of the **CSS Class Applier** is that it will also unwrap the selection.  So, since we're always calling `toggleSelection()` when the button is clicked, if you highlight the same text and click the button again, the text will go back to normal and the `<mark>` element will be removed.
+
+***
+### 5. Respond to Selection
+
+The last piece of functionality we want is to have the button's appearance respond to what the user has selected.  We want the button to appear as 'active' if the selection occurs inside of a `<mark>` element, and we want to the button to appear as `inactive` if the selection is outside of a `<mark>` element.
+
+**CODE:**
+```js
+rangy.init();
+
+var HighlighterButton = MediumEditor.Extension.extend({
+  name: 'highlighter',
+
+  init: function () {
+    this.classApplier = rangy.createCssClassApplier('highlight', {
+        elementTagName: 'mark',
+        normalize: true
+    });
+    
+    this.button = this.document.createElement('button');
+    this.button.classList.add('medium-editor-action');
+    this.button.innerHTML = '<i class="fa fa-paint-brush"></i>';
+    this.button.title = 'Highlight';
+
+    this.on(this.button, 'click', this.handleClick.bind(this));
+  },
+
+  getButton: function () {
+    return this.button;
+  },
+
+  handleClick: function (event) {
+    this.classApplier.toggleSelection();
+  },
+
+  isAlreadyApplied: function (node) {
+    return node.nodeName.toLowerCase() === 'mark';
+  },
+
+  isActive: function () {
+    return this.button.classList.contains('medium-editor-button-active');
+  },
+
+  setInactive: function () {
+    this.button.classList.remove('medium-editor-button-active');
+  },
+
+  setActive: function () {
+    this.button.classList.add('medium-editor-button-active');
+  }
+});
+```
+
+**SELECTION IS HIGHLIGHTED:**
+<p align="center"><img src="http://yabwe.github.io/medium-editor/img/button-example-05.png" /></p>
+
+**SELECTION IS NOT HIGHLIGHTED:**
+<p align="center"><img src="http://yabwe.github.io/medium-editor/img/button-example-06.png" /></p>
+
+As shown above, now our button responds to what the user has selected.  To make this final piece work, we've implemented 4 extension methods:
+
+1. **isAlreadyApplied(node)**
+  * This will be called on each element which contains the user's selection, starting with the lowest element and climbing its ancestors.  If any of these elements are a `<mark>` element, we return `true` since that means the selection is higlighted.
+1. **isActive()**
+  * This should return whether the button is already active.  We check this by seeing if the `'medium-editor-button-active'` class already exists on the toolbar button. 
+1. **setActive()**
+  * This is called when we should make our button active (add the '`medium-editor-button-active'` class)
+1. **setInactive()**
+  * This is called when we should make our button inactive (remove the `'medium-editor-button-active'` class)
+
+***
+### 6. Leverage Existing Button Code
+
+Since a lot of the built-in buttons for MediumEditor do very similar things, we can leverage a large portion of the existing button code to help reduce the amount of code we need for our extension.  To take advantage of this, we can extend from the `MediumEditor.extensions.button` extension and re-use much of the functionality.  You can find this code in [`button.js`](button.js).
+
+The result is a HighlighterButton extension which requires significantly less custom code:
+
+```js
+rangy.init();
+
+var HighlighterButton = MediumEditor.extensions.button.extend({
+  name: 'highlighter',
+
+  tagNames: ['mark'], // nodeName which indicates the button should be 'active' when isAlreadyApplied() is called
+  contentDefault: '<b>H</b>', // default innerHTML of the button
+  contentFA: '<i class="fa fa-paint-brush"></i>', // innerHTML of button when 'fontawesome' is being used
+  aria: 'Hightlight', // used as both aria-label and title attributes
+  action: 'highlight', // used as the data-action attribute of the button
+
+  init: function () {
+    MediumEditor.extensions.button.prototype.init.call(this);
+
+    this.classApplier = rangy.createCssClassApplier('highlight', {
+      elementTagName: 'mark',
+      normalize: true
+    });
+  },
+
+  handleClick: function (event) {
+    this.classApplier.toggleSelection();
+  }
+});
+```
+
+The built-in functionality we were able to take advantage of includes:
+
+1. **getButton()**
+  * The default button implementation will ensure the button is created using configurable custom options
+1. **Button element properties**
+  * `contentDefault`: default innerHTML of the button
+  * `contentFA`: innerHTML of the button when 'fontawesome' is being used
+  * `aria`: used as both the aria-label and title attributes of the button
+  * `action`: the value of the `data-action` attribute of the button
+1. **handleClick**
+  * The default button implementation will attach the `handleClick` method as an event listener to the 'click' event of the button.  We've overridden `handleClick()` to do our own custom logic using the **CSS Class Applier**.
+1. **isAlreadyApplied()** and **tagNames**
+  * The default implementation of `isAlreadyApplied()` will use the `tagNames` array of element names to decide whether the button is implemented or not.  If a node with one of these `tagNames` is found, the button will be activated.
+1. **isActive()**, **setActive()**, and **setInactive()**
+  * The default button extension implements each of these methods, using whatever css class is configured as the `activeButtonClass` in MediumEditor (`'medium-editor-button-active'` by default)

--- a/src/js/extensions/WALKTHROUGH-EXTENSION.md
+++ b/src/js/extensions/WALKTHROUGH-EXTENSION.md
@@ -1,0 +1,137 @@
+# Walkthrough - Building an Extension
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [DisableContextMenuExtension](#disablecontextmenuextension)
+  - [1. Define the Extension](#1-define-the-extension)
+  - [2. Attaching To Context Menu Event](#2-attaching-to-context-menu-event)
+  - [3. Adding Functionality](#3-adding-functionality)
+  - [4. Leveraging Custom Event Listeners](#4-leveraging-custom-event-listeners)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## DisableContextMenuExtension
+
+You can find a demo of this example in the source code via [extension-example.html](../../../demo/extension-example.html).
+
+To interact with the demo, load the page from your fork in a browser via: 
+
+`file://[Medium Editor Source Root]/demo/extension-example.html`
+
+### 1. Define the Extension
+
+As a simple example, let's create an extension that disables the context menu from appearing when the user right-clicks on the editor.
+
+Defining this extension is as simple as calling `MediumEditor.Extension.extend()` and passing in the methods/properties we want to override.
+
+```js
+var DisableContextMenuExtension = MediumEditor.Extension.extend({
+  name: 'disable-context-menu'
+});
+```
+
+We now have an extension named `'disable-context-menu'` which we can pass into MediumEditor like this:
+
+```js
+var editor = new MediumEditor('.editable', {
+  extensions: {
+    'disable-context-menu': new DisableContextMenuExtension()
+  }
+});
+```
+
+***
+### 2. Attaching To Context Menu Event
+
+To make the extension actually do something, we'll want to attach to the `contextmenu` event on all **elements** of the editor.  We can set this up by implementing the `init()` method, which is called on every Extension during setup of MediumEditor:
+
+```js
+var DisableContextMenuExtension = MediumEditor.Extension.extend({
+  name: 'disable-context-menu',
+
+  init: function () {
+    this.getEditorElements().forEach(function (element) {
+      this.base.on(element, 'contextmenu', this.handleContextmenu.bind(this));
+    }, this);
+  },
+
+  handleContextmenu: function (event) { }
+});
+```
+
+Here, we're leveraging some of the helpers that are available to all Extensions.
+
+* We're using `this.getEditorElements()`, which is a helper function to give us an array containing all **elements** maintained by this editor.
+* We're using `this.base`, which is a reference to the MediumEditor instance.
+* We're using `this.base.on()`, which is a [method of MediumEditor](../../../API.md#ontarget-event-listener-usecapture) for attaching to DOM Events. Using this method ensures our event handlers will be detached when MediumEditor is destroyed.
+
+**NOTE:**
+
+* There are a few helper methods that allow us to make calls directly into the MediumEditor instance without having to reference `this.base`. One of them is a reference to the `on()` method, so instead of the above code we can just use `this.on(element, 'contextmenu', this.handleContextmenu.bind(this))` which is what we'll use in the rest of the example.
+
+***
+### 3. Adding Functionality
+
+So, the last piece we need is to handle the `contextmenu` event and prevent the default action:
+
+```js
+var DisableContextMenuExtension = MediumEditor.Extension.extend({
+  name: 'disable-context-menu',
+
+  init: function () {
+    this.getEditorElements().forEach(function (element) {
+      this.base.on(element, 'contextmenu', this.handleContextmenu.bind(this));
+    }, this);
+  },
+
+  handleContextmenu: function (event) {
+    event.preventDefault();
+  }
+});
+```
+
+Now we have a working extension which prevents the context menu from showing up for any of the **elements**.  Let's add some more functionality to allow for toggling this feature on and off.
+
+***
+### 4. Leveraging Custom Event Listeners
+
+Let's say we wanted to support toggling on/off the disable-context-menu extension, for a specific **element**, whenever the user presses ESCAPE.  To do this, we'll need to add 2 pieces of functionality:
+
+1. Listen to the `keydown` event on each **element**. For this, we can leverage the built-in [`editableKeyDown` custom event](../../../CUSTOM-EVENTS.md#editablekeydown).  This allows us to use the 2nd argument of custom event listeners (the active editor **element**) to toggle on/off a `data-allow-context-menu` attribute on the **element**.
+
+2. When the `contextmenu` event fires, we only want to prevent the context menu from appearing if the `data-allow-context-menu` attribute is not present.
+
+```js
+var DisableContextMenuExtension = MediumEditor.Extension.extend({
+  name: 'disable-context-menu',
+
+  init: function () {
+    this.getEditorElements().forEach(function (element) {
+      this.on(element, 'contextmenu', this.handleContextmenu.bind(this));
+    }, this);
+    this.subscribe('editableKeydown', this.handleKeydown.bind(this));
+  },
+
+  handleContextmenu: function (event) {
+    if (!event.currentTarget.getAttribute('data-allow-context-menu')) {
+      event.preventDefault();
+    }
+  },
+
+  handleKeydown: function (event, editable) {
+    // If the user hits escape, toggle the data-allow-context-menu attribute
+    if (MediumEditor.util.isKey(event, MediumEditor.util.keyCode.ESCAPE)) {
+      if (editable.hasAttribute('data-allow-context-menu')) {
+        editable.removeAttribute('data-allow-context-menu');
+      } else {
+        editable.setAttribute('data-allow-context-menu', true);
+      }
+    }
+  }
+});
+```
+
+**NOTE:**
+
+For events like `keydown`, we could always use `currentTarget` and not need to use the reference to the editable element (like how we use the `currentTarget` when handling the `contextmenu` event).  However, there may be times when we want to trigger one of these events manually, and this allows us to specify exactly which editable element we want to trigger the event for.  It's also a handy standardization for events which are more complicated, like the custom `focus` and `blur` events.


### PR DESCRIPTION
This PR moves the documentation we have in the Wiki into the source code via markdown files.

This keeps the documentation as close to the code as possible, and allows everyone to search through both documentation and code at the same time to find things that are incorrect or need to be updated.

If we go with this route, I'll change the wiki pages to just link to these documents within the repo.