### PR TITLE
Added enter of emacs key bindings to handleKeydown

### DIFF
--- a/spec/content.spec.js
+++ b/spec/content.spec.js
@@ -212,6 +212,111 @@ describe('Content TestCase', function () {
         });
     });
 
+    describe('when the ctrl key and m key is pressed', function () {
+        it('should prevent new lines from being inserted when disableReturn options is true', function () {
+            this.el.innerHTML = 'lorem ipsum';
+
+            var editor = this.newMediumEditor('.editor', { disableReturn: true }),
+                evt;
+
+            placeCursorInsideElement(editor.elements[0], 0);
+
+            evt = prepareEvent(editor.elements[0], 'keydown', {
+                ctrlKey: true,
+                keyCode: Util.keyCode.M
+            });
+
+            spyOn(evt, 'preventDefault').and.callThrough();
+
+            firePreparedEvent(evt, editor.elements[0], 'keydown');
+
+            expect(evt.preventDefault).toHaveBeenCalled();
+        });
+
+        it('should prevent new lines from being inserted when data-disable-return is defined', function () {
+            this.el.innerHTML = 'lorem ipsum';
+            this.el.setAttribute('data-disable-return', true);
+
+            var editor = this.newMediumEditor('.editor'),
+                evt;
+
+            placeCursorInsideElement(editor.elements[0], 0);
+
+            evt = prepareEvent(editor.elements[0], 'keydown', {
+                ctrlKey: true,
+                keyCode: Util.keyCode.M
+            });
+
+            spyOn(evt, 'preventDefault').and.callThrough();
+
+            firePreparedEvent(evt, editor.elements[0], 'keydown');
+
+            expect(evt.preventDefault).toHaveBeenCalled();
+        });
+
+        it('should prevent consecutive new lines from being inserted when disableDoubleReturn is true', function () {
+            this.el.innerHTML = '<p><br></p>';
+            var editor = this.newMediumEditor('.editor', { disableDoubleReturn: true }),
+                p = editor.elements[0].querySelector('p'),
+                evt;
+
+            placeCursorInsideElement(p, 0);
+
+            evt = prepareEvent(p, 'keydown', {
+                ctrlKey: true,
+                keyCode: Util.keyCode.M
+            });
+
+            spyOn(evt, 'preventDefault').and.callThrough();
+
+            firePreparedEvent(evt, p, 'keydown');
+
+            expect(evt.preventDefault).toHaveBeenCalled();
+        });
+
+        it('should prevent consecutive new lines from being inserted when data-disable-double-return is defined', function () {
+            this.el.innerHTML = '<p><br></p>';
+            this.el.setAttribute('data-disable-double-return', true);
+
+            var editor = this.newMediumEditor('.editor'),
+                p = editor.elements[0].querySelector('p'),
+                evt;
+
+            placeCursorInsideElement(p, 0);
+
+            evt = prepareEvent(p, 'keydown', {
+                ctrlKey: true,
+                keyCode: Util.keyCode.M
+            });
+
+            spyOn(evt, 'preventDefault').and.callThrough();
+
+            firePreparedEvent(evt, p, 'keydown');
+
+            expect(evt.preventDefault).toHaveBeenCalled();
+        });
+
+        it('should prevent consecutive new lines from being inserted inside a sentence when disableDoubleReturn is true', function () {
+            this.el.innerHTML = '<p>hello</p><p><br></p><p>word</p>';
+            var editor = this.newMediumEditor('.editor', { disableDoubleReturn: true }),
+                p = editor.elements[0].getElementsByTagName('p')[2],
+                evt;
+
+            placeCursorInsideElement(p, 0);
+
+            evt = prepareEvent(p, 'keydown', {
+                ctrlKey: true,
+                keyCode: Util.keyCode.M
+            });
+
+            spyOn(evt, 'preventDefault').and.callThrough();
+
+            firePreparedEvent(evt, p, 'keydown');
+
+            expect(evt.preventDefault).toHaveBeenCalled();
+        });
+    });
+
     describe('should unlink anchors', function () {
         it('when the user presses enter inside an anchor', function () {
             this.el.innerHTML = '<a href="#">test</a>';

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -487,7 +487,7 @@ var Events;
         handleKeydown: function (event) {
             this.triggerCustomEvent('editableKeydown', event, event.currentTarget);
 
-            if (Util.isKey(event, Util.keyCode.ENTER)) {
+            if (Util.isKey(event, Util.keyCode.ENTER) || Util.isKey(event, Util.keyCode.ENTER_OF_EMACS)) {
                 return this.triggerCustomEvent('editableKeydownEnter', event, event.currentTarget);
             }
 

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -487,7 +487,7 @@ var Events;
         handleKeydown: function (event) {
             this.triggerCustomEvent('editableKeydown', event, event.currentTarget);
 
-            if (Util.isKey(event, Util.keyCode.ENTER) || Util.isKey(event, Util.keyCode.ENTER_OF_EMACS)) {
+            if (Util.isKey(event, Util.keyCode.ENTER) || (event.ctrlKey && Util.isKey(event, Util.keyCode.M))) {
                 return this.triggerCustomEvent('editableKeydownEnter', event, event.currentTarget);
             }
 

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -41,7 +41,8 @@ var Util;
             ESCAPE: 27,
             SPACE: 32,
             DELETE: 46,
-            K: 75 // K keycode, and not k
+            K: 75, // K keycode, and not k
+            ENTER_OF_EMACS: 77
         },
 
         /**

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -42,7 +42,7 @@ var Util;
             SPACE: 32,
             DELETE: 46,
             K: 75, // K keycode, and not k
-            ENTER_OF_EMACS: 77
+            M: 77
         },
 
         /**


### PR DESCRIPTION
This PR is fix for disableReturn and disableDoubleReturn.
I can't use return-key when I use disableReturn option, but I can use enter of emacs key bindings(ctrl + m).