### PR TITLE
Fix clean paste

### DIFF
--- a/spec/paste.spec.js
+++ b/spec/paste.spec.js
@@ -285,6 +285,23 @@ describe('Pasting content', function () {
 
             expect(this.el.innerHTML).toMatch(new RegExp('^Before(&nbsp;|\\s)(<span id="editor-inner">)?<sub>div one</sub><sub>div two</sub>(</span>)?(&nbsp;|\\s)after\\.$'));
         });
+
+        it('should cleanup only pasted element on multi-line when nothing is selected', function () {
+            var editor = this.newMediumEditor('.editor', {
+                paste: {
+                    forcePlainText: false,
+                    cleanPastedHTML: true
+                }
+            });
+
+            this.el.innerHTML = '<div><img src="http://0.0.0.0/ohyeah.png" /></div>';
+
+            selectElementContents(this.el.firstChild, { collapse: true });
+
+            editor.cleanPaste('<table><tr><td>test</td><td><br/></td></tr></table>');
+
+            expect(this.el.innerHTML).toContain('<img src="http://0.0.0.0/ohyeah.png"></div>');
+        });
     });
 
     describe('using pasteHTML', function () {
@@ -293,6 +310,23 @@ describe('Pasting content', function () {
             selectElementContents(this.el.firstChild);
             editor.pasteHTML('<p class="some-class" style="font-weight: bold" dir="ltr"><meta name="description" content="test" />test</p>');
             expect(editor.elements[0].innerHTML).toBe('<p>test</p>');
+        });
+
+        it('should not remove node with "empty" content', function () {
+            var editor = this.newMediumEditor('.editor', {
+                paste: {
+                    forcePlainText: false,
+                    cleanPastedHTML: true
+                }
+            });
+
+            this.el.innerHTML = '<div>this is a div</div><figure id="editor-inner">and this is a figure</figure>.';
+
+            selectElementContents(this.el.firstChild);
+
+            editor.pasteHTML('<table><tr><td>test</td><td><br/></td></tr></table>');
+
+            expect(this.el.innerHTML).toContain('<table><tbody><tr><td>test</td><td><br></td></tr></tbody></table>');
         });
 
         it('should accept a list of attrs to clean up', function () {

--- a/src/js/extensions/paste.js
+++ b/src/js/extensions/paste.js
@@ -141,7 +141,7 @@ var PasteHandler;
         },
 
         cleanPaste: function (text) {
-            var i, elList,
+            var i, elList, tmp, workEl,
                 multiline = /<p|<br|<div/.test(text),
                 replacements = createReplacements().concat(this.cleanReplacements || []);
 
@@ -153,10 +153,34 @@ var PasteHandler;
                 return this.pasteHTML(text);
             }
 
-            // double br's aren't converted to p tags, but we want paragraphs.
-            elList = text.split('<br><br>');
+            // create a temporary div to cleanup block elements
+            tmp = this.document.createElement('div');
 
-            this.pasteHTML('<p>' + elList.join('</p><p>') + '</p>');
+            // double br's aren't converted to p tags, but we want paragraphs.
+            tmp.innerHTML = '<p>' + text.split('<br><br>').join('</p><p>') + '</p>';
+
+            // block element cleanup
+            elList = tmp.querySelectorAll('a,p,div,br');
+            for (i = 0; i < elList.length; i += 1) {
+                workEl = elList[i];
+
+                // Microsoft Word replaces some spaces with newlines.
+                // While newlines between block elements are meaningless, newlines within
+                // elements are sometimes actually spaces.
+                workEl.innerHTML = workEl.innerHTML.replace(/\n/gi, ' ');
+
+                switch (workEl.nodeName.toLowerCase()) {
+                    case 'p':
+                    case 'div':
+                        this.filterCommonBlocks(workEl);
+                        break;
+                    case 'br':
+                        this.filterLineBreak(workEl);
+                        break;
+                }
+            }
+
+            this.pasteHTML(tmp.innerHTML);
         },
 
         pasteHTML: function (html, options) {
@@ -184,27 +208,6 @@ var PasteHandler;
 
                 Util.cleanupAttrs(workEl, options.cleanAttrs);
                 Util.cleanupTags(workEl, options.cleanTags);
-            }
-
-            // block element cleanup
-            elList = fragmentBody.querySelectorAll('a,p,div,br');
-            for (i = 0; i < elList.length; i += 1) {
-                workEl = elList[i];
-
-                // Microsoft Word replaces some spaces with newlines.
-                // While newlines between block elements are meaningless, newlines within
-                // elements are sometimes actually spaces.
-                workEl.innerHTML = workEl.innerHTML.replace(/\n/gi, ' ');
-
-                switch (workEl.nodeName.toLowerCase()) {
-                    case 'p':
-                    case 'div':
-                        this.filterCommonBlocks(workEl);
-                        break;
-                    case 'br':
-                        this.filterLineBreak(workEl);
-                        break;
-                }
             }
 
             Util.insertHTMLCommand(this.document, fragmentBody.innerHTML.replace(/&nbsp;/g, ' '));


### PR DESCRIPTION
Kind of revert #746 (with a better solution !)

I made some changes in `pasteHTML` which breaks compatibility with previous extension that might used `pasteHTML` directly (like https://github.com/yabwe/medium-editor-tables).

I now use a work around to be sure that the block element cleanup only apply to the pasted content instead of the whole document (if no content were previously selected).

And I added tests to avoid future regression … (mostly related to yabwe/medium-editor-tables#15)