### PR TITLE
Fire editableInput only once, at the end of link creation

### DIFF
--- a/spec/events.spec.js
+++ b/spec/events.spec.js
@@ -52,6 +52,20 @@ describe('Events TestCase', function () {
             editor.trigger('myIncredibleEvent', tempData, editor.elements[0]);
             expect(spy).toHaveBeenCalledWith(tempData, editor.elements[0]);
         });
+
+        it('can be disabled for a temporary period of time on a named basis', function () {
+            var editor = this.newMediumEditor('.editor'),
+                spy = jasmine.createSpy('handler'),
+                tempData = { temp: 'data' };
+            editor.subscribe('myIncredibleEvent', spy);
+            expect(spy).not.toHaveBeenCalled();
+            editor.events.disableCustomEvent('myIncredibleEvent');
+            editor.trigger('myIncredibleEvent', tempData, editor.elements[0]);
+            expect(spy).not.toHaveBeenCalled();
+            editor.events.enableCustomEvent('myIncredibleEvent');
+            editor.trigger('myIncredibleEvent', tempData, editor.elements[0]);
+            expect(spy).toHaveBeenCalledWith(tempData, editor.elements[0]);
+        });
     });
 
     describe('Custom Focus/Blur Listener', function () {

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -1012,10 +1012,12 @@ function MediumEditor(elements, options) {
                     }
                 }
                 // Fire input event for backwards compatibility if anyone was listening directly to the DOM input event
-                customEvent = this.options.ownerDocument.createEvent('HTMLEvents');
-                customEvent.initEvent('input', true, true, this.options.contentWindow);
-                for (i = 0; i < this.elements.length; i += 1) {
-                    this.elements[i].dispatchEvent(customEvent);
+                if (this.options.targetBlank || opts.target === '_blank' || opts.buttonClass) {
+                    customEvent = this.options.ownerDocument.createEvent('HTMLEvents');
+                    customEvent.initEvent('input', true, true, this.options.contentWindow);
+                    for (i = 0; i < this.elements.length; i += 1) {
+                        this.elements[i].dispatchEvent(customEvent);
+                    }
                 }
             } finally {
                 this.events.enableCustomEvent('editableInput');

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -897,10 +897,10 @@ function MediumEditor(elements, options) {
         },
 
         createLink: function (opts) {
-            var customEvent, i;
+            var currentEditor, customEvent, i;
 
             try {
-                this.events.disabledEvents.push('editableInput');
+                this.events.disableCustomEvent('editableInput');
                 if (opts.url && opts.url.trim().length > 0) {
                     var currentSelection = this.options.contentWindow.getSelection();
                     if (currentSelection) {
@@ -933,8 +933,8 @@ function MediumEditor(elements, options) {
                         // which can happen with the built in browser functionality
                         if (commonAncestorContainer.nodeType !== 3 && startContainerParentElement === endContainerParentElement) {
 
-                            var currentEditor = Selection.getSelectionElement(this.options.contentWindow),
-                                parentElement = (startContainerParentElement || currentEditor),
+                            currentEditor = Selection.getSelectionElement(this.options.contentWindow);
+                            var parentElement = (startContainerParentElement || currentEditor),
                                 fragment = this.options.ownerDocument.createDocumentFragment();
 
                             // since we are going to create a link from an extracted text,
@@ -1011,15 +1011,17 @@ function MediumEditor(elements, options) {
                         }
                     }
                 }
+                // Fire input event for backwards compatibility if anyone was listening directly to the DOM input event
+                customEvent = this.options.ownerDocument.createEvent('HTMLEvents');
+                customEvent.initEvent('input', true, true, this.options.contentWindow);
+                for (i = 0; i < this.elements.length; i += 1) {
+                    this.elements[i].dispatchEvent(customEvent);
+                }
             } finally {
-                this.events.disabledEvents.splice(this.events.disabledEvents.indexOf('editableInput'), 1);
+                this.events.enableCustomEvent('editableInput');
             }
-
-            customEvent = this.options.ownerDocument.createEvent('HTMLEvents');
-            customEvent.initEvent('input', true, true, this.options.contentWindow);
-            for (i = 0; i < this.elements.length; i += 1) {
-                this.elements[i].dispatchEvent(customEvent);
-            }
+            // Fire our custom editableInput event
+            this.events.triggerCustomEvent('editableInput', customEvent, currentEditor);
         },
 
         cleanPaste: function (text) {

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -899,123 +899,126 @@ function MediumEditor(elements, options) {
         createLink: function (opts) {
             var customEvent, i;
 
-            if (opts.url && opts.url.trim().length > 0) {
-                var currentSelection = this.options.contentWindow.getSelection();
-                if (currentSelection) {
-                    var currRange = currentSelection.getRangeAt(0),
-                        commonAncestorContainer = currRange.commonAncestorContainer,
-                        exportedSelection,
-                        startContainerParentElement,
-                        endContainerParentElement,
-                        textNodes;
+            try {
+                this.events.disabledEvents.push('editableInput');
+                if (opts.url && opts.url.trim().length > 0) {
+                    var currentSelection = this.options.contentWindow.getSelection();
+                    if (currentSelection) {
+                        var currRange = currentSelection.getRangeAt(0),
+                            commonAncestorContainer = currRange.commonAncestorContainer,
+                            exportedSelection,
+                            startContainerParentElement,
+                            endContainerParentElement,
+                            textNodes;
 
-                    // If the selection is contained within a single text node
-                    // and the selection starts at the beginning of the text node,
-                    // MSIE still says the startContainer is the parent of the text node.
-                    // If the selection is contained within a single text node, we
-                    // want to just use the default browser 'createLink', so we need
-                    // to account for this case and adjust the commonAncestorContainer accordingly
-                    if (currRange.endContainer.nodeType === 3 &&
-                        currRange.startContainer.nodeType !== 3 &&
-                        currRange.startOffset === 0 &&
-                        currRange.startContainer.firstChild === currRange.endContainer) {
-                        commonAncestorContainer = currRange.endContainer;
-                    }
-
-                    startContainerParentElement = Util.getClosestBlockContainer(currRange.startContainer);
-                    endContainerParentElement = Util.getClosestBlockContainer(currRange.endContainer);
-
-                    // If the selection is not contained within a single text node
-                    // but the selection is contained within the same block element
-                    // we want to make sure we create a single link, and not multiple links
-                    // which can happen with the built in browser functionality
-                    if (commonAncestorContainer.nodeType !== 3 && startContainerParentElement === endContainerParentElement) {
-
-                        var currentEditor = Selection.getSelectionElement(this.options.contentWindow),
-                            parentElement = (startContainerParentElement || currentEditor),
-                            fragment = this.options.ownerDocument.createDocumentFragment();
-
-                        // since we are going to create a link from an extracted text,
-                        // be sure that if we are updating a link, we won't let an empty link behind (see #754)
-                        // (Workaroung for Chrome)
-                        this.execAction('unlink');
-
-                        exportedSelection = this.exportSelection();
-                        fragment.appendChild(parentElement.cloneNode(true));
-
-                        if (currentEditor === parentElement) {
-                            // We have to avoid the editor itself being wiped out when it's the only block element,
-                            // as our reference inside this.elements gets detached from the page when insertHTML runs.
-                            // If we just use [parentElement, 0] and [parentElement, parentElement.childNodes.length]
-                            // as the range boundaries, this happens whenever parentElement === currentEditor.
-                            // The tradeoff to this workaround is that a orphaned tag can sometimes be left behind at
-                            // the end of the editor's content.
-                            // In Gecko:
-                            // as an empty <strong></strong> if parentElement.lastChild is a <strong> tag.
-                            // In WebKit:
-                            // an invented <br /> tag at the end in the same situation
-                            Selection.select(
-                                this.options.ownerDocument,
-                                parentElement.firstChild,
-                                0,
-                                parentElement.lastChild,
-                                parentElement.lastChild.nodeType === 3 ?
-                                parentElement.lastChild.nodeValue.length : parentElement.lastChild.childNodes.length
-                            );
-                        } else {
-                            Selection.select(
-                                this.options.ownerDocument,
-                                parentElement,
-                                0,
-                                parentElement,
-                                parentElement.childNodes.length
-                            );
+                        // If the selection is contained within a single text node
+                        // and the selection starts at the beginning of the text node,
+                        // MSIE still says the startContainer is the parent of the text node.
+                        // If the selection is contained within a single text node, we
+                        // want to just use the default browser 'createLink', so we need
+                        // to account for this case and adjust the commonAncestorContainer accordingly
+                        if (currRange.endContainer.nodeType === 3 &&
+                            currRange.startContainer.nodeType !== 3 &&
+                            currRange.startOffset === 0 &&
+                            currRange.startContainer.firstChild === currRange.endContainer) {
+                            commonAncestorContainer = currRange.endContainer;
                         }
 
-                        var modifiedExportedSelection = this.exportSelection();
+                        startContainerParentElement = Util.getClosestBlockContainer(currRange.startContainer);
+                        endContainerParentElement = Util.getClosestBlockContainer(currRange.endContainer);
 
-                        textNodes = Util.findOrCreateMatchingTextNodes(
-                            this.options.ownerDocument,
-                            fragment,
-                            {
-                                start: exportedSelection.start - modifiedExportedSelection.start,
-                                end: exportedSelection.end - modifiedExportedSelection.start,
-                                editableElementIndex: exportedSelection.editableElementIndex
+                        // If the selection is not contained within a single text node
+                        // but the selection is contained within the same block element
+                        // we want to make sure we create a single link, and not multiple links
+                        // which can happen with the built in browser functionality
+                        if (commonAncestorContainer.nodeType !== 3 && startContainerParentElement === endContainerParentElement) {
+
+                            var currentEditor = Selection.getSelectionElement(this.options.contentWindow),
+                                parentElement = (startContainerParentElement || currentEditor),
+                                fragment = this.options.ownerDocument.createDocumentFragment();
+
+                            // since we are going to create a link from an extracted text,
+                            // be sure that if we are updating a link, we won't let an empty link behind (see #754)
+                            // (Workaroung for Chrome)
+                            this.execAction('unlink');
+
+                            exportedSelection = this.exportSelection();
+                            fragment.appendChild(parentElement.cloneNode(true));
+
+                            if (currentEditor === parentElement) {
+                                // We have to avoid the editor itself being wiped out when it's the only block element,
+                                // as our reference inside this.elements gets detached from the page when insertHTML runs.
+                                // If we just use [parentElement, 0] and [parentElement, parentElement.childNodes.length]
+                                // as the range boundaries, this happens whenever parentElement === currentEditor.
+                                // The tradeoff to this workaround is that a orphaned tag can sometimes be left behind at
+                                // the end of the editor's content.
+                                // In Gecko:
+                                // as an empty <strong></strong> if parentElement.lastChild is a <strong> tag.
+                                // In WebKit:
+                                // an invented <br /> tag at the end in the same situation
+                                Selection.select(
+                                    this.options.ownerDocument,
+                                    parentElement.firstChild,
+                                    0,
+                                    parentElement.lastChild,
+                                    parentElement.lastChild.nodeType === 3 ?
+                                    parentElement.lastChild.nodeValue.length : parentElement.lastChild.childNodes.length
+                                );
+                            } else {
+                                Selection.select(
+                                    this.options.ownerDocument,
+                                    parentElement,
+                                    0,
+                                    parentElement,
+                                    parentElement.childNodes.length
+                                );
                             }
-                        );
 
-                        // Creates the link in the document fragment
-                        Util.createLink(this.options.ownerDocument, textNodes, opts.url.trim());
+                            var modifiedExportedSelection = this.exportSelection();
 
-                        // Chrome trims the leading whitespaces when inserting HTML, which messes up restoring the selection.
-                        var leadingWhitespacesCount = (fragment.firstChild.innerHTML.match(/^\s+/) || [''])[0].length;
+                            textNodes = Util.findOrCreateMatchingTextNodes(
+                                this.options.ownerDocument,
+                                fragment,
+                                {
+                                    start: exportedSelection.start - modifiedExportedSelection.start,
+                                    end: exportedSelection.end - modifiedExportedSelection.start,
+                                    editableElementIndex: exportedSelection.editableElementIndex
+                                }
+                            );
 
-                        // Now move the created link back into the original document in a way to preserve undo/redo history
-                        Util.insertHTMLCommand(this.options.ownerDocument, fragment.firstChild.innerHTML.replace(/^\s+/, ''));
-                        exportedSelection.start -= leadingWhitespacesCount;
-                        exportedSelection.end -= leadingWhitespacesCount;
+                            // Creates the link in the document fragment
+                            Util.createLink(this.options.ownerDocument, textNodes, opts.url.trim());
 
-                        this.importSelection(exportedSelection);
-                    } else {
-                        this.options.ownerDocument.execCommand('createLink', false, opts.url);
-                    }
+                            // Chrome trims the leading whitespaces when inserting HTML, which messes up restoring the selection.
+                            var leadingWhitespacesCount = (fragment.firstChild.innerHTML.match(/^\s+/) || [''])[0].length;
 
-                    if (this.options.targetBlank || opts.target === '_blank') {
-                        Util.setTargetBlank(Selection.getSelectionStart(this.options.ownerDocument), opts.url);
-                    }
+                            // Now move the created link back into the original document in a way to preserve undo/redo history
+                            Util.insertHTMLCommand(this.options.ownerDocument, fragment.firstChild.innerHTML.replace(/^\s+/, ''));
+                            exportedSelection.start -= leadingWhitespacesCount;
+                            exportedSelection.end -= leadingWhitespacesCount;
 
-                    if (opts.buttonClass) {
-                        Util.addClassToAnchors(Selection.getSelectionStart(this.options.ownerDocument), opts.buttonClass);
+                            this.importSelection(exportedSelection);
+                        } else {
+                            this.options.ownerDocument.execCommand('createLink', false, opts.url);
+                        }
+
+                        if (this.options.targetBlank || opts.target === '_blank') {
+                            Util.setTargetBlank(Selection.getSelectionStart(this.options.ownerDocument), opts.url);
+                        }
+
+                        if (opts.buttonClass) {
+                            Util.addClassToAnchors(Selection.getSelectionStart(this.options.ownerDocument), opts.buttonClass);
+                        }
                     }
                 }
+            } finally {
+                this.events.disabledEvents.splice(this.events.disabledEvents.indexOf('editableInput'), 1);
             }
 
-            if (this.options.targetBlank || opts.target === '_blank' || opts.buttonClass) {
-                customEvent = this.options.ownerDocument.createEvent('HTMLEvents');
-                customEvent.initEvent('input', true, true, this.options.contentWindow);
-                for (i = 0; i < this.elements.length; i += 1) {
-                    this.elements[i].dispatchEvent(customEvent);
-                }
+            customEvent = this.options.ownerDocument.createEvent('HTMLEvents');
+            customEvent.initEvent('input', true, true, this.options.contentWindow);
+            for (i = 0; i < this.elements.length; i += 1) {
+                this.elements[i].dispatchEvent(customEvent);
             }
         },
 

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -9,7 +9,7 @@ var Events;
         this.base = instance;
         this.options = this.base.options;
         this.events = [];
-        this.disabledEvents = [];
+        this.disabledEvents = {};
         this.customEvents = {};
         this.listeners = {};
     };
@@ -52,6 +52,16 @@ var Events;
             }
         },
 
+        enableCustomEvent: function (event) {
+            if (this.disabledEvents[event] !== undefined) {
+                delete this.disabledEvents[event];
+            }
+        },
+
+        disableCustomEvent: function (event) {
+            this.disabledEvents[event] = true;
+        },
+
         // custom events
         attachCustomEvent: function (event, listener) {
             this.setupListener(event);
@@ -83,7 +93,7 @@ var Events;
         },
 
         triggerCustomEvent: function (name, data, editable) {
-            if (this.customEvents[name] && this.disabledEvents.indexOf(name) === -1) {
+            if (this.customEvents[name] && !this.disabledEvents[name]) {
                 this.customEvents[name].forEach(function (listener) {
                     listener(data, editable);
                 });

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -9,6 +9,7 @@ var Events;
         this.base = instance;
         this.options = this.base.options;
         this.events = [];
+        this.disabledEvents = [];
         this.customEvents = {};
         this.listeners = {};
     };
@@ -82,7 +83,7 @@ var Events;
         },
 
         triggerCustomEvent: function (name, data, editable) {
-            if (this.customEvents[name]) {
+            if (this.customEvents[name] && this.disabledEvents.indexOf(name) === -1) {
                 this.customEvents[name].forEach(function (listener) {
                     listener(data, editable);
                 });


### PR DESCRIPTION
I found that editableInput could be fired twice in the situation where you create a link with a target=_blank attribute. It fires once when the document execCommand `insertHTML` is called, and a second time after the link is modified.

This also had the result of editableInput being fired before medium restored the selection after calling `insertHTML`, which put the selection out of sync with what it should have been.

This PR changes the createLink command to suppress firing of the `editableInput` event until after the HTML is inserted and the selection is restored, plus after any changes to the link attributes have been made in the DOM.