### PR TITLE
Fix #732 - Fix issue with selection inside nested block elements

### DIFF
--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -1,5 +1,5 @@
 /*global MediumEditor, describe, it, expect, spyOn,
-         afterEach, beforeEach, fireEvent, Util,
+         afterEach, beforeEach, fireEvent,
          jasmine, selectElementContents, setupTestHelpers,
          selectElementContentsAndFire, Selection,
          placeCursorInsideElement */
@@ -202,7 +202,7 @@ describe('Selection TestCase', function () {
                 'emptyBlocksIndex': 1
             });
 
-            var startParagraph = Util.getClosestTag(window.getSelection().getRangeAt(0).startContainer, 'p');
+            var startParagraph = MediumEditor.util.getClosestTag(window.getSelection().getRangeAt(0).startContainer, 'p');
             expect(startParagraph).toBe(editor.elements[0].getElementsByTagName('p')[1], 'empty paragraph');
         });
 
@@ -217,7 +217,7 @@ describe('Selection TestCase', function () {
                 'emptyBlocksIndex': 2
             });
 
-            var startParagraph = Util.getClosestTag(window.getSelection().getRangeAt(0).startContainer, 'p');
+            var startParagraph = MediumEditor.util.getClosestTag(window.getSelection().getRangeAt(0).startContainer, 'p');
             expect(startParagraph).toBe(editor.elements[0].getElementsByTagName('p')[2], 'paragraph after empty paragraph');
         });
 
@@ -233,7 +233,7 @@ describe('Selection TestCase', function () {
                 'emptyBlocksIndex': 2
             });
 
-            var startParagraph = Util.getClosestTag(window.getSelection().getRangeAt(0).startContainer, 'p');
+            var startParagraph = MediumEditor.util.getClosestTag(window.getSelection().getRangeAt(0).startContainer, 'p');
             expect(startParagraph).toBe(editor.elements[1].getElementsByTagName('p')[2], 'paragraph after empty paragraph');
         });
 
@@ -248,7 +248,7 @@ describe('Selection TestCase', function () {
                 'emptyBlocksIndex': 2
             });
 
-            var startParagraph = Util.getClosestTag(window.getSelection().getRangeAt(0).startContainer, 'h2');
+            var startParagraph = MediumEditor.util.getClosestTag(window.getSelection().getRangeAt(0).startContainer, 'h2');
             expect(startParagraph).toBe(editor.elements[0].querySelector('h2'), 'block element after empty block element');
         });
 
@@ -263,7 +263,7 @@ describe('Selection TestCase', function () {
                 'emptyBlocksIndex': 2
             });
 
-            var startParagraph = Util.getClosestTag(window.getSelection().getRangeAt(0).startContainer, 'h2');
+            var startParagraph = MediumEditor.util.getClosestTag(window.getSelection().getRangeAt(0).startContainer, 'h2');
             expect(startParagraph).toBe(editor.elements[0].querySelector('h2'), 'block element after empty block element');
         });
 
@@ -279,7 +279,7 @@ describe('Selection TestCase', function () {
             });
 
             var innerElement = window.getSelection().getRangeAt(0).startContainer;
-            expect(Util.isDescendant(editor.elements[0].querySelector('i'), innerElement, true)).toBe(true, 'nested inline elment inside block element after empty block element');
+            expect(MediumEditor.util.isDescendant(editor.elements[0].querySelector('i'), innerElement, true)).toBe(true, 'nested inline elment inside block element after empty block element');
         });
 
         ['br', 'img'].forEach(function (tagName) {
@@ -317,7 +317,7 @@ describe('Selection TestCase', function () {
 
             var innerElement = window.getSelection().getRangeAt(0).startContainer;
             // The behavior varies from browser to browser for this case, some select TH, some #textNode
-            expect(Util.isDescendant(editor.elements[0].querySelector('th'), innerElement, true))
+            expect(MediumEditor.util.isDescendant(editor.elements[0].querySelector('th'), innerElement, true))
                 .toBe(true, 'expect selection to be of TH or a descendant');
             expect(innerElement).toBe(window.getSelection().getRangeAt(0).endContainer);
         });
@@ -335,8 +335,32 @@ describe('Selection TestCase', function () {
             });
 
             var innerElement = window.getSelection().getRangeAt(0).startContainer;
-            expect(Util.isDescendant(editor.elements[0].querySelectorAll('p')[1], innerElement, true)).toBe(false, 'moved selection beyond non-empty block element');
-            expect(Util.isDescendant(editor.elements[0].querySelector('h2'), innerElement, true)).toBe(true, 'moved selection to element to incorrect block element');
+            expect(MediumEditor.util.isDescendant(editor.elements[0].querySelectorAll('p')[1], innerElement, true)).toBe(false, 'moved selection beyond non-empty block element');
+            expect(MediumEditor.util.isDescendant(editor.elements[0].querySelector('h2'), innerElement, true)).toBe(true, 'moved selection to element to incorrect block element');
+        });
+
+        // https://github.com/yabwe/medium-editor/issues/732
+        it('should support a selection correctly when space + newlines are separating block elements', function () {
+            this.el.innerHTML = '<ul>\n' +
+                                '    <li><a href="#">a link</a></li>\n' +
+                                '    <li>a list item</li>\n' +
+                                '    <li>target</li>\n' +
+                                '</ul>';
+            var editor = this.newMediumEditor('.editor'),
+                lastLi = this.el.querySelectorAll('ul > li')[2];
+
+            // Select the <li> with 'target'
+            selectElementContents(lastLi.firstChild);
+
+            var selectionData = editor.exportSelection();
+            expect(selectionData.emptyBlocksIndex).toBe(0);
+
+            editor.importSelection(selectionData);
+            var range = window.getSelection().getRangeAt(0);
+
+            expect(range.toString()).toBe('target', 'The selection is around the wrong element');
+            expect(MediumEditor.util.isDescendant(lastLi, range.startContainer, true)).toBe(true, 'The start of the selection is invalid');
+            expect(MediumEditor.util.isDescendant(lastLi, range.endContainer, true)).toBe(true, 'The end of the selection is invalid');
         });
     });
 
@@ -457,7 +481,7 @@ describe('Selection TestCase', function () {
 
     describe('getSelectedElements', function () {
         it('no selected elements on empty selection', function () {
-            var elements = Selection.getSelectedElements(document);
+            var elements = MediumEditor.selection.getSelectedElements(document);
 
             expect(elements.length).toBe(0);
         });
@@ -468,7 +492,7 @@ describe('Selection TestCase', function () {
                 elements;
 
             selectElementContents(editor.elements[0].querySelector('i').firstChild);
-            elements = Selection.getSelectedElements(document);
+            elements = MediumEditor.selection.getSelectedElements(document);
 
             expect(elements.length).toBe(1);
             expect(elements[0].nodeName.toLowerCase()).toBe('i');
@@ -480,7 +504,7 @@ describe('Selection TestCase', function () {
             var elements;
 
             selectElementContents(this.el);
-            elements = Selection.getSelectedElements(document);
+            elements = MediumEditor.selection.getSelectedElements(document);
 
             expect(elements.length).toBe(1);
             expect(elements[0].nodeName.toLowerCase()).toBe('i');
@@ -490,8 +514,8 @@ describe('Selection TestCase', function () {
 
     describe('getSelectedParentElement', function () {
         it('should return null on bad range', function () {
-            expect(Selection.getSelectedParentElement(null)).toBe(null);
-            expect(Selection.getSelectedParentElement(false)).toBe(null);
+            expect(MediumEditor.selection.getSelectedParentElement(null)).toBe(null);
+            expect(MediumEditor.selection.getSelectedParentElement(false)).toBe(null);
         });
 
         it('should select the document', function () {
@@ -506,7 +530,7 @@ describe('Selection TestCase', function () {
             sel.removeAllRanges();
             sel.addRange(range);
 
-            element = Selection.getSelectedParentElement(range);
+            element = MediumEditor.selection.getSelectedParentElement(range);
 
             expect(element).toBe(document);
         });

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -89,7 +89,15 @@ var Util;
             return keyCode;
         },
 
-        blockContainerElementNames: ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'pre'],
+        blockContainerElementNames: [
+            // elements our editor generates
+            'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'pre', 'ul', 'li', 'ol',
+            // all other known block elements
+            'address', 'article', 'aside', 'audio', 'canvas', 'dd', 'dl', 'dt', 'fieldset',
+            'figcaption', 'figure', 'footer', 'form', 'header', 'hgroup', 'main', 'nav',
+            'noscript', 'output', 'section', 'table', 'tbody', 'tfoot', 'video'
+        ],
+
         emptyElementNames: ['br', 'col', 'colgroup', 'hr', 'img', 'input', 'source', 'wbr'],
 
         extend: function extend(/* dest, source1, source2, ...*/) {
@@ -461,7 +469,7 @@ var Util;
 
             var parentNode = node.parentNode,
                 tagName = parentNode.nodeName.toLowerCase();
-            while (!this.isBlockContainer(parentNode) && tagName !== 'div') {
+            while (tagName === 'li' || (!this.isBlockContainer(parentNode) && tagName !== 'div')) {
                 if (tagName === 'li') {
                     return true;
                 }


### PR DESCRIPTION
This PR includes the changes for #761, so that PR should be merged first.

This fixes #732 

This PR fixes a variety issues around preserving selection within nested block elements (ie `<li>` inside of `<ul>`)

1. When a selection starts at the beginning of a block element, we need to do some special handling to ensure the cursor is placed there when selection is restored (vs the selection be inserted at the end of the block element before it).
2. This change accounts for any type of block element other than `<div>`.  The previous code only accounted for block elements that could be generated by the built-in MediumEditor commands.
3. This change expects that block elements can occur anywhere in the DOM, and can be nested within other block elements. The original code assumed there wouldn't be nested block elements, and all block elements are direct children of the parent `contenteditable` element.
4. This change accounts for the case when the starting HTML, or potentially pasted HTML contains newlines and spaces between block elements (ie, `<ul>` and `<li>` elements with indentation between them).  Chrome treats these as separate text nodes that are siblings of block elements, which was causing a lot of problems when trying to add links at the beginning of `<li>` elements when the HTML was generated by hand and not via the `contenteditable`, thus containing manual indentation.