### PR TITLE
Embed extension

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,6 +24,7 @@ module.exports = function (grunt) {
             'src/js/extensions/anchor.js',
             'src/js/extensions/anchor-preview.js',
             'src/js/extensions/auto-link.js',
+            'src/js/extensions/embed.js',
             'src/js/extensions/file-dragging.js',
             'src/js/extensions/keyboard-commands.js',
             'src/js/extensions/fontsize.js',

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -703,6 +703,9 @@
                 case 'autoLink':
                     extension = new MediumEditor.extensions.autoLink();
                     break;
+                case 'embed':
+                    extension = new MediumEditor.extensions.embed(this.options.embed);
+                    break;
                 case 'fileDragging':
                     extension = new MediumEditor.extensions.fileDragging(opts);
                     break;

--- a/src/js/extensions/embed.js
+++ b/src/js/extensions/embed.js
@@ -1,0 +1,166 @@
+(function () {
+    'use strict';
+
+    var EmbedForm = MediumEditor.extensions.form.extend({
+        name: 'embed',
+        action: 'embed',
+        aria: 'embed HTML',
+        contentDefault: '<b>&lt;&gt;</b>',
+        contentFA: '<i class="fa fa-code"></i>',
+
+        transforms: [
+            {
+                pattern: /https?:\/\/www\.youtube\.com\/watch\?.*?v=([a-zA-Z0-9]{11})/,
+                embed: '<iframe width="420" height="315" src="https://www.youtube.com/embed/$1" frameborder="0" allowfullscreen></iframe>'
+            }
+        ],
+
+        init: function () {
+            MediumEditor.extensions.form.prototype.init.apply(this, arguments);
+        },
+
+        handleClick: function (event) {
+            event.preventDefault();
+            event.stopPropagation();
+
+            if (!this.isDisplayed()) {
+                this.showForm();
+            }
+
+            return false;
+        },
+
+        getForm: function () {
+            if (!this.form) {
+                this.form = this.createForm();
+            }
+            return this.form;
+        },
+
+        isDisplayed: function () {
+            return this.getForm().style.display === 'block';
+        },
+
+        hideForm: function () {
+            this.getForm().style.display = 'none';
+            this.getInput().value = '';
+        },
+
+        showForm: function () {
+            var input = this.getInput();
+
+            this.base.saveSelection();
+            this.hideToolbarDefaultActions();
+            this.getForm().style.display = 'block';
+            this.setToolbarPosition();
+
+            input.value = '';
+            input.focus();
+        },
+
+        // Called by core when tearing down medium-editor (destroy)
+        destroy: function () {
+            if (!this.form) {
+                return false;
+            }
+
+            if (this.form.parentNode) {
+                this.form.parentNode.removeChild(this.form);
+            }
+
+            delete this.form;
+        },
+
+        // core methods
+
+        doFormSave: function () {
+            this.base.restoreSelection();
+            this.insert();
+            this.base.checkSelection();
+        },
+
+        doFormCancel: function () {
+            this.base.restoreSelection();
+            this.base.checkSelection();
+        },
+
+        // form creation and event handling
+        createForm: function () {
+            var doc = this.document,
+                form = doc.createElement('div'),
+                input = doc.createElement('input'),
+                close = doc.createElement('a'),
+                save = doc.createElement('a');
+
+            // Font Color Form (div)
+            form.className = 'medium-editor-toolbar-form';
+            form.id = 'medium-editor-toolbar-form-embed-' + this.getEditorId();
+
+            // Handle clicks on the form itself
+            this.on(form, 'click', this.handleFormClick.bind(this));
+
+            // Add input
+            input.setAttribute('type', 'input');
+            input.className = 'medium-editor-toolbar-input';
+            form.appendChild(input);
+
+            // Add save buton
+            save.setAttribute('href', '#');
+            save.className = 'medium-editor-toobar-save';
+            save.innerHTML = this.getEditorOption('buttonLabels') === 'fontawesome' ?
+                             '<i class="fa fa-check"></i>' :
+                             '&#10003;';
+            form.appendChild(save);
+
+            // Handle save button clicks (capture)
+            this.on(save, 'click', this.handleSaveClick.bind(this), true);
+
+            // Add close button
+            close.setAttribute('href', '#');
+            close.className = 'medium-editor-toobar-close';
+            close.innerHTML = this.getEditorOption('buttonLabels') === 'fontawesome' ?
+                              '<i class="fa fa-times"></i>' :
+                              '&times;';
+            form.appendChild(close);
+
+            // Handle close button clicks
+            this.on(close, 'click', this.handleCloseClick.bind(this));
+
+            return form;
+        },
+
+        getInput: function () {
+            return this.getForm().querySelector('input.medium-editor-toolbar-input');
+        },
+
+        insert: function () {
+            var embed = this.getInput().value;
+            for (var i = 0; i < this.transforms.length; i++) {
+                if (this.transforms[i].pattern.test(embed)) {
+                    this.base.pasteHTML(embed.replace(this.transforms[i].pattern, this.transforms[i].embed));
+                    return;
+                }
+            }
+            this.base.pasteHTML(embed);
+        },
+
+        handleFormClick: function (event) {
+            // make sure not to hide form when clicking inside the form
+            event.stopPropagation();
+        },
+
+        handleSaveClick: function (event) {
+            // Clicking Save -> create the font color
+            event.preventDefault();
+            this.doFormSave();
+        },
+
+        handleCloseClick: function (event) {
+            // Click Close -> close the form
+            event.preventDefault();
+            this.doFormCancel();
+        }
+    });
+
+    MediumEditor.extensions.embed = EmbedForm;
+}());


### PR DESCRIPTION
I coded a new extension for inserting embeds. I know there's medium-editor-insert-plugin, but I don't like it being dependent on jQuery.

This extension presents the user with an input and then inserts its content to the editor. In between, several transformations can be defined to clean, transform or validate the content. These transformations can be overriden through the embed:transforms option as an array of objects containing the properties "pattern" (a regex) and "embed" (a string). I've added a default where a Youtube URL is converted to an embed:
```javascript
transforms: [
            {
                pattern: /https?:\/\/www\.youtube\.com\/watch\?.*?v=([a-zA-Z0-9]{11})/,
                embed: '<iframe width="420" height="315" src="https://www.youtube.com/embed/$1" frameborder="0" allowfullscreen></iframe>'
            }
        ],
```

I had to code this extension for a project I'm working on and though you could use it. If, for any reason, it's not something you would like to add to the project or think it should live on a separate repository, feel free to discard it.