### PR TITLE
More autolink fixes

### DIFF
--- a/spec/auto-link.spec.js
+++ b/spec/auto-link.spec.js
@@ -465,6 +465,15 @@ describe('Autolink', function () {
                 expect(lastLi.firstChild).toBe(links[0]);
                 expect(lastLi.textContent).toBe('www.example.com');
             });
+
+            it('should not create a link which spans multiple list items', function () {
+                this.el.innerHTML = '<blockquote><ol><li>www</li><li>.example.com</li></ol></blockquote>';
+
+                selectElementContentsAndFire(this.el);
+                triggerAutolinking(this.el);
+                var links = this.el.getElementsByTagName('a');
+                expect(links.length).toBe(0, 'There should not have been any links created');
+            });
         });
     });
 

--- a/spec/auto-link.spec.js
+++ b/spec/auto-link.spec.js
@@ -454,7 +454,7 @@ describe('Autolink', function () {
 
             // https://github.com/yabwe/medium-editor/issues/790
             it('should not create a link which spans multiple list items', function () {
-                this.el.innerHTML = '<ol><li>abc</li><li>www.example.com</li></ol>';
+                this.el.innerHTML = '<blockquote><ol><li>abc</li><li>www.example.com</li></ol></li>';
 
                 selectElementContentsAndFire(this.el);
                 triggerAutolinking(this.el);

--- a/spec/auto-link.spec.js
+++ b/spec/auto-link.spec.js
@@ -454,7 +454,7 @@ describe('Autolink', function () {
 
             // https://github.com/yabwe/medium-editor/issues/790
             it('should not create a link which spans multiple list items', function () {
-                this.el.innerHTML = '<blockquote><ol><li>abc</li><li>www.example.com</li></ol></li>';
+                this.el.innerHTML = '<blockquote><ol><li>abc</li><li>www.example.com</li></ol></blockquote>';
 
                 selectElementContentsAndFire(this.el);
                 triggerAutolinking(this.el);

--- a/spec/util.spec.js
+++ b/spec/util.spec.js
@@ -442,4 +442,52 @@ describe('MediumEditor.util', function () {
             expect(MediumEditor.util.isDescendant(parent, child)).toBe(false);
         });
     });
+
+    describe('splitByBlockElements', function () {
+        it('should return block elements without block elements as children', function () {
+            var el = this.createElement('div');
+            el.innerHTML = '' +
+                '<blockquote><ol>' +
+                        '<li><div><table><thead><tr><th>Head</th></tr></thead></table></div></li>' +
+                        '<li>List Item</li>' +
+                    '</ol>' +
+                    '<p>paragraph</p>' +
+                '</blockquote>';
+
+            var parts = MediumEditor.util.splitByBlockElements(el);
+            expect(parts.length).toBe(3);
+
+            // <th>Head</th>
+            expect(parts[0].nodeName.toLowerCase()).toBe('th');
+            expect(parts[0].textContent).toBe('Head');
+            // <li>List Item</li>
+            expect(parts[1].nodeName.toLowerCase()).toBe('li');
+            expect(parts[1].textContent).toBe('List Item');
+            // <p>paragraph</p>
+            expect(parts[2].nodeName.toLowerCase()).toBe('p');
+            expect(parts[2].textContent).toBe('paragraph');
+        });
+
+        it('should return inline elements and text nodes if they are siblings of blocks', function () {
+            var el = this.createElement('div');
+            el.innerHTML = '' +
+                '<blockquote>' +
+                    '<span>Text <b>bold <i>bold + italics</i></b> <u>underlined</u></span>' +
+                    '<ol><li>List Item</li></ol>' +
+                    'Text Node' +
+                '</blockquote>';
+            var parts = MediumEditor.util.splitByBlockElements(el);
+            expect(parts.length).toBe(3);
+
+            // <span>Text <b>bold <i>bold + italics</i></b> <u>underlined</u></span>
+            expect(parts[0].nodeName.toLowerCase()).toBe('span');
+            expect(parts[0].textContent).toBe('Text bold bold + italics underlined');
+            // <li>List Item</li>
+            expect(parts[1].nodeName.toLowerCase()).toBe('li');
+            expect(parts[1].textContent).toBe('List Item');
+            // Text Node
+            expect(parts[2].nodeName.toLowerCase()).toBe('#text');
+            expect(parts[2].textContent).toBe('Text Node');
+        });
+    });
 });

--- a/src/js/extensions/auto-link.js
+++ b/src/js/extensions/auto-link.js
@@ -4,9 +4,7 @@
     var WHITESPACE_CHARS,
         KNOWN_TLDS_FRAGMENT,
         LINK_REGEXP_TEXT,
-        IGNORED_BLOCK_ELEMENTS,
-        KNOWN_TLDS_REGEXP,
-        AUTO_LINK_BLOCK_ELEMENTS;
+        KNOWN_TLDS_REGEXP;
 
     WHITESPACE_CHARS = [' ', '\t', '\n', '\r', '\u00A0', '\u2000', '\u2001', '\u2002', '\u2003',
                                     '\u2028', '\u2029'];
@@ -26,18 +24,7 @@
         // Addition to above Regexp to support bare domains/one level subdomains with common non-i18n TLDs and without www prefix:
         ')|(([a-z0-9\\-]+\\.)?[a-z0-9\\-]+\\.(' + KNOWN_TLDS_FRAGMENT + '))';
 
-    // Block elements to ignore when querying all block elements for whether they contain auto-linkable text
-    // These are elements whose text content should be ignored, but instead the text of their child nodes
-    // should be evaluated for auto-link text
-    // (ie don't check the text of an <ol>, check the <li>'s inside of it instead)
-    IGNORED_BLOCK_ELEMENTS = ['ol', 'ul', 'dl', 'table', 'tbody', 'tfoot', 'tr'];
-
     KNOWN_TLDS_REGEXP = new RegExp('^(' + KNOWN_TLDS_FRAGMENT + ')$', 'i');
-
-    // List of block elements to search for when trying to find auto-linkable text
-    AUTO_LINK_BLOCK_ELEMENTS = MediumEditor.util.blockContainerElementNames.filter(function (name) {
-        return (IGNORED_BLOCK_ELEMENTS.indexOf(name) === -1);
-    });
 
     function nodeIsNotInsideAnchorTag(node) {
         return !MediumEditor.util.getClosestTag(node, 'a');
@@ -97,7 +84,7 @@
             // "link." and the next paragraph beginning with "my" is interpreted into "link.my" and the code tries to create
             // a link across blockElements - which doesn't work and is terrible.
             // (Medium deletes the spaces/returns between P tags so the textContent ends up without paragraph spacing)
-            var blockElements = contenteditable.querySelectorAll(AUTO_LINK_BLOCK_ELEMENTS.join(',')),
+            var blockElements = MediumEditor.util.splitByBlockElements(contenteditable),
                 documentModified = false;
             if (blockElements.length === 0) {
                 blockElements = [contenteditable];
@@ -110,6 +97,10 @@
         },
 
         removeObsoleteAutoLinkSpans: function (element) {
+            if (!element || element.nodeType === 3) {
+                return false;
+            }
+
             var spans = element.querySelectorAll('span[data-auto-link="true"]'),
                 documentModified = false;
 

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -238,11 +238,11 @@
          * </blockquote>
          *
          * This function would return these elements as an array:
-         *   [ <p>Some</p>, <li>List Item 1</li>, <li>List Item 2</li> ]
+         *   [ <p>Some Text</p>, <li>List Item 1</li>, <li>List Item 2</li> ]
          *
-         * Since the <blockquote> and <ol> elements contain blocks within them
-         * They are not returned.  Since the <p> and <li>'s cover all text content,
-         * that is what is returned
+         * Since the <blockquote> and <ol> elements contain blocks within them they are not returned.
+         * Since the <p> and <li>'s don't contain block elements and cover all the text content of the
+         * <blockquote> container, they are the elements returned.
          */
         splitByBlockElements: function (element) {
             var toRet = [],


### PR DESCRIPTION
My original attempt to fix auto-link issues within nested block elements (ie `<li>` elements inside of `<ol>` elements) was very targeted towards specific common cases where we know we don't want to auto-link the `textContent` of the element, but rather auto-link the content of its children (`'ol', 'ul', 'dl', 'table', 'tbody', 'tfoot', 'tr'` elements).

However, there are still many other cases where we don't want to auto-link the `textContent` of a block element, since it can have other block elements:

```html
<div>
  <blockquote>
    <ol>
      <li>www</li>
      <li>.example.com</li>
    </ol>
  </blockquote>
<div>
```
In this example, the auto-link code would try to create a link around the entire `<ol>` element, since the code would first find the `<blockquote>` and then see that its textContent ('www.example.com') is a valid URL. 

The fix is to do a better job of finding the unique pieces of the content which contain no block elements.

So there is now a `MediumEditor.util.splitByBlockElements(element)` method which will find these pieces and return them as an array.  Calling this helper on the above example would return `[<li>www</li>, <li>.example.com</li>]` elements.  Thus, when auto-link calls this, it would check each of the `<li>` elements to see if they individually have auto-linkable text, and never look at the `<blockquote>` or `<ol>` for textContent.