### PR TITLE
If disableDoubleReturn is true, prevents returns from caret position 0

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -11,7 +11,8 @@
 
             // if current text selection is empty OR previous sibling text is empty
             if ((node && node.textContent.trim() === '') ||
-                (node.previousElementSibling && node.previousElementSibling.textContent.trim() === '')) {
+                (node.previousElementSibling && node.previousElementSibling.textContent.trim() === '') ||
+                (MediumEditor.selection.getCaretOffsets(node).left === 0)) {
                 event.preventDefault();
             }
         }


### PR DESCRIPTION
This patch lets `disableDoubleReturn` work as expected. If the caret position is at 0, there is no need to create a new line, paragraph or list item.

It should resolve one or more of these issues: https://github.com/yabwe/medium-editor/issues/70 , https://github.com/yabwe/medium-editor/issues/207 , https://github.com/yabwe/medium-editor/issues/248