### PR TITLE
Recreate all attributes when using textarea

### DIFF
--- a/spec/textarea.spec.js
+++ b/spec/textarea.spec.js
@@ -15,6 +15,7 @@ describe('Textarea TestCase', function () {
         this.el.setAttribute('data-disable-double-return', false);
         this.el.setAttribute('data-disable-preview', false);
         this.el.setAttribute('spellcheck', true);
+        this.el.setAttribute('data-imhere', 'ohyeah');
         document.body.appendChild(this.el);
     });
 
@@ -23,19 +24,22 @@ describe('Textarea TestCase', function () {
         this.cleanupTest();
     });
 
-    it('should accept a textarea element and "convert" it to a div, preserving important attributes', function () {
+    it('should accept a textarea element and "convert" it to a div, preserving all attributes', function () {
         var editor = this.newMediumEditor('.editor'),
             textarea = this.el;
         expect(editor.elements[0].nodeName.toLowerCase()).toBe('div');
 
-        var attributesToPreserve = ['data-disable-editing',
+        var attributes = [
+            'data-disable-editing',
             'data-disable-toolbar',
             'data-placeholder',
             'data-disable-return',
             'data-disable-double-return',
             'data-disable-preview',
-            'spellcheck'];
-        attributesToPreserve.forEach(function (attr) {
+            'spellcheck',
+            'data-imhere'
+        ];
+        attributes.forEach(function (attr) {
             expect(editor.elements[0].getAttribute(attr)).toBe(textarea.getAttribute(attr));
         });
     });

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -293,28 +293,23 @@ function MediumEditor(elements, options) {
     function createContentEditable(textarea, id) {
         var div = this.options.ownerDocument.createElement('div'),
             uniqueId = 'medium-editor-' + Date.now() + '-' + id,
-            attributesToClone = [
-                'data-disable-editing',
-                'data-disable-toolbar',
-                'data-placeholder',
-                'data-disable-return',
-                'data-disable-double-return',
-                'data-disable-preview',
-                'spellcheck'
-            ];
+            atts = textarea.attributes;
 
         div.className = textarea.className;
         div.id = uniqueId;
         div.innerHTML = textarea.value;
-        div.setAttribute('medium-editor-textarea-id', id);
-        attributesToClone.forEach(function (attr) {
-            if (textarea.hasAttribute(attr)) {
-                div.setAttribute(attr, textarea.getAttribute(attr));
+
+        textarea.setAttribute('medium-editor-textarea-id', id);
+
+        // re-create all attributes from the textearea to the new created div
+        for (var i = 0, n = atts.length; i < n; i++) {
+            // do not re-create existing attributes
+            if (!div.hasAttribute(atts[i].nodeName)) {
+                div.setAttribute(atts[i].nodeName, atts[i].nodeValue);
             }
-        });
+        }
 
         textarea.classList.add('medium-editor-hidden');
-        textarea.setAttribute('medium-editor-textarea-id', id);
         textarea.parentNode.insertBefore(
             div,
             textarea


### PR DESCRIPTION
This should fix #711

All attributes from the textarea are now re-created when the medium-editor is created, except attributes that are already attached to the div. Should I remove this condition?

Should we enable that using an option or by default it's fine?