### PR TITLE
removed trailing white spaces from the link and undid the changes in dist files made in earlier commit

### DIFF
--- a/spec/anchor.spec.js
+++ b/spec/anchor.spec.js
@@ -72,6 +72,43 @@ describe('Anchor Button TestCase', function () {
             expect(this.el.innerHTML.indexOf('<a href="test">lorem ipsum</a>')).toBe(0);
         });
 
+        it('should remove the extra white spaces in the link when user presses enter', function () {
+            spyOn(MediumEditor.prototype, 'createLink').and.callThrough();
+            var editor = this.newMediumEditor('.editor'),
+                toolbar = editor.getExtensionByName('toolbar'),
+                button, input;
+
+            selectElementContents(editor.elements[0]);
+            button = toolbar.getToolbarElement().querySelector('[data-action="createLink"]');
+            fireEvent(button, 'click');
+            input = editor.getExtensionByName('anchor').getInput();
+            input.value = '    test   ';
+            fireEvent(input, 'keyup', {
+                keyCode: MediumEditor.util.keyCode.ENTER
+            });
+            expect(editor.createLink).toHaveBeenCalled();
+            // A trailing <br> may be added when insertHTML is used to add the link internally.
+            expect(this.el.innerHTML.indexOf('<a href="test">lorem ipsum</a>')).toBe(0);
+        });
+
+        it('should not set any href if all user passes is spaces in the link when user presses enter', function () {
+            spyOn(MediumEditor.prototype, 'createLink').and.callThrough();
+            var editor = this.newMediumEditor('.editor'),
+                toolbar = editor.getExtensionByName('toolbar'),
+                button, input;
+
+            selectElementContents(editor.elements[0]);
+            button = toolbar.getToolbarElement().querySelector('[data-action="createLink"]');
+            fireEvent(button, 'click');
+            input = editor.getExtensionByName('anchor').getInput();
+            input.value = '    ';
+            fireEvent(input, 'keyup', {
+                keyCode: MediumEditor.util.keyCode.ENTER
+            });
+            //Since user only passes empty string in the url, there should be no <a> tag created for the element.
+            expect(this.el.innerHTML.indexOf('<a href="">lorem ipsum</a>')).toBe(-1);
+        });
+
         it('should create only one anchor tag when the user selects across a boundary', function () {
             this.el.innerHTML = 'Hello world, this <strong>will become a link, but this part won\'t.</strong>';
 

--- a/src/js/extensions/anchor.js
+++ b/src/js/extensions/anchor.js
@@ -201,7 +201,7 @@
             var targetCheckbox = this.getAnchorTargetCheckbox(),
                 buttonCheckbox = this.getAnchorButtonCheckbox(),
                 opts = {
-                    url: this.getInput().value
+                    url: this.getInput().value.trim()
                 };
 
             if (this.linkValidation) {


### PR DESCRIPTION
Fix for https://github.com/yabwe/medium-editor/issues/824

1. Squashed multiple commits into 1 commit.
2. trimmed the url.
3. Removed unnecessary conditional check with trimmed values as now we are initialising  it with the trimmed values itself.