### PR TITLE
Cleanup comment created by Chrome

### DIFF
--- a/src/js/extensions/paste.js
+++ b/src/js/extensions/paste.js
@@ -12,7 +12,6 @@ var PasteHandler;
     */
     function createReplacements() {
         return [
-
             // replace two bogus tags that begin pastes from google docs
             [new RegExp(/<[^>]*docs-internal-guid[^>]*>/gi), ''],
             [new RegExp(/<\/b>(<br[^>]*>)?$/gi), ''],
@@ -42,7 +41,11 @@ var PasteHandler;
             [new RegExp(/\n+<p/gi), '<p'],
 
             // Microsoft Word makes these odd tags, like <o:p></o:p>
-            [new RegExp(/<\/?o:[a-z]*>/gi), '']
+            [new RegExp(/<\/?o:[a-z]*>/gi), ''],
+
+            // cleanup comments added by Chrome when pasting html
+            ['<!--EndFragment-->', ''],
+            ['<!--StartFragment-->', '']
         ];
     }
     /*jslint regexp: false*/

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -324,11 +324,6 @@ var Util;
         insertHTMLCommand: function (doc, html) {
             var selection, range, el, fragment, node, lastNode, toReplace;
 
-            // cleanup fragment comment created by Chrome
-            html = html
-                .replace('<!--EndFragment-->', '')
-                .replace('<!--StartFragment-->', '');
-
             if (doc.queryCommandSupported('insertHTML')) {
                 try {
                     return doc.execCommand('insertHTML', false, html);

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -324,6 +324,11 @@ var Util;
         insertHTMLCommand: function (doc, html) {
             var selection, range, el, fragment, node, lastNode, toReplace;
 
+            // cleanup fragment comment created by Chrome
+            html = html
+                .replace('<!--EndFragment-->', '')
+                .replace('<!--StartFragment-->', '');
+
             if (doc.queryCommandSupported('insertHTML')) {
                 try {
                     return doc.execCommand('insertHTML', false, html);


### PR DESCRIPTION
Chrome add comments when you paste content with html enabled.

It's not really a problem if you paste your content once. But if you past it twice, everything after the pasted content will be removed. I guess Chrome find its _fragment_ comments again and erase them ...

Here is a more revelant gif of the problem:

![medium-photo-firefox](https://cloud.githubusercontent.com/assets/62333/9091633/92ccfa96-3ba1-11e5-9b9c-57f2e6e7d0af.gif)

Should I add some tests specific to Chrome?