### PR TITLE
Ensure anchor target + class checkboxes are initialized correctly

### DIFF
--- a/spec/anchor-preview.spec.js
+++ b/spec/anchor-preview.spec.js
@@ -14,7 +14,9 @@ describe('Anchor Preview TestCase', function () {
             '<a id="test-empty-link" href="">ipsum</a> ' +
             '<a id="test-link-disable-preview" data-disable-preview="true" href="http://test.com">ipsum</a> ' +
             '<a id="test-markup-link" href="http://test.com"><b>ipsum</b></a> ' +
-            '<a id="test-symbol-link" href="http://[{~#custom#~}].com"></a>');
+            '<a id="test-symbol-link" href="http://[{~#custom#~}].com"></a> ' +
+            '<a id="text-target-blank-link" target="_blank" href="http://test.com">ipsum</a> ' +
+            '<a id="text-custom-class-link" class="custom-class" href="http://test.com">ipsum</a>');
     });
 
     afterEach(function () {
@@ -116,7 +118,14 @@ describe('Anchor Preview TestCase', function () {
         });
 
         it('should display the anchor form in the toolbar when clicked', function () {
-            var editor = this.newMediumEditor('.editor'),
+            var editor = this.newMediumEditor('.editor', {
+                    anchor: {
+                        targetCheckbox: true,
+                        targetCheckboxText: 'Open in new window',
+                        customClassOption: 'custom-class',
+                        customClassOptionText: 'Custom Class'
+                    }
+                }),
                 anchorPreview = editor.getExtensionByName('anchor-preview'),
                 anchor = editor.getExtensionByName('anchor'),
                 toolbar = editor.getExtensionByName('toolbar');
@@ -131,6 +140,68 @@ describe('Anchor Preview TestCase', function () {
 
             expect(toolbar.isDisplayed()).toBe(true);
             expect(anchor.isDisplayed()).toBe(true);
+
+            // the checkboxes should be unchecked
+            expect(anchor.getAnchorTargetCheckbox().checked).toBe(false);
+            expect(anchor.getAnchorButtonCheckbox().checked).toBe(false);
+        });
+
+        it('should display the anchor form with target checkbox checked in the toolbar when clicked', function () {
+            var editor = this.newMediumEditor('.editor', {
+                    anchor: {
+                        targetCheckbox: true,
+                        targetCheckboxText: 'Open in new window',
+                        customClassOption: 'custom-class',
+                        customClassOptionText: 'Custom Class'
+                    }
+                }),
+                anchorPreview = editor.getExtensionByName('anchor-preview'),
+                anchor = editor.getExtensionByName('anchor'),
+                toolbar = editor.getExtensionByName('toolbar');
+
+            // show preview
+            fireEvent(document.getElementById('text-target-blank-link'), 'mouseover');
+
+            // load into editor
+            jasmine.clock().tick(1);
+            fireEvent(anchorPreview.getPreviewElement(), 'click');
+            jasmine.clock().tick(200);
+
+            expect(toolbar.isDisplayed()).toBe(true);
+            expect(anchor.isDisplayed()).toBe(true);
+
+            // the checkboxes should be unchecked
+            expect(anchor.getAnchorTargetCheckbox().checked).toBe(true);
+            expect(anchor.getAnchorButtonCheckbox().checked).toBe(false);
+        });
+
+        it('should display the anchor form with custom class checkbox checked in the toolbar when clicked', function () {
+            var editor = this.newMediumEditor('.editor', {
+                    anchor: {
+                        targetCheckbox: true,
+                        targetCheckboxText: 'Open in new window',
+                        customClassOption: 'custom-class',
+                        customClassOptionText: 'Custom Class'
+                    }
+                }),
+                anchorPreview = editor.getExtensionByName('anchor-preview'),
+                anchor = editor.getExtensionByName('anchor'),
+                toolbar = editor.getExtensionByName('toolbar');
+
+            // show preview
+            fireEvent(document.getElementById('text-custom-class-link'), 'mouseover');
+
+            // load into editor
+            jasmine.clock().tick(1);
+            fireEvent(anchorPreview.getPreviewElement(), 'click');
+            jasmine.clock().tick(200);
+
+            expect(toolbar.isDisplayed()).toBe(true);
+            expect(anchor.isDisplayed()).toBe(true);
+
+            // the checkboxes should be unchecked
+            expect(anchor.getAnchorTargetCheckbox().checked).toBe(false);
+            expect(anchor.getAnchorButtonCheckbox().checked).toBe(true);
         });
 
         it('should NOT be displayed when the hovered link is empty', function () {

--- a/src/js/extensions/anchor-preview.js
+++ b/src/js/extensions/anchor-preview.js
@@ -134,7 +134,12 @@ var AnchorPreview;
                 // We may actually be displaying the anchor form, which should be controlled by delay
                 this.base.delay(function () {
                     if (activeAnchor) {
-                        anchorExtension.showForm(activeAnchor.attributes.href.value);
+                        var opts = {
+                            url: activeAnchor.attributes.href.value,
+                            target: activeAnchor.getAttribute('target'),
+                            buttonClass: activeAnchor.getAttribute('class')
+                        };
+                        anchorExtension.showForm(opts);
                         activeAnchor = null;
                     }
                 }.bind(this));

--- a/src/js/extensions/anchor.js
+++ b/src/js/extensions/anchor.js
@@ -147,16 +147,40 @@ var AnchorForm;
             this.getInput().value = '';
         },
 
-        showForm: function (linkValue) {
-            var input = this.getInput();
+        showForm: function (opts) {
+            var input = this.getInput(),
+                targetCheckbox = this.getAnchorTargetCheckbox(),
+                buttonCheckbox = this.getAnchorButtonCheckbox();
+
+            opts = opts || { url: '' };
+            // TODO: This is for backwards compatability
+            // We don't need to support the 'string' argument in 6.0.0
+            if (typeof opts === 'string') {
+                opts = {
+                    url: opts
+                };
+            }
 
             this.base.saveSelection();
             this.hideToolbarDefaultActions();
             this.getForm().style.display = 'block';
             this.setToolbarPosition();
 
-            input.value = linkValue || '';
+            input.value = opts.url;
             input.focus();
+
+            // If we have a target checkbox, we want it to be checked/unchecked
+            // based on whether the existing link has target=_blank
+            if (targetCheckbox) {
+                targetCheckbox.checked = opts.target === '_blank';
+            }
+
+            // If we have a custom class checkbox, we want it to be checked/unchecked
+            // based on whether an existing link already has the class
+            if (buttonCheckbox) {
+                var classList = opts.buttonClass ? opts.buttonClass.split(' ') : [];
+                buttonCheckbox.checked = (classList.indexOf(this.customClassOption) !== -1);
+            }
         },
 
         // Called by core when tearing down medium-editor (destroy)
@@ -176,8 +200,8 @@ var AnchorForm;
 
         getFormOpts: function () {
             // no notion of private functions? wanted `_getFormOpts`
-            var targetCheckbox = this.getForm().querySelector('.medium-editor-toolbar-anchor-target'),
-                buttonCheckbox = this.getForm().querySelector('.medium-editor-toolbar-anchor-button'),
+            var targetCheckbox = this.getAnchorTargetCheckbox(),
+                buttonCheckbox = this.getAnchorButtonCheckbox(),
                 opts = {
                     url: this.getInput().value
                 };
@@ -254,6 +278,14 @@ var AnchorForm;
 
         getInput: function () {
             return this.getForm().querySelector('input.medium-editor-toolbar-input');
+        },
+
+        getAnchorTargetCheckbox: function () {
+            return this.getForm().querySelector('.medium-editor-toolbar-anchor-target');
+        },
+
+        getAnchorButtonCheckbox: function () {
+            return this.getForm().querySelector('.medium-editor-toolbar-anchor-button');
         },
 
         handleTextboxKeyup: function (event) {


### PR DESCRIPTION
This addreses some of the issues discovered in #738 

Currently, when using MediumEditor's anchor button with the `targetCheckbox` and/or `customClassOption` options enabled, the checkboxes will be displayed inside the anchor form whenever creating a link.

However, if the user checks either of these checkboxes, the next link they create will still have the checkboxes checked by default (since the checkboxes are not cleared when displaying the anchor form).

This PR fixes 2 issues:

1. The state of the checkboxes will be cleared each time the anchor form is displayed.  This way, the checkboxes will always be 'unchecked' when creating a new link.
2. When editing an existing link (via clicking the anchor-preview popover), the checkboxes will be checked/unchecked based on whether the link being edited has `target=_blank` and/or has the custom button class already on it.