### PR TITLE
Fix auto-link within list items

### DIFF
--- a/spec/auto-link.spec.js
+++ b/spec/auto-link.spec.js
@@ -425,6 +425,20 @@ describe('Autolink', function () {
                 triggerAutolinking(this.el);
                 expect(spy.calls.count()).toBe(1);
             });
+
+            it('should create a link for a url within a list item', function () {
+                this.el.innerHTML = '<p>This is my list of links:</p><ol><li>http://www.example.com</li></ol><p>It is very impressive</p>';
+
+                selectElementContentsAndFire(this.el);
+                triggerAutolinking(this.el);
+                var links = this.el.getElementsByTagName('a'),
+                    li = this.el.querySelector('li');
+                expect(links.length).toBe(1, 'A single link was not automatically created');
+                expect(li.firstChild).toBe(links[0]);
+                expect(li.textContent).toBe('http://www.example.com');
+                expect(links[0].getAttribute('href')).toBe('http://www.example.com');
+                expect(links[0].firstChild.getAttribute('data-auto-link')).toBe('true');
+            });
         });
     });
 

--- a/src/js/extensions/auto-link.js
+++ b/src/js/extensions/auto-link.js
@@ -80,16 +80,16 @@ LINK_REGEXP_TEXT =
             // Perform linking on a paragraph level basis as otherwise the detection can wrongly find the end
             // of one paragraph and the beginning of another paragraph to constitute a link, such as a paragraph ending
             // "link." and the next paragraph beginning with "my" is interpreted into "link.my" and the code tries to create
-            // a link across paragraphs - which doesn't work and is terrible.
+            // a link across blockElements - which doesn't work and is terrible.
             // (Medium deletes the spaces/returns between P tags so the textContent ends up without paragraph spacing)
-            var paragraphs = contenteditable.querySelectorAll('p'),
+            var blockElements = contenteditable.querySelectorAll(MediumEditor.util.blockContainerElementNames.join(',')),
                 documentModified = false;
-            if (paragraphs.length === 0) {
-                paragraphs = [contenteditable];
+            if (blockElements.length === 0) {
+                blockElements = [contenteditable];
             }
-            for (var i = 0; i < paragraphs.length; i++) {
-                documentModified = this.removeObsoleteAutoLinkSpans(paragraphs[i]) || documentModified;
-                documentModified = this.performLinkingWithinElement(paragraphs[i]) || documentModified;
+            for (var i = 0; i < blockElements.length; i++) {
+                documentModified = this.removeObsoleteAutoLinkSpans(blockElements[i]) || documentModified;
+                documentModified = this.performLinkingWithinElement(blockElements[i]) || documentModified;
             }
             return documentModified;
         },


### PR DESCRIPTION
This fixes an issue where auto-link was not finding valid urls within list items.

Auto-Link was iterating over `<p>` tags and finding text within them which could be a link.  By instead iterating over all possible block elements, it was able to find valid urls within any of our defined block elements, including list items.