### PR TITLE
Fix #757 Track beginning of paragraph in exportSelection

### DIFF
--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -113,6 +113,16 @@ describe('Selection TestCase', function () {
             expect(exportedSelection.emptyBlocksIndex).toEqual(undefined);
         });
 
+        it('should export a position indicating the cursor is at the beginning of a paragraph', function () {
+            this.el.innerHTML = '<p><span>www.google.com</span></p><p><b>Whatever</b></p>';
+            var editor = this.newMediumEditor('.editor', {
+                buttons: ['italic', 'underline', 'strikethrough']
+            });
+            placeCursorInsideElement(editor.elements[0].querySelector('b'), 0); // beginning of <b> tag
+            var exportedSelection = editor.exportSelection();
+            expect(exportedSelection.emptyBlocksIndex).toEqual(0);
+        });
+
         it('should not export a position indicating the cursor is after an empty paragraph', function () {
             this.el.innerHTML = '<p><span>www.google.com</span></p><p><br /></p>' +
                 '<p class="target">Whatever</p>';

--- a/src/js/selection.js
+++ b/src/js/selection.js
@@ -180,9 +180,11 @@ var Selection;
             return range;
         },
 
-        // Returns 0 unless the cursor is within or preceded by empty paragraphs/blocks,
-        // in which case it returns the count of such preceding paragraphs, including
-        // the empty paragraph in which the cursor itself may be embedded.
+        // Returns -1 unless the cursor is at the beginning of a paragraph/block
+        // If the paragraph/block is preceeded by empty paragraphs/block (with no text)
+        // it will return the number of empty paragraphs before the cursor.
+        // Otherwise, it will return 0, which indicates the cursor is at the beginning
+        // of a paragraph/block, and not at the end of the paragraph/block before it
         getIndexRelativeToAdjacentEmptyBlocks: function (doc, root, cursorContainer, cursorOffset) {
             // If there is text in front of the cursor, that means there isn't only empty blocks before it
             if (cursorContainer.nodeType === 3 && cursorOffset > 0) {
@@ -192,7 +194,6 @@ var Selection;
             // Check if the block that contains the cursor has any other text in front of the cursor
             var node = cursorContainer;
             if (node.nodeType !== 3) {
-                //node = cursorContainer.childNodes.length === cursorOffset ? null : cursorContainer.childNodes[cursorOffset];
                 node = cursorContainer.childNodes[cursorOffset];
             }
             if (node && !Util.isElementAtBeginningOfBlock(node)) {

--- a/src/js/selection.js
+++ b/src/js/selection.js
@@ -187,7 +187,7 @@ var Selection;
         // of a paragraph/block, and not at the end of the paragraph/block before it
         getIndexRelativeToAdjacentEmptyBlocks: function (doc, root, cursorContainer, cursorOffset) {
             // If there is text in front of the cursor, that means there isn't only empty blocks before it
-            if (cursorContainer.nodeType === 3 && cursorOffset > 0) {
+            if (cursorContainer.textContent.length > 0 && cursorOffset > 0) {
                 return -1;
             }
 

--- a/src/js/selection.js
+++ b/src/js/selection.js
@@ -60,7 +60,7 @@ var Selection;
                 // If start = 0 there may still be an empty paragraph before it, but we don't care.
                 if (start !== 0) {
                     var emptyBlocksIndex = this.getIndexRelativeToAdjacentEmptyBlocks(doc, root, range.startContainer, range.startOffset);
-                    if (emptyBlocksIndex !== 0) {
+                    if (emptyBlocksIndex !== -1) {
                         selectionState.emptyBlocksIndex = emptyBlocksIndex;
                     }
                 }
@@ -119,11 +119,11 @@ var Selection;
                 }
             }
 
-            if (selectionState.emptyBlocksIndex) {
+            if (typeof selectionState.emptyBlocksIndex !== 'undefined') {
                 var targetNode = Util.getTopBlockContainer(range.startContainer),
                     index = 0;
                 // Skip over empty blocks until we hit the block we want the selection to be in
-                while (index < selectionState.emptyBlocksIndex && targetNode.nextSibling) {
+                while ((index === 0 || index < selectionState.emptyBlocksIndex) && targetNode.nextSibling) {
                     targetNode = targetNode.nextSibling;
                     index++;
                     // If we find a non-empty block, ignore the emptyBlocksIndex and just put selection here
@@ -186,7 +186,7 @@ var Selection;
         getIndexRelativeToAdjacentEmptyBlocks: function (doc, root, cursorContainer, cursorOffset) {
             // If there is text in front of the cursor, that means there isn't only empty blocks before it
             if (cursorContainer.nodeType === 3 && cursorOffset > 0) {
-                return 0;
+                return -1;
             }
 
             // Check if the block that contains the cursor has any other text in front of the cursor
@@ -196,7 +196,7 @@ var Selection;
                 node = cursorContainer.childNodes[cursorOffset];
             }
             if (node && !Util.isElementAtBeginningOfBlock(node)) {
-                return 0;
+                return -1;
             }
 
             // Walk over block elements, counting number of empty blocks between last piece of text


### PR DESCRIPTION
This fixes an issue when saving selection if the cursor is at beginning of a paragraph, but not preceded by empty paragraphs.

We track whether the cursor is at the beginning of a paragraph that has empty paragraphs before it by counting the empty paragraph and storing in the selection data.  However, if the paragraph did not have empty paragraphs in front of it, we didn't store anything, which made the selection get set to the end of the paragraph before it, rather the beginning of the paragraph it should be within.

The fix is to always track if the cursor is at the beginning of a paragraph, and set `emptyBlocksIndex` to `0` if there are no empty paragraphs before it.  Before, this case would have just left `emptyBlocksIndex` as undefined.

This manifested itself in the re-opened issue for #757 and should now be fixed.  