### PR TITLE
Fix for #754, issue with replacing the anchor that already has one

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -906,6 +906,7 @@ function MediumEditor(elements, options) {
                 i;
 
             if (opts.url && opts.url.trim().length > 0) {
+	            this.execAction('unlink');
                 var currentSelection = this.options.contentWindow.getSelection();
                 if (currentSelection) {
                     var exportedSelection,

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -906,7 +906,7 @@ function MediumEditor(elements, options) {
                 i;
 
             if (opts.url && opts.url.trim().length > 0) {
-	            this.execAction('unlink');
+                this.execAction('unlink');
                 var currentSelection = this.options.contentWindow.getSelection();
                 if (currentSelection) {
                     var exportedSelection,


### PR DESCRIPTION
If we unlink the anchor before adding a new one, it works as intended.