### PR TITLE
Fix some breaks in isDescendant that were introduced by #792

### DIFF
--- a/spec/util.spec.js
+++ b/spec/util.spec.js
@@ -405,4 +405,41 @@ describe('MediumEditor.util', function () {
             expect(document.body.contains(el)).toBe(true, 'The editor element has been removed from the page');
         });
     });
+
+    describe('isDescendant', function () {
+        it('should return true for an element which is a descendant of another', function () {
+            var parent = this.createElement('div'),
+                child = parent.appendChild(document.createTextNode('text'));
+            expect(MediumEditor.util.isDescendant(parent, child)).toBe(true);
+        });
+
+        it('should return false for an element which is not a descendant of another', function () {
+            var parent = this.createElement('div'),
+                child = document.createTextNode('text');
+            expect(MediumEditor.util.isDescendant(parent, child)).toBe(false);
+        });
+
+        it('should return false when checking the same element', function () {
+            var parent = this.createElement('div');
+            expect(MediumEditor.util.isDescendant(parent, parent)).toBe(false);
+        });
+
+        it('should return true when checking the same element but using the equality param', function () {
+            var parent = this.createElement('div');
+            expect(MediumEditor.util.isDescendant(parent, parent, true)).toBe(true);
+        });
+
+        it('should return false when the elements are null', function () {
+            var parent = this.createElement('div');
+            expect(MediumEditor.util.isDescendant(parent, null)).toBe(false);
+            expect(MediumEditor.util.isDescendant(null, parent)).toBe(false);
+            expect(MediumEditor.util.isDescendant(null, null)).toBe(false);
+        });
+
+        it('should return false when the parent element is a text node', function () {
+            var parent = document.createTextNode('text'),
+                child = this.createElement('div');
+            expect(MediumEditor.util.isDescendant(parent, child)).toBe(false);
+        });
+    });
 });

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -249,8 +249,12 @@
             if (!parent || !child) {
                 return false;
             }
-            if (checkEquality && parent === child) {
-                return true;
+            if (parent === child) {
+                return !!checkEquality;
+            }
+            // If parent is not an element, it can't have any descendants
+            if (parent.nodeType !== 1) {
+                return false;
             }
             if (nodeContainsWorksWithTextNodes || child.nodeType !== 3) {
                 return parent.contains(child);


### PR DESCRIPTION
2 Things were broken by #792:

1. When 2 elements that are equal are passed as arguments, `isDescendant()` used to return false.  However, the native `node.contains()` will return true in this case.  This makes the behavior inconsistent depending on the browser or support, so catching this case and falling back to the original behavior

2. When the `parent` is a textnode, the current implementation would throw an exception, since `.contains()` is undefined on textnodes.