### PR TITLE
Placeholder text should only show when empty

### DIFF
--- a/src/sass/components/_placeholder.scss
+++ b/src/sass/components/_placeholder.scss
@@ -1,7 +1,7 @@
 .medium-editor-placeholder {
     position: relative;
 
-    &:after {
+    &:empty:after {
         content: attr(data-placeholder) !important;
         font-style: italic;
         left: 0;


### PR DESCRIPTION
Integrating this into my app (using Angular ngModel), and I found the placeholder text would show up when I rendered the content of the ngModel into the body. Using the psuedo-class :empty ensures that the placeholder only shows if there is nothing in the element.