### PR TITLE
Fix #757, issue where selection restored too large

### DIFF
--- a/spec/anchor.spec.js
+++ b/spec/anchor.spec.js
@@ -262,6 +262,40 @@ describe('Anchor Button TestCase', function () {
             expect(link.classList.contains('btn')).toBe(true);
             expect(link.classList.contains('btn-default')).toBe(true);
         });
+
+        it('should not select empty paragraphs when link is created at beginning of paragraph', function () {
+            spyOn(MediumEditor.prototype, 'createLink').and.callThrough();
+            this.el.innerHTML = '<p>Some text</p><p><br/></p><p><br/></p><p>link text more text</p>';
+            var editor = this.newMediumEditor('.editor'),
+                lastP = this.el.lastChild,
+                anchorExtension = editor.getExtensionByName('anchor'),
+                toolbar = editor.getExtensionByName('toolbar');
+
+            // Select the text 'link text' in the last paragraph
+            MediumEditor.selection.select(document, lastP.firstChild, 0, lastP.firstChild, 'link text'.length);
+            fireEvent(editor.elements[0], 'focus');
+            jasmine.clock().tick(1);
+
+            // Click the 'anchor' button in the toolbar
+            fireEvent(toolbar.getToolbarElement().querySelector('[data-action="createLink"]'), 'click');
+
+            // Input a url and save
+            var input = anchorExtension.getInput();
+            input.value = 'http://www.example.com';
+            fireEvent(input, 'keyup', {
+                keyCode: Util.keyCode.ENTER
+            });
+
+            expect(editor.createLink).toHaveBeenCalledWith({
+                url: 'http://www.example.com',
+                target: '_self'
+            });
+
+            // Make sure selection is only the link
+            var range = window.getSelection().getRangeAt(0);
+            expect(MediumEditor.util.isDescendant(lastP, range.startContainer, true)).toBe(true, 'The start of the selection is incorrect');
+            expect(MediumEditor.util.isDescendant(lastP, range.endContainer, true)).toBe(true, 'The end of the selection is incorrect');
+        });
     });
 
     describe('Cancel', function () {

--- a/src/js/selection.js
+++ b/src/js/selection.js
@@ -119,7 +119,7 @@ var Selection;
                 }
             }
 
-            if (selectionState.emptyBlocksIndex && selectionState.end === nextCharIndex) {
+            if (selectionState.emptyBlocksIndex) {
                 var targetNode = Util.getTopBlockContainer(range.startContainer),
                     index = 0;
                 // Skip over empty blocks until we hit the block we want the selection to be in
@@ -174,6 +174,7 @@ var Selection;
                         }
                     }
                     range.setStart(currentNode.parentNode, currentNodeIndex + 1);
+                    range.collapse(true);
                 }
             }
             return range;


### PR DESCRIPTION
Fix issue #757 where the selection import would ignore the embedded
information about empty paragraphs before it and would import a
selection as multiline that should have been contained at the beginning
of a paragraph.

Also restore a `range.collapse(true)` that was used for an MSIE-specific
fix unrelated to restoring these types of selections.