### PR TITLE
Multiple medium instances cannot be used in a single page with textareas

### DIFF
--- a/spec/textarea.spec.js
+++ b/spec/textarea.spec.js
@@ -77,6 +77,31 @@ describe('Textarea TestCase', function () {
         });
     });
 
+    it('should create unique medium-editor-textarea-ids across all editor instances', function () {
+        var tas = [];
+        for (var i = 0; i < 12; i++) {
+            var ta = document.createElement('textarea');
+            ta.className = 'editor';
+            ta.value = 'test content';
+            document.body.appendChild(ta);
+            tas.push(ta);
+        }
+        var editors = [];
+        tas.forEach(function (el) {
+            editors.push(this.newMediumEditor(el));
+        }, this);
+        editors.forEach(function (editor) {
+            expect(document.querySelectorAll('textarea[medium-editor-textarea-id="' +
+                editor.elements[0].getAttribute('medium-editor-textarea-id') + '"]').length).toEqual(1);
+        });
+        editors.forEach(function (editor) {
+            editor.destroy();
+        });
+        tas.forEach(function (el) {
+            document.body.removeChild(el);
+        });
+    });
+
     it('should cleanup after destroy', function () {
         var editor = this.newMediumEditor('.editor');
         expect(this.el.classList.contains('medium-editor-hidden')).toBe(true);

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -299,7 +299,7 @@ function MediumEditor(elements, options) {
         div.id = uniqueId;
         div.innerHTML = textarea.value;
 
-        textarea.setAttribute('medium-editor-textarea-id', id);
+        textarea.setAttribute('medium-editor-textarea-id', uniqueId);
 
         // re-create all attributes from the textearea to the new created div
         for (var i = 0, n = atts.length; i < n; i++) {


### PR DESCRIPTION
When medium replaces textareas with divs, the medium-editor-textarea-id attributes used to link them together is not unique across the whole page. If you need to use multiple editor instances (for example, if you have a dynamic page, or if your are binding the editor inside some other component framework), the syncing between textarea and editor doesn't work if there are multiple editors.

This change simply re-uses the existing unique div id to make the medium-editor-textarea-id value unique in the page.