### PR TITLE
Fix #768 + Fix #783 + Simplify and Fix Placeholder Extension

### DIFF
--- a/spec/anchor.spec.js
+++ b/spec/anchor.spec.js
@@ -479,11 +479,11 @@ describe('Anchor Button TestCase', function () {
         });
 
         it('should unlink when selection is a link', function () {
-            spyOn(document, 'execCommand').and.callThrough();
             this.el.innerHTML = '<a href="#">link</a>';
             var button,
                 editor = this.newMediumEditor('.editor'),
                 toolbar = editor.getExtensionByName('toolbar');
+            spyOn(document, 'execCommand').and.callThrough();
             selectElementContentsAndFire(editor.elements[0]);
             jasmine.clock().tick(11); // checkSelection delay
             button = toolbar.getToolbarElement().querySelector('[data-action="createLink"]');

--- a/spec/buttons.spec.js
+++ b/spec/buttons.spec.js
@@ -325,10 +325,10 @@ describe('Buttons TestCase', function () {
 
     describe('AppendEl', function () {
         it('should call the document.execCommand method when button action is append', function () {
-            spyOn(document, 'execCommand');
             var button,
                 editor = this.newMediumEditor('.editor'),
                 toolbar = editor.getExtensionByName('toolbar');
+            spyOn(document, 'execCommand');
             selectElementContentsAndFire(editor.elements[0]);
             jasmine.clock().tick(1);
             button = toolbar.getToolbarElement().querySelector('[data-action="append-h3"]');
@@ -444,10 +444,10 @@ describe('Buttons TestCase', function () {
 
     describe('Italics', function () {
         it('should call the execCommand for native actions', function () {
-            spyOn(document, 'execCommand').and.callThrough();
             var button,
                 editor = this.newMediumEditor('.editor'),
                 toolbar = editor.getExtensionByName('toolbar');
+            spyOn(document, 'execCommand').and.callThrough();
             selectElementContentsAndFire(editor.elements[0]);
             button = toolbar.getToolbarElement().querySelector('[data-action="italic"]');
             fireEvent(button, 'click');
@@ -727,7 +727,6 @@ describe('Buttons TestCase', function () {
 
     describe('Image', function () {
         it('should create an image', function () {
-            spyOn(document, 'execCommand').and.callThrough();
             var editor = this.newMediumEditor('.editor', {
                     toolbar: {
                         buttons: ['image']
@@ -735,6 +734,7 @@ describe('Buttons TestCase', function () {
                 }),
                 toolbar = editor.getExtensionByName('toolbar'),
                 button = toolbar.getToolbarElement().querySelector('[data-action="image"]');
+            spyOn(document, 'execCommand').and.callThrough();
 
             this.el.innerHTML = '<span id="span-image">http://i.imgur.com/twlXfUq.jpg</span>';
             selectElementContentsAndFire(document.getElementById('span-image'));

--- a/spec/events.spec.js
+++ b/spec/events.spec.js
@@ -233,12 +233,12 @@ describe('MediumEditor.Events TestCase', function () {
         });
 
         it('should wrap and unwrap execCommand when using MediumEditor methods', function () {
+            var originalInputSupport = MediumEditor.Events.prototype.InputEventOnContenteditableSupported;
+            MediumEditor.Events.prototype.InputEventOnContenteditableSupported = false;
+
             spyOn(document, 'execCommand').and.callThrough();
             var origExecCommand = document.execCommand,
-                editor = this.newMediumEditor('.editor'),
-                originalInputSupport = MediumEditor.Events.prototype.InputEventOnContenteditableSupported;
-
-            MediumEditor.Events.prototype.InputEventOnContenteditableSupported = false;
+                editor = this.newMediumEditor('.editor');
 
             editor.subscribe('editableInput', function () { });
             expect(document.execCommand).not.toBe(origExecCommand);
@@ -260,16 +260,17 @@ describe('MediumEditor.Events TestCase', function () {
             var namePrefix = inputSupported ? 'when Input is supported' : 'when Input is NOT supported';
 
             it(namePrefix + ' should trigger with the corresponding editor element passed as an argument', function () {
+                var originalInputSupport = MediumEditor.Events.prototype.InputEventOnContenteditableSupported;
+                MediumEditor.Events.prototype.InputEventOnContenteditableSupported = inputSupported;
+
                 var editableTwo = this.createElement('div', 'editor', 'lore ipsum'),
                     firedTarget,
                     editor = this.newMediumEditor('.editor'),
                     handler = function (event, editable) {
                         firedTarget = editable;
-                    },
-                    originalInputSupport = MediumEditor.Events.prototype.InputEventOnContenteditableSupported;
+                    };
                 expect(editor.elements.length).toBe(2);
 
-                MediumEditor.Events.prototype.InputEventOnContenteditableSupported = inputSupported;
                 editor.subscribe('editableInput', handler);
                 editor.selectElement(editableTwo.firstChild);
 
@@ -288,16 +289,17 @@ describe('MediumEditor.Events TestCase', function () {
             });
 
             it(namePrefix + ' should only trigger when the content has actually changed', function () {
+                var originalInputSupport = MediumEditor.Events.prototype.InputEventOnContenteditableSupported;
+                MediumEditor.Events.prototype.InputEventOnContenteditableSupported = inputSupported;
+
                 var editableTwo = this.createElement('div', 'editor', 'lore ipsum'),
                     firedTarget,
                     editor = this.newMediumEditor('.editor'),
                     handler = function (event, editable) {
                         firedTarget = editable;
-                    },
-                    originalInputSupport = MediumEditor.Events.prototype.InputEventOnContenteditableSupported;
+                    };
                 expect(editor.elements.length).toBe(2);
 
-                MediumEditor.Events.prototype.InputEventOnContenteditableSupported = inputSupported;
                 editor.subscribe('editableInput', handler);
 
                 // If content hasn't changed, custom event won't fire
@@ -316,12 +318,12 @@ describe('MediumEditor.Events TestCase', function () {
             });
 
             it(namePrefix + ',setContent should fire editableInput when content changes', function () {
+                var originalInputSupport = MediumEditor.Events.prototype.InputEventOnContenteditableSupported;
+                MediumEditor.Events.prototype.InputEventOnContenteditableSupported = inputSupported;
+
                 var newHTML = 'Lorem ipsum dolor',
                     editor = this.newMediumEditor('.editor'),
-                    spy = jasmine.createSpy('handler'),
-                    originalInputSupport = MediumEditor.Events.prototype.InputEventOnContenteditableSupported;
-
-                MediumEditor.Events.prototype.InputEventOnContenteditableSupported = inputSupported;
+                    spy = jasmine.createSpy('handler');
 
                 editor.subscribe('editableInput', spy);
                 expect(spy).not.toHaveBeenCalled();
@@ -333,12 +335,12 @@ describe('MediumEditor.Events TestCase', function () {
             });
 
             it(namePrefix + ', setContent should not fire editableInput when content doesn\'t change', function () {
+                var originalInputSupport = MediumEditor.Events.prototype.InputEventOnContenteditableSupported;
+                MediumEditor.Events.prototype.InputEventOnContenteditableSupported = inputSupported;
+
                 var sameHTML = 'lore ipsum',
                     editor = this.newMediumEditor('.editor'),
-                    spy = jasmine.createSpy('handler'),
-                    originalInputSupport = MediumEditor.Events.prototype.InputEventOnContenteditableSupported;
-
-                MediumEditor.Events.prototype.InputEventOnContenteditableSupported = inputSupported;
+                    spy = jasmine.createSpy('handler');
 
                 editor.subscribe('editableInput', spy);
                 expect(spy).not.toHaveBeenCalled();
@@ -353,6 +355,9 @@ describe('MediumEditor.Events TestCase', function () {
         runEditableInputTests(false);
 
         it('should trigger when bolding text when input event is NOT supported', function () {
+            var originalInputSupport = MediumEditor.Events.prototype.InputEventOnContenteditableSupported;
+            MediumEditor.Events.prototype.InputEventOnContenteditableSupported = false;
+
             var editableTwo = this.createElement('div', 'editor', 'lore ipsum'),
                 firedTarget,
                 editor = this.newMediumEditor('.editor'),
@@ -360,11 +365,9 @@ describe('MediumEditor.Events TestCase', function () {
                 button = toolbar.getToolbarElement().querySelector('[data-action="bold"]'),
                 handler = function (event, editable) {
                     firedTarget = editable;
-                },
-                originalInputSupport = MediumEditor.Events.prototype.InputEventOnContenteditableSupported;
+                };
             expect(editor.elements.length).toBe(2);
 
-            MediumEditor.Events.prototype.InputEventOnContenteditableSupported = false;
             editor.subscribe('editableInput', handler);
 
             selectElementContentsAndFire(editableTwo.firstChild);

--- a/spec/events.spec.js
+++ b/spec/events.spec.js
@@ -142,7 +142,9 @@ describe('MediumEditor.Events TestCase', function () {
     describe('ExecCommand Listener', function () {
         it('should only wrap document.execCommand when required', function () {
             var origExecCommand = document.execCommand;
-            this.newMediumEditor('.editor');
+            this.newMediumEditor('.editor', {
+                placeholder: false
+            });
             expect(document.execCommand).toBe(origExecCommand);
         });
 

--- a/spec/extension.spec.js
+++ b/spec/extension.spec.js
@@ -81,6 +81,9 @@ describe('Extensions TestCase', function () {
                     },
                     createElement: function () {
                         return document.createElement.apply(document, arguments);
+                    },
+                    execCommand: function () {
+                        return document.execCommand.apply(document, arguments);
                     }
                 },
                 fakeWindow = {

--- a/spec/placeholder.spec.js
+++ b/spec/placeholder.spec.js
@@ -117,6 +117,19 @@ describe('MediumEditor.extensions.placeholder TestCase', function () {
         expect(editor.elements[0].className).not.toContain('medium-editor-placeholder');
     });
 
+    // https://github.com/yabwe/medium-editor/issues/783
+    it('should not show a placeholder when input changes but editor is still empty', function () {
+        var editor = this.newMediumEditor('.editor');
+        expect(editor.elements[0].className).toContain('medium-editor-placeholder');
+        fireEvent(editor.elements[0], 'click');
+        editor.elements[0].focus();
+        expect(editor.elements[0].className).not.toContain('medium-editor-placeholder');
+        var toolbar = editor.getExtensionByName('toolbar');
+        fireEvent(editor.elements[0], 'blur');
+        fireEvent(toolbar.getToolbarElement().querySelector('[data-action="append-h2"]'), 'click');
+        expect(editor.elements[0].className).not.toContain('medium-editor-placeholder');
+    });
+
     /*jslint regexp: true*/
     function validatePlaceholderContent(element, expectedValue) {
         var placeholder = window.getComputedStyle(element, ':after').getPropertyValue('content'),

--- a/spec/placeholder.spec.js
+++ b/spec/placeholder.spec.js
@@ -109,6 +109,14 @@ describe('MediumEditor.extensions.placeholder TestCase', function () {
         expect(editor.elements[0].className).not.toContain('medium-editor-placeholder');
     });
 
+    // https://github.com/yabwe/medium-editor/issues/768
+    it('should remove the placeholder when the content is updated manually', function () {
+        var editor = this.newMediumEditor('.editor');
+        expect(editor.elements[0].className).toContain('medium-editor-placeholder');
+        editor.setContent('<p>lorem ipsum</p>');
+        expect(editor.elements[0].className).not.toContain('medium-editor-placeholder');
+    });
+
     /*jslint regexp: true*/
     function validatePlaceholderContent(element, expectedValue) {
         var placeholder = window.getComputedStyle(element, ':after').getPropertyValue('content'),

--- a/spec/placeholder.spec.js
+++ b/spec/placeholder.spec.js
@@ -1,4 +1,4 @@
-/*global fireEvent */
+/*global fireEvent, selectElementContentsAndFire */
 
 describe('MediumEditor.extensions.placeholder TestCase', function () {
     'use strict';
@@ -47,10 +47,10 @@ describe('MediumEditor.extensions.placeholder TestCase', function () {
         expect(editor.elements[0].className).toContain('medium-editor-placeholder');
     });
 
-    it('should remove the placeholder on keypress', function () {
+    it('should remove the placeholder on focus', function () {
         var editor = this.newMediumEditor('.editor');
         expect(editor.elements[0].className).toContain('medium-editor-placeholder');
-        fireEvent(editor.elements[0], 'keypress');
+        selectElementContentsAndFire(editor.elements[0]);
         expect(editor.elements[0].className).not.toContain('medium-editor-placeholder');
     });
 
@@ -59,25 +59,29 @@ describe('MediumEditor.extensions.placeholder TestCase', function () {
         expect(editor.elements[0].className).toContain('medium-editor-placeholder');
         fireEvent(editor.elements[0], 'click');
         expect(editor.elements[0].className).not.toContain('medium-editor-placeholder');
-        fireEvent(editor.elements[0], 'blur');
+        fireEvent(document.body, 'mousedown');
+        fireEvent(document.body, 'mouseup');
+        fireEvent(document.body, 'click');
         expect(editor.elements[0].className).toContain('medium-editor-placeholder');
         this.el.innerHTML = '<p>lorem</p><p id="target">ipsum</p><p>dolor</p>';
         fireEvent(document.getElementById('target'), 'click');
         expect(editor.elements[0].className).not.toContain('medium-editor-placeholder');
     });
 
-    it('should NOT remove the placeholder on click', function () {
+    it('should remove the placeholder on input, and NOT on click', function () {
         var editor = this.newMediumEditor('.editor', { placeholder: { hideOnClick: false }});
         expect(editor.elements[0].className).toContain('medium-editor-placeholder');
         fireEvent(editor.elements[0], 'click');
         expect(editor.elements[0].className).toContain('medium-editor-placeholder');
-        fireEvent(editor.elements[0], 'blur');
+        fireEvent(document.body, 'mousedown');
+        fireEvent(document.body, 'mouseup');
+        fireEvent(document.body, 'click');
         expect(editor.elements[0].className).toContain('medium-editor-placeholder');
         this.el.innerHTML = '<p>lorem</p><p id="target">ipsum</p><p>dolor</p>';
-        fireEvent(document.getElementById('target'), 'keypress');
+        fireEvent(editor.elements[0], 'input');
         expect(editor.elements[0].className).not.toContain('medium-editor-placeholder');
         this.el.innerHTML = '';
-        fireEvent(editor.elements[0], 'keyup', { keyCode: MediumEditor.util.keyCode.DELETE });
+        fireEvent(editor.elements[0], 'input');
         expect(editor.elements[0].className).toContain('medium-editor-placeholder');
     });
 
@@ -88,7 +92,9 @@ describe('MediumEditor.extensions.placeholder TestCase', function () {
         fireEvent(editor.elements[0], 'focus');
         expect(editor.elements[0].className).not.toContain('medium-editor-placeholder');
         editor.elements[0].innerHTML = '';
-        fireEvent(document.querySelector('div'), 'click');
+        fireEvent(document.body, 'mousedown');
+        fireEvent(document.body, 'mouseup');
+        fireEvent(document.body, 'click');
         expect(editor.elements[0].className).toContain('medium-editor-placeholder');
     });
 
@@ -96,7 +102,10 @@ describe('MediumEditor.extensions.placeholder TestCase', function () {
         var editor = this.newMediumEditor('.editor');
         expect(editor.elements[0].className).toContain('medium-editor-placeholder');
         editor.elements[0].innerHTML = 'some text';
-        fireEvent(editor.elements[0], 'blur');
+        editor.selectElement(this.el.firstChild);
+        fireEvent(document.body, 'mousedown');
+        fireEvent(document.body, 'mouseup');
+        fireEvent(document.body, 'click');
         expect(editor.elements[0].className).not.toContain('medium-editor-placeholder');
     });
 

--- a/spec/placeholder.spec.js
+++ b/spec/placeholder.spec.js
@@ -78,10 +78,10 @@ describe('MediumEditor.extensions.placeholder TestCase', function () {
         fireEvent(document.body, 'click');
         expect(editor.elements[0].className).toContain('medium-editor-placeholder');
         this.el.innerHTML = '<p>lorem</p><p id="target">ipsum</p><p>dolor</p>';
-        fireEvent(editor.elements[0], 'input');
+        editor.trigger('editableInput', {}, editor.elements[0]);
         expect(editor.elements[0].className).not.toContain('medium-editor-placeholder');
         this.el.innerHTML = '';
-        fireEvent(editor.elements[0], 'input');
+        editor.trigger('editableInput', {}, editor.elements[0]);
         expect(editor.elements[0].className).toContain('medium-editor-placeholder');
     });
 

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -930,8 +930,6 @@
                         // we want to make sure we create a single link, and not multiple links
                         // which can happen with the built in browser functionality
                         if (commonAncestorContainer.nodeType !== 3 && startContainerParentElement === endContainerParentElement) {
-
-                            currentEditor = MediumEditor.selection.getSelectionElement(this.options.contentWindow);
                             var parentElement = (startContainerParentElement || currentEditor),
                                 fragment = this.options.ownerDocument.createDocumentFragment();
 

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -889,7 +889,13 @@
         },
 
         createLink: function (opts) {
-            var currentEditor, customEvent, i;
+            var currentEditor = MediumEditor.selection.getSelectionElement(this.options.contentWindow),
+                customEvent = {};
+
+            // Make sure the selection is within an element this editor is tracking
+            if (this.elements.indexOf(currentEditor) === -1) {
+                return;
+            }
 
             try {
                 this.events.disableCustomEvent('editableInput');
@@ -1007,7 +1013,7 @@
                 if (this.options.targetBlank || opts.target === '_blank' || opts.buttonClass) {
                     customEvent = this.options.ownerDocument.createEvent('HTMLEvents');
                     customEvent.initEvent('input', true, true, this.options.contentWindow);
-                    for (i = 0; i < this.elements.length; i += 1) {
+                    for (var i = 0; i < this.elements.length; i += 1) {
                         this.elements[i].dispatchEvent(customEvent);
                     }
                 }

--- a/src/js/extensions/placeholder.js
+++ b/src/js/extensions/placeholder.js
@@ -53,24 +53,28 @@
         },
 
         updatePlaceholder: function (el) {
-            // if one of these element ('img, blockquote, ul, ol') are found inside the given element, we won't display the placeholder
-            if (!(el.querySelector('img, blockquote, ul, ol')) && el.textContent.replace(/^\s+|\s+$/g, '') === '') {
-                return this.showPlaceholder(el);
+            // If the element has content, hide the placeholder
+            if (el.querySelector('img, blockquote, ul, ol') || el.textContent.replace(/^\s+|\s+$/g, '') !== '') {
+                return this.hidePlaceholder(el);
             }
 
-            this.hidePlaceholder(el);
+            // The element is empty. The placeholder should be shown except
+            // for cases where the placeholder should not be visible while the editor has focus
+            if (this.hideOnClick || el !== this.base.getFocusedElement()) {
+                this.showPlaceholder(el);
+            }
         },
 
         attachEventHandlers: function () {
             if (this.hideOnClick) {
-                // We want to always hide the placeholder when it gets focus
+                // For the 'hideOnClick' option, the placeholder should always be hidden on focus
                 this.subscribe('focus', this.handleFocus.bind(this));
-            } else {
-                // We want to hide/show the placeholder each time something changes
-                this.subscribe('editableInput', this.handleInput.bind(this));
             }
 
-            // When the editor loses focus, we should always check if the placeholder shoudl be visible
+            // If the editor has content, it should always hide the placeholder
+            this.subscribe('editableInput', this.handleInput.bind(this));
+
+            // When the editor loses focus, check if the placeholder should be visible
             this.subscribe('blur', this.handleBlur.bind(this));
         },
 

--- a/src/js/extensions/placeholder.js
+++ b/src/js/extensions/placeholder.js
@@ -52,15 +52,13 @@
             }
         },
 
-        updatePlaceholder: function (el) {
+        updatePlaceholder: function (el, dontShow) {
             // If the element has content, hide the placeholder
-            if (el.querySelector('img, blockquote, ul, ol') || el.textContent.replace(/^\s+|\s+$/g, '') !== '') {
+            if (el.querySelector('img, blockquote, ul, ol') || (el.textContent.replace(/^\s+|\s+$/g, '') !== '')) {
                 return this.hidePlaceholder(el);
             }
 
-            // The element is empty. The placeholder should be shown except
-            // for cases where the placeholder should not be visible while the editor has focus
-            if (this.hideOnClick || el !== this.base.getFocusedElement()) {
+            if (!dontShow) {
                 this.showPlaceholder(el);
             }
         },
@@ -79,8 +77,12 @@
         },
 
         handleInput: function (event, element) {
+            // If the placeholder should be hidden on focus and the
+            // element has focus, don't show the placeholder
+            var dontShow = this.hideOnClick && (element === this.base.getFocusedElement());
+
             // Editor's content has changed, check if the placeholder should be hidden
-            this.updatePlaceholder(element);
+            this.updatePlaceholder(element, dontShow);
         },
 
         handleFocus: function (event, element) {
@@ -89,7 +91,7 @@
         },
 
         handleBlur: function (event, element) {
-            // Editor has lost focus, check the placeholder should be shown
+            // Editor has lost focus, check if the placeholder should be shown
             this.updatePlaceholder(element);
         }
     });

--- a/src/js/extensions/placeholder.js
+++ b/src/js/extensions/placeholder.js
@@ -62,37 +62,31 @@
         },
 
         attachEventHandlers: function () {
-            // Custom events
-            this.subscribe('blur', this.handleExternalInteraction.bind(this));
-
-            // Check placeholder on blur
-            this.subscribe('editableBlur', this.handleBlur.bind(this));
-
-            // if we don't want the placeholder to be removed on click but when user start typing
             if (this.hideOnClick) {
-                this.subscribe('editableClick', this.handleHidePlaceholderEvent.bind(this));
+                // We want to always hide the placeholder when it gets focus
+                this.subscribe('focus', this.handleFocus.bind(this));
             } else {
-                this.subscribe('editableKeyup', this.handleBlur.bind(this));
+                // We want to hide/show the placeholder each time something changes
+                this.subscribe('editableInput', this.handleInput.bind(this));
             }
 
-            // Events where we always hide the placeholder
-            this.subscribe('editableKeypress', this.handleHidePlaceholderEvent.bind(this));
-            this.subscribe('editablePaste', this.handleHidePlaceholderEvent.bind(this));
+            // When the editor loses focus, we should always check if the placeholder shoudl be visible
+            this.subscribe('blur', this.handleBlur.bind(this));
         },
 
-        handleHidePlaceholderEvent: function (event, element) {
-            // Events where we hide the placeholder
+        handleInput: function (event, element) {
+            // Editor's content has changed, check if the placeholder should be hidden
+            this.updatePlaceholder(element);
+        },
+
+        handleFocus: function (event, element) {
+            // Editor has focus, hide the placeholder
             this.hidePlaceholder(element);
         },
 
         handleBlur: function (event, element) {
-            // Update placeholder for element that lost focus
+            // Editor has lost focus, check the placeholder should be shown
             this.updatePlaceholder(element);
-        },
-
-        handleExternalInteraction: function () {
-            // Update all placeholders
-            this.initPlaceholders();
         }
     });
 


### PR DESCRIPTION
This PR covers a bit of a re-write of how the placeholder extension handles hiding/showing the placeholder text.

The new placeholder extension leverages the `editableInput`, `focus`, and `blur` custom-events provided by the internal MediumEditor code to better detect when the placeholder text should be hidden or shown.

By listening to `editableInput`, the extension is also able to detect when calls to `setContent()` happen, which fixes #768 .

By listening to `focus`, `blur`, and `editableInput`, and checking the value of the `placeholder.hideOnClick` option, the extension is also able to prevent showing the placeholder incorrectly while clicking buttons on the toolbar, which fixes #783 

Other Issues Resolved:
* Since the placeholder extension now uses `editableInput`, MediumEditor will now always monitor for the `editableInput` event whenever it's instantiated.  This required tweaking some of the tests around `editableInput` which assumed that the event detection wouldn't happen automatically.
* Since the placeholder extension is using `editableInput`, a bug was found inside link creation when it came time to manually trigger the custom event.  In some cases, the reference to the editable element passed to the custom event was `null`, so this is now fixed as well.