### PR TITLE
Fix for custom extension not suppressing built in anchor preview

### DIFF
--- a/spec/anchor-preview.spec.js
+++ b/spec/anchor-preview.spec.js
@@ -208,16 +208,13 @@ describe('Anchor Preview TestCase', function () {
         });
 
         it('should NOT be in the DOM when a custom anchorPreview extension is provided', function () {
-            var editor = this.newMediumEditor('.editor', {
+            this.newMediumEditor('.editor', {
                 extensions: {
                     'anchor-preview': {}
                 }
             });
 
             expect(document.querySelector('.medium-editor-anchor-preview')).toBeNull();
-
-            // destroy
-            editor.destroy();
         });
     });
 

--- a/spec/anchor-preview.spec.js
+++ b/spec/anchor-preview.spec.js
@@ -206,6 +206,19 @@ describe('Anchor Preview TestCase', function () {
             expect(document.querySelector('.medium-editor-anchor-preview-active')).toBeNull();
             expect(document.querySelector('.medium-editor-anchor-preview')).toBeNull();
         });
+
+        it('should NOT be in the DOM when a custom anchorPreview extension is provided', function () {
+            var editor = this.newMediumEditor('.editor', {
+                extensions: {
+                    'anchor-preview': {}
+                }
+            });
+
+            expect(document.querySelector('.medium-editor-anchor-preview')).toBeNull();
+
+            // destroy
+            editor.destroy();
+        });
     });
 
 });

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -418,7 +418,7 @@ function MediumEditor(elements, options) {
         // Built-in extensions
         var builtIns = {
             paste: true,
-            anchorPreview: isAnchorPreviewEnabled.call(this),
+            'anchor-preview': isAnchorPreviewEnabled.call(this),
             autoLink: isAutoLinkEnabled.call(this),
             keyboardCommands: isKeyboardCommandsEnabled.call(this),
             placeholder: isPlaceholderEnabled.call(this)
@@ -710,7 +710,7 @@ function MediumEditor(elements, options) {
                     merged = Util.extend({}, this.options.anchor, opts);
                     extension = new MediumEditor.extensions.anchor(merged);
                     break;
-                case 'anchorPreview':
+                case 'anchor-preview':
                     extension = new MediumEditor.extensions.anchorPreview(this.options.anchorPreview);
                     break;
                 case 'autoLink':


### PR DESCRIPTION
We realized in our application that our custom extension was not suppressing the built in anchor preview so we were seeing unstyled, extra and unwanted preview nodes in our application. The unit test should exercise this bug and the couple of lines changes are all that should be needed to fix it, without introducing any breakage for existing users of the built-in.