### PR TITLE
Cleanup only pasted elements

### DIFF
--- a/src/js/extensions/paste.js
+++ b/src/js/extensions/paste.js
@@ -1,4 +1,4 @@
-/*global Util, Selection, Extension */
+/*global Util, Extension */
 var PasteHandler;
 
 (function () {
@@ -138,8 +138,7 @@ var PasteHandler;
         },
 
         cleanPaste: function (text) {
-            var i, elList, workEl,
-                el = Selection.getSelectionElement(this.window),
+            var i, elList,
                 multiline = /<p|<br|<div/.test(text),
                 replacements = createReplacements().concat(this.cleanReplacements || []);
 
@@ -155,31 +154,6 @@ var PasteHandler;
             elList = text.split('<br><br>');
 
             this.pasteHTML('<p>' + elList.join('</p><p>') + '</p>');
-
-            try {
-                this.document.execCommand('insertText', false, '\n');
-            } catch (ignore) { }
-
-            // block element cleanup
-            elList = el.querySelectorAll('a,p,div,br');
-            for (i = 0; i < elList.length; i += 1) {
-                workEl = elList[i];
-
-                // Microsoft Word replaces some spaces with newlines.
-                // While newlines between block elements are meaningless, newlines within
-                // elements are sometimes actually spaces.
-                workEl.innerHTML = workEl.innerHTML.replace(/\n/gi, ' ');
-
-                switch (workEl.nodeName.toLowerCase()) {
-                    case 'p':
-                    case 'div':
-                        this.filterCommonBlocks(workEl);
-                        break;
-                    case 'br':
-                        this.filterLineBreak(workEl);
-                        break;
-                }
-            }
         },
 
         pasteHTML: function (html, options) {
@@ -198,7 +172,6 @@ var PasteHandler;
             this.cleanupSpans(fragmentBody);
 
             elList = fragmentBody.querySelectorAll('*');
-
             for (i = 0; i < elList.length; i += 1) {
                 workEl = elList[i];
 
@@ -208,6 +181,27 @@ var PasteHandler;
 
                 Util.cleanupAttrs(workEl, options.cleanAttrs);
                 Util.cleanupTags(workEl, options.cleanTags);
+            }
+
+            // block element cleanup
+            elList = fragmentBody.querySelectorAll('a,p,div,br');
+            for (i = 0; i < elList.length; i += 1) {
+                workEl = elList[i];
+
+                // Microsoft Word replaces some spaces with newlines.
+                // While newlines between block elements are meaningless, newlines within
+                // elements are sometimes actually spaces.
+                workEl.innerHTML = workEl.innerHTML.replace(/\n/gi, ' ');
+
+                switch (workEl.nodeName.toLowerCase()) {
+                    case 'p':
+                    case 'div':
+                        this.filterCommonBlocks(workEl);
+                        break;
+                    case 'br':
+                        this.filterLineBreak(workEl);
+                        break;
+                }
             }
 
             Util.insertHTMLCommand(this.document, fragmentBody.innerHTML.replace(/&nbsp;/g, ' '));


### PR DESCRIPTION
When you use `cleanPaste` with a multiline pasted text it will do some custom stuff related to paragraph.

But it will also cleanup *block elements*. The problem is that it cleans block element of the WHOLE content (if you do not have a selection, the selected element will be the editor), not only the pasted one. So I moved the code that performs this cleanup inside `pasteHTML` where I have a node so I can cleanup ONLY the pasted content.

Problem appear when using external library that update MediumEditor content adding custom html, like medium-editor-insert-plugin. It adds div, figure, etc .. so if the pasted content was multiline, the cleanup will remove all this tags (according to my `cleanTag` attributes).

Also, we previously added a new line after pasted content. Why ? I think when user paste content it doesn't want a new paragraph to be created right after the pasted content.

*PS: don't take a closer look at the branch name, I was fixing the wrong issue at first :)*