### PR TITLE
Fix #751 - issue with finding anchor when clicking anchor button

### DIFF
--- a/src/js/extensions/anchor.js
+++ b/src/js/extensions/anchor.js
@@ -60,17 +60,11 @@ var AnchorForm;
             event.preventDefault();
             event.stopPropagation();
 
-            var linkSelected = false,
-                range = Selection.getSelectionRange(this.document);
+            var range = Selection.getSelectionRange(this.document);
 
             if (range.startContainer.nodeName.toLowerCase() === 'a' ||
-                range.endContainer.nodeName.toLowerCase() === 'a') {
-                linkSelected = true;
-            } else if (Util.getClosestTag(Selection.getSelectedParentElement(range), 'a')) {
-                linkSelected = true;
-            }
-
-            if (linkSelected) {
+                range.endContainer.nodeName.toLowerCase() === 'a' ||
+                Util.getClosestTag(Selection.getSelectedParentElement(range), 'a')) {
                 return this.execAction('unlink');
             }
 

--- a/src/js/extensions/anchor.js
+++ b/src/js/extensions/anchor.js
@@ -60,10 +60,9 @@ var AnchorForm;
             event.preventDefault();
             event.stopPropagation();
 
-            var selectedParentElement = Selection.getSelectedParentElement(Selection.getSelectionRange(this.document)),
-                firstTextNode = Util.getFirstTextNode(selectedParentElement);
+            var selectedParentElement = Selection.getSelectedParentElement(Selection.getSelectionRange(this.document));
 
-            if (Util.getClosestTag(firstTextNode, 'a')) {
+            if (Util.getClosestTag(selectedParentElement, 'a')) {
                 return this.execAction('unlink');
             }
 

--- a/src/js/extensions/anchor.js
+++ b/src/js/extensions/anchor.js
@@ -60,9 +60,17 @@ var AnchorForm;
             event.preventDefault();
             event.stopPropagation();
 
-            var selectedParentElement = Selection.getSelectedParentElement(Selection.getSelectionRange(this.document));
+            var linkSelected = false,
+                range = Selection.getSelectionRange(this.document);
 
-            if (Util.getClosestTag(selectedParentElement, 'a')) {
+            if (range.startContainer.nodeName.toLowerCase() === 'a' ||
+                range.endContainer.nodeName.toLowerCase() === 'a') {
+                linkSelected = true;
+            } else if (Util.getClosestTag(Selection.getSelectedParentElement(range), 'a')) {
+                linkSelected = true;
+            }
+
+            if (linkSelected) {
                 return this.execAction('unlink');
             }
 


### PR DESCRIPTION
This fixes #751 

When the user clicks the 'anchor' button, we attempt to find an existing anchor within the selection.  If there is one, we 'unlink' that anchor, otherwise we display the anchor form an allow them to create a link.

There was a bug in the code that tries to find the existing link.  It was incorrectly looking for the first text node within the parent selection node, which manifested itself as being unable to create a link when a link appeared as a previousSibling of a text node which was being selected.