### PR TITLE
Fix for #738 issue with importSelection after empty paragraphs

### DIFF
--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -68,6 +68,24 @@ describe('Selection TestCase', function () {
             expect(node.getAttribute('id')).toBe('1');
         });
 
+        it('should import an exported non-collapsed selection after an empty paragraph', function () {
+            this.el.innerHTML = '<p>This is <a href="#">a link</a></p><p><br/></p><p>not a link</p>';
+            var editor = this.newMediumEditor('.editor'),
+                lastTextNode = this.el.childNodes[2].firstChild;
+
+            MediumEditor.selection.select(document, lastTextNode, 0, lastTextNode, 'not a link'.length);
+
+            var exportedSelection = editor.exportSelection();
+            expect(exportedSelection).toEqual({ start: 14, end: 24, emptyBlocksIndex: 2 });
+            editor.importSelection(exportedSelection);
+
+            var range = window.getSelection().getRangeAt(0);
+            expect(range.startContainer).toBe(lastTextNode);
+            expect(range.startOffset).toBe(0, 'The start of the selection is not at the beginning of the text node');
+            expect(range.endContainer).toBe(lastTextNode);
+            expect(range.endOffset).toBe('not a link'.length, 'The end of the selection is not at the end of the text node');
+        });
+
         it('should have an index in the exported selection when it is in the second contenteditable', function () {
             this.createElement('div', 'editor', 'lorem <i>ipsum</i> dolor');
             var editor = this.newMediumEditor('.editor', {

--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -68,6 +68,7 @@ describe('Selection TestCase', function () {
             expect(node.getAttribute('id')).toBe('1');
         });
 
+        // https://github.com/yabwe/medium-editor/issues/738
         it('should import an exported non-collapsed selection after an empty paragraph', function () {
             this.el.innerHTML = '<p>This is <a href="#">a link</a></p><p><br/></p><p>not a link</p>';
             var editor = this.newMediumEditor('.editor'),
@@ -80,9 +81,11 @@ describe('Selection TestCase', function () {
             editor.importSelection(exportedSelection);
 
             var range = window.getSelection().getRangeAt(0);
-            expect(range.startContainer).toBe(lastTextNode);
+            expect(range.startContainer === lastTextNode || range.startContainer === lastTextNode.parentNode)
+                .toBe(true, 'The selection is starting at the wrong element');
             expect(range.startOffset).toBe(0, 'The start of the selection is not at the beginning of the text node');
-            expect(range.endContainer).toBe(lastTextNode);
+            expect(range.endContainer === lastTextNode || range.endContainer === lastTextNode.parentNode)
+                .toBe(true, 'The selection is ending at the wrong element');
             expect(range.endOffset).toBe('not a link'.length, 'The end of the selection is not at the end of the text node');
         });
 

--- a/src/js/selection.js
+++ b/src/js/selection.js
@@ -135,7 +135,6 @@ var Selection;
                 // We're selecting a high-level block node, so make sure the cursor gets moved into the deepest
                 // element at the beginning of the block
                 range.setStart(Util.getFirstSelectableLeafNode(targetNode), 0);
-                range.collapse(true);
             }
 
             // If the selection is right at the ending edge of a link, put it outside the anchor tag instead of inside.
@@ -175,7 +174,6 @@ var Selection;
                         }
                     }
                     range.setStart(currentNode.parentNode, currentNodeIndex + 1);
-                    range.collapse(true);
                 }
             }
             return range;


### PR DESCRIPTION
There is logic which handles the case where we import/export the current selection, but the selection occurs after 1 or more empty paragraphs.  We determine where to position the cursor by tracking how many empty paragraphs there are between the last piece of text, and where the selection begins.

However, this logic was assuming that in the case where we need to import the selection, the selection is always collapsed (just a cursor).  Because of this, we were unable to import/export selections correctly at the beginning of paragraphs.  

This also manifested itself such that we were unable to create links at the beginning of paragraphs (ie #738).

This PR removes the code which collapsed the selection when importing selections that occur after empty paragraphs.