### PR TITLE
Enable Saucelabs tests for Windows 10

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -49,29 +49,29 @@ module.exports = function (grunt) {
             version: '11',
             platform: 'WIN8.1'
         }, {
-            browserName: 'chrome',
-            platform: 'WIN8.1'
-        }, {
-            browserName: 'firefox',
-            platform: 'WIN8.1'
-        }, {
             browserName: 'internet explorer',
             version: '11',
             platform: 'Windows 10'
         }, {
             browserName: 'chrome',
+            platform: 'WIN8.1'
+        }, {
+            browserName: 'chrome',
             platform: 'Windows 10'
-        }, {
-            browserName: 'firefox',
-            platform: 'Windows 10'
-        }, {
-            browserName: 'safari',
-            platform: 'OS X 10.10'
-        }, {
-            browserName: 'firefox',
-            platform: 'OS X 10.10'
         }, {
             browserName: 'googlechrome',
+            platform: 'OS X 10.10'
+        }, {
+            browserName: 'firefox',
+            platform: 'WIN8.1'
+        }, {
+            browserName: 'firefox',
+            platform: 'Windows 10'
+        }, {
+            browserName: 'firefox',
+            platform: 'OS X 10.10'
+        }, {
+            browserName: 'safari',
             platform: 'OS X 10.10'
         }];
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -55,6 +55,16 @@ module.exports = function (grunt) {
             browserName: 'firefox',
             platform: 'WIN8.1'
         }, {
+            browserName: 'internet explorer',
+            version: '11',
+            platform: 'Windows 10'
+        }, {
+            browserName: 'chrome',
+            platform: 'Windows 10'
+        }, {
+            browserName: 'firefox',
+            platform: 'Windows 10'
+        }, {
             browserName: 'safari',
             platform: 'OS X 10.10'
         }, {


### PR DESCRIPTION
Enable saucelabs tests to run for:
* Latest Chrome on Windows 10
* Latest Firefox on Windows 10
* IE11 on Windows 10