### PR TITLE
Handle backward compatibility with <= 5.4.0

### DIFF
--- a/spec/keyboard-commands.spec.js
+++ b/spec/keyboard-commands.spec.js
@@ -93,18 +93,35 @@ describe('KeyboardCommands TestCase', function () {
                             key: 'p',
                             meta: true,
                             shift: false
+                        },
+                        {
+                            command: 'subscript',
+                            key: 'r',
+                            meta: true,
+                            shift: false
                         }
                     ]
                 }
             });
             selectElementContentsAndFire(editor.elements[0]);
             jasmine.clock().tick(1);
+            // If alt-key is not pressed, command should still be executed
             fireEvent(editor.elements[0], 'keydown', {
                 keyCode: 'p'.charCodeAt(0),
                 ctrlKey: true,
-                metaKey: true
+                metaKey: true,
+                altKey: false
             });
             expect(editor.execAction).toHaveBeenCalledWith('superscript');
+
+            // If alt-key is pressed, command should stil be executed
+            fireEvent(editor.elements[0], 'keydown', {
+                keyCode: 'r'.charCodeAt(0),
+                ctrlKey: true,
+                metaKey: true,
+                altKey: true
+            });
+            expect(editor.execAction).toHaveBeenCalledWith('subscript');
         });
 
         it('should support the use of Alt key', function () {

--- a/spec/keyboard-commands.spec.js
+++ b/spec/keyboard-commands.spec.js
@@ -82,6 +82,31 @@ describe('KeyboardCommands TestCase', function () {
             expect(editor.execAction).toHaveBeenCalledWith('superscript');
         });
 
+        // TODO: remove this test when jumping in 6.0.0
+        it('should be executed for custom command without alt defined', function () {
+            spyOn(MediumEditor.prototype, 'execAction');
+            var editor = this.newMediumEditor('.editor', {
+                keyboardCommands: {
+                    commands: [
+                        {
+                            command: 'superscript',
+                            key: 'p',
+                            meta: true,
+                            shift: false
+                        }
+                    ]
+                }
+            });
+            selectElementContentsAndFire(editor.elements[0]);
+            jasmine.clock().tick(1);
+            fireEvent(editor.elements[0], 'keydown', {
+                keyCode: 'p'.charCodeAt(0),
+                ctrlKey: true,
+                metaKey: true
+            });
+            expect(editor.execAction).toHaveBeenCalledWith('superscript');
+        });
+
         it('should support the use of Alt key', function () {
             spyOn(MediumEditor.prototype, 'execAction');
             var editor = this.newMediumEditor('.editor', {

--- a/src/js/extensions/keyboard-commands.js
+++ b/src/js/extensions/keyboard-commands.js
@@ -64,14 +64,10 @@
                 isAlt = !!event.altKey;
 
             this.keys[keyCode].forEach(function (data) {
-                // TODO, deprecated: remove that when jumping to 6.0.0
-                if (undefined === data.alt) {
-                    data.alt = false;
-                }
-
                 if (data.meta === isMeta &&
                     data.shift === isShift &&
-                    data.alt === isAlt) {
+                    (data.alt === isAlt ||
+                     undefined === data.alt)) { // TODO deprecated: remove check for undefined === data.alt when jumping to 6.0.0
                     event.preventDefault();
                     event.stopPropagation();
 

--- a/src/js/extensions/keyboard-commands.js
+++ b/src/js/extensions/keyboard-commands.js
@@ -64,6 +64,7 @@
                 isAlt = !!event.altKey;
 
             this.keys[keyCode].forEach(function (data) {
+                // TODO, deprecated: remove that when jumping to 6.0.0
                 if (undefined === data.alt) {
                     data.alt = false;
                 }

--- a/src/js/extensions/keyboard-commands.js
+++ b/src/js/extensions/keyboard-commands.js
@@ -64,6 +64,10 @@
                 isAlt = !!event.altKey;
 
             this.keys[keyCode].forEach(function (data) {
+                if (undefined === data.alt) {
+                    data.alt = false;
+                }
+
                 if (data.meta === isMeta &&
                     data.shift === isShift &&
                     data.alt === isAlt) {


### PR DESCRIPTION
`alt` options was added in 5.4.0 (see #727).

Every custom keyboardCommands config since this version will get a `data.alt` as `undefined` when testing if <kbd>alt</kbd> is pressed. Config example before 5.4.0:

```js
{
  command: 'bold',
  key: 'B',
  meta: true,
  shift: false
},
```

And then `undefined === false` is falsy so the command will never be fired.

I don't know if we need this extra `if` or an extra check in the following `if`.
If you guys agree about that solution, I'll add some tests after.