### PR TITLE
New anchor preview option to show when toolbar is visible

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -105,7 +105,7 @@ CSS class added to active buttons in the toolbar.
 #### `buttonLabels`
 **Default:** `false`
 
-Custom content for the toolbar buttons. 
+Custom content for the toolbar buttons.
 
 **Valid Values:**
 * `false`
@@ -318,6 +318,12 @@ Time in milliseconds to show the anchor tag preview after the mouse has left the
 **Default:** `'a'`
 
 The default selector to locate where to put the activeAnchor value in the preview. You should only need to override this if you've modified the way in which the anchor-preview extension renders.
+
+***
+#### `showWhenToolbarIsVisible`
+**Default:** `false`
+
+Determines whether the anchor tag preview shows up when the toolbar is visible. You should set this value to true if the static option for the toolbar is true and you want the preview to show at the same time.
 
 ### Disabling Anchor Preview
 

--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ var editor = new MediumEditor('.editable', {
 
 * __hideDelay__: time in milliseconds to show the anchor tag preview after the mouse has left the anchor tag. Default: `500`
 * __previewValueSelector__: the default selector to locate where to put the activeAnchor value in the preview. You should only need to override this if you've modified the way in which the anchor-preview extension renders. Default: `'a'`
+* __showWhenToolbarIsVisible__: determines whether the anchor tag preview shows up when the toolbar is visible. You should set this value to true if the static option for the toolbar is true and you want the preview to show at the same time. Default: `false`
 
 To disable the anchor preview, set the value of the `anchorPreview` option to `false`:
 ```javascript

--- a/spec/anchor-preview.spec.js
+++ b/spec/anchor-preview.spec.js
@@ -1,4 +1,4 @@
-/*global fireEvent */
+/*global fireEvent, selectElementContentsAndFire */
 
 describe('Anchor Preview TestCase', function () {
     'use strict';
@@ -232,6 +232,58 @@ describe('Anchor Preview TestCase', function () {
             expect(anchorPreview.showPreview).toHaveBeenCalled();
 
             // showPreview is called but the preview isn't displayed
+            expect(anchorPreview.getPreviewElement().classList.contains('medium-toolbar-arrow-over')).toBe(false);
+        });
+
+        it('should be displayed when the option showWhenToolbarIsVisible is set to true and toolbar is visible', function () {
+            var editor = this.newMediumEditor('.editor', {
+                delay: 200,
+                anchorPreview: {
+                      showWhenToolbarIsVisible: true
+                  },
+                toolbar: {
+                      static: true
+                  }
+            }),
+            anchorPreview = editor.getExtensionByName('anchor-preview'),
+            toolbar = editor.getExtensionByName('toolbar');
+
+            selectElementContentsAndFire(editor.elements[0].firstChild);
+
+            // show preview
+            spyOn(MediumEditor.extensions.anchorPreview.prototype, 'showPreview').and.callThrough();
+            fireEvent(document.getElementById('test-link'), 'mouseover');
+
+            // preview shows only after delay
+            jasmine.clock().tick(250);
+            expect(anchorPreview.showPreview).toHaveBeenCalled();
+            expect(toolbar.isDisplayed()).toBe(true);
+            expect(anchorPreview.getPreviewElement().classList.contains('medium-toolbar-arrow-over')).toBe(true);
+        });
+
+        it('should be displayed when the option showWhenToolbarIsVisible is set to true and toolbar is visible', function () {
+            var editor = this.newMediumEditor('.editor', {
+                delay: 200,
+                anchorPreview: {
+                      showWhenToolbarIsVisible: false
+                  },
+                toolbar: {
+                      static: true
+                  }
+            }),
+            anchorPreview = editor.getExtensionByName('anchor-preview'),
+            toolbar = editor.getExtensionByName('toolbar');
+
+            selectElementContentsAndFire(editor.elements[0].firstChild);
+
+            // show preview
+            spyOn(MediumEditor.extensions.anchorPreview.prototype, 'showPreview').and.callThrough();
+            fireEvent(document.getElementById('test-link'), 'mouseover');
+
+            // preview shows only after delay
+            jasmine.clock().tick(250);
+            expect(anchorPreview.showPreview).not.toHaveBeenCalled();
+            expect(toolbar.isDisplayed()).toBe(true);
             expect(anchorPreview.getPreviewElement().classList.contains('medium-toolbar-arrow-over')).toBe(false);
         });
 

--- a/src/js/extensions/anchor-preview.js
+++ b/src/js/extensions/anchor-preview.js
@@ -16,6 +16,11 @@
          */
         previewValueSelector: 'a',
 
+        /* showWhenToolbarIsVisible: [boolean]
+         * determine if the preview shows up when the toolbar is visible
+         */
+        showWhenToolbarIsVisible: false,
+
         init: function () {
             this.anchorPreview = this.createPreview();
 
@@ -167,7 +172,7 @@
 
             // only show when toolbar is not present
             var toolbar = this.base.getExtensionByName('toolbar');
-            if (toolbar && toolbar.isDisplayed && toolbar.isDisplayed()) {
+            if (!this.showWhenToolbarIsVisible && toolbar && toolbar.isDisplayed && toolbar.isDisplayed()) {
                 return true;
             }
 

--- a/src/js/extensions/anchor-preview.js
+++ b/src/js/extensions/anchor-preview.js
@@ -17,7 +17,7 @@
         previewValueSelector: 'a',
 
         /* showWhenToolbarIsVisible: [boolean]
-         * determine if the preview shows up when the toolbar is visible
+         * determines whether the anchor tag preview shows up when the toolbar is visible
          */
         showWhenToolbarIsVisible: false,
 


### PR DESCRIPTION
New option as discussed here: https://github.com/yabwe/medium-editor/issues/825