### PR TITLE
Fix anchor + selection inconsitencies in IE

### DIFF
--- a/spec/placeholder.spec.js
+++ b/spec/placeholder.spec.js
@@ -111,7 +111,7 @@ describe('Placeholder TestCase', function () {
             // In firefox, getComputedStyle().getPropertyValue('content') can return attr() instead of what attr() evaluates to
             expect(match[1]).toBe('data-placeholder');
         } else {
-            expect(placeholder).toBe('\'' + expectedValue + '\'');
+            expect(placeholder).toMatch(new RegExp('^[\'"]' + expectedValue + '[\'"]$'));
         }
     }
     /*jslint regexp: false*/

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -330,13 +330,13 @@ var Util;
                 } catch (ignore) {}
             }
 
-            selection = doc.defaultView.getSelection();
-            if (selection.getRangeAt && selection.rangeCount) {
+            selection = doc.getSelection();
+            if (selection.rangeCount) {
                 range = selection.getRangeAt(0);
                 toReplace = range.commonAncestorContainer;
                 // Ensure range covers maximum amount of nodes as possible
                 // By moving up the DOM and selecting ancestors whose only child is the range
-                if ((toReplace.nodeType === 3 && toReplace.nodeValue === range.toString()) ||
+                if ((toReplace.nodeType === 3 && range.startOffset === 0 && range.endOffset === toReplace.nodeValue.length) ||
                         (toReplace.nodeType !== 3 && toReplace.innerHTML === range.toString())) {
                     while (toReplace.parentNode &&
                             toReplace.parentNode.childNodes.length === 1 &&


### PR DESCRIPTION
This PR fixes some issue with inserting links and helps work around some existing issues with selection in Internet Explorer.  It also fixes a seemingly random test failure that started occurring in Chrome on Windows.

1. Fix the current test failure happening in MSIE in MediumEditor version 5.5.3.
2. Whenever attempting to create a link within a single text node, just fall back to the browser's default `document.execCommand('createLink', ...)`.
  * This fixes an issue where the top-level `<p>` tag was getting removed in MSIE when a link was created inside that `<p>` who only had a single text-node
  * When selection starts at the beginning of a text-node, MSIE still says the `range.startContainer` is a parent of the text-node, and thus the `commonAncestorContainer` is also a parent of the text-node.  A workaround for this needed to be added for detecting when selection starts and ends within a single text-node.
3. Fix an issue for the custom `insertHTML` command we have for MSIE & Firefox, where it was incorrectly moving up the DOM to find the top-level element to replace when inserting HTML.
4. For the placeholder test case, for some reason Chrome in Windows started expecting the value of the placeholder to be wrapped in double quotes (`"`) instead of a single quote (`'`).  I've updated the test case to use a regular expression to handle this new case.