### PR TITLE
Singleenterblockelement

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -19,6 +19,7 @@ var editor = new MediumEditor('.editor', {
     - [`disableReturn`](#disablereturn)
     - [`disableDoubleReturn`](#disabledoublereturn)
     - [`disableExtraSpaces`](#disableextraspaces)
+    - [`singleEnterBlockElement`](#singleenterblockelement)
     - [`disableEditing`](#disableediting)
     - [`elementsContainer`](#elementscontainer)
     - [`extensions`](#extensions)
@@ -89,6 +90,7 @@ var editor = new MediumEditor('.editable', {
     disableReturn: false,
     disableDoubleReturn: false,
     disableExtraSpaces: false,
+    singleEnterBlockElement: true,
     disableEditing: false,
     elementsContainer: false,
     extensions: {},
@@ -148,6 +150,12 @@ Allows/disallows two (or more) empty new lines. You can also set specific elemen
 **Default:** `false`
 
 When set to true, it disallows spaces at the beginning and end of the element. Also it disallows entering 2 consecutive spaces between 2 words.
+
+***
+#### `singleEnterBlockElement`
+**Default:** `true`
+
+When set to false, upon using the return-key for first time it will add a `br` tag. Upon pressing the return-key twice, it adds a `p` tag.
 
 ***
 #### `disableEditing`

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Using `'fontawesome'` as the buttonLabels requires version 4.1.0 of the fontawes
 * __disableReturn__:  enables/disables the use of the return-key. You can also set specific element behavior by using setting a data-disable-return attribute. Default: `false`
 * __disableDoubleReturn__:  allows/disallows two (or more) empty new lines. You can also set specific element behavior by using setting a data-disable-double-return attribute. Default: `false`
 * __disableExtraSpaces__:  when set to true, it disallows spaces at the beginning and end of the element. Also it disallows entering 2 consecutive spaces between 2 words. Default: `false`
+* __singleEnterBlockElement__:  when set to false, upon pressing return-key for first time will add a br tag and a p tag upon pressing return-key for another time. Default: `true`
 * __disableEditing__: enables/disables adding the contenteditable behavior. Useful for using the toolbar with customized buttons/actions. You can also set specific element behavior by using setting a data-disable-editing attribute. Default: `false`
 * __elementsContainer__: specifies a DOM node to contain MediumEditor's toolbar and anchor preview elements. Default: `document.body`
 * __extensions__: extension to use (see [Custom Buttons and Extensions](src/js/extensions)) for more. Default: `{}`

--- a/spec/content.spec.js
+++ b/spec/content.spec.js
@@ -123,6 +123,70 @@ describe('Content TestCase', function () {
     });
 
     describe('when the enter key is pressed', function () {
+        it('should not do anything when singleEnterBlockElement options is true', function () {
+            this.el.innerHTML = '<p>lorem ipsum</p>';
+
+            var editor = this.newMediumEditor('.editor', { singleEnterBlockElement: true }),
+                evt;
+
+            placeCursorInsideElement(editor.elements[0], 1);
+
+            evt = prepareEvent(editor.elements[0], 'keydown', {
+                keyCode: MediumEditor.util.keyCode.ENTER
+            });
+
+            spyOn(evt, 'preventDefault').and.callThrough();
+
+            firePreparedEvent(evt, editor.elements[0], 'keydown');
+            expect(evt.preventDefault).not.toHaveBeenCalled();
+        });
+
+        it('should add a br tag when enter is pressed once and singleEnterBlockElement options is false', function () {
+            this.el.innerHTML = '<p>lorem ipsum</p>';
+
+            var editor = this.newMediumEditor('.editor', { singleEnterBlockElement: false }),
+                evt;
+
+            placeCursorInsideElement(editor.elements[0], 1);
+
+            evt = prepareEvent(editor.elements[0], 'keydown', {
+                keyCode: MediumEditor.util.keyCode.ENTER
+            });
+
+            spyOn(evt, 'preventDefault').and.callThrough();
+
+            firePreparedEvent(evt, editor.elements[0], 'keydown');
+            expect(evt.preventDefault).toHaveBeenCalled();
+            expect(this.el.innerHTML).toBe('<p>lorem ipsum<br></p>');
+        });
+
+        it('should add a p tag when enter is pressed twice and singleEnterBlockElement options is false', function () {
+            this.el.innerHTML = '<p>lorem ipsum</p>';
+
+            var editor = this.newMediumEditor('.editor', { singleEnterBlockElement: false }),
+                evt;
+
+            placeCursorInsideElement(editor.elements[0], 1);
+
+            evt = prepareEvent(editor.elements[0], 'keydown', {
+                keyCode: MediumEditor.util.keyCode.ENTER
+            });
+
+            spyOn(evt, 'preventDefault').and.callThrough();
+
+            firePreparedEvent(evt, editor.elements[0], 'keydown');
+
+            expect(evt.preventDefault).toHaveBeenCalled();
+            expect(this.el.innerHTML).toBe('<p>lorem ipsum<br></p>');
+
+            //placing cursor and firing second enter
+            //it should remove the br tag added by first enter and add a new p tag
+            placeCursorInsideElement(editor.elements[0], 1);
+            firePreparedEvent(evt, editor.elements[0], 'keydown');
+            expect(evt.preventDefault).toHaveBeenCalled();
+            expect(this.el.innerHTML).toBe('<p>lorem ipsum</p><p></p>');
+        });
+
         it('should prevent new lines from being inserted when disableReturn options is true', function () {
             this.el.innerHTML = 'lorem ipsum';
 

--- a/spec/init.spec.js
+++ b/spec/init.spec.js
@@ -102,6 +102,7 @@ describe('Initialization TestCase', function () {
                 disableDoubleReturn: false,
                 disableExtraSpaces: false,
                 disableEditing: false,
+                singleEnterBlockElement: true,
                 autoLink: false,
                 elementsContainer: document.body,
                 contentWindow: window,

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -22,15 +22,25 @@
                 textRight,
                 newEl;
 
+            if (p.nodeName.toLowerCase() !== 'p') {
+                return;
+            }
+
             textLeft = nodeHtml.substring(0, caretPositions.left);
             textRight = nodeHtml.substring(caretPositions.left, nodeHtml.length);
+
+            event.preventDefault();
 
             //if enter is being pressed twice
             if (textRight.substring(0, 4) === '<br>') {
                 //need to remove the last added br tag, and add a new p tag
-                event.preventDefault();
+                p.innerHTML = textLeft;
+                var newPElement = document.createElement('p');
+                textRight = textRight.substring(4, textRight.length);
+                newPElement.innerHTML = textRight;
+                p.parentNode.insertBefore(newPElement, p.nextSibling);
+                MediumEditor.selection.moveCursor(this.options.ownerDocument, newPElement, 1);
             } else {
-                event.preventDefault();
                 newEl = textLeft + '<br/>' + textRight;
                 p.innerHTML = newEl;
                 MediumEditor.selection.moveCursor(this.options.ownerDocument, p, 1);

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -16,18 +16,24 @@
     function handleDisabledEnterKeydown(event, element) {
         if (!this.options.singleEnterBlockElement) {
             var p = MediumEditor.selection.getSelectionStart(this.options.ownerDocument),
-                br = document.createElement('br');
-            //p_tag = document.createElement('p');
+                caretPositions = MediumEditor.selection.getCaretOffsets(p),
+                nodeHtml = p.innerHTML,
+                textLeft,
+                textRight,
+                newEl;
 
-            if (p.nextSibling.nodeName.toLowerCase() === 'br') {
+            textLeft = nodeHtml.substring(0, caretPositions.left);
+            textRight = nodeHtml.substring(caretPositions.left, nodeHtml.length);
 
-                p.parentNode.removeChild(p.nextSibling);
-                //p.parentNode.insertBefore(p_tag, p.nextSibling);
-                //MediumEditor.selection.moveCursor(this.options.ownerDocument, p_tag);
+            //if enter is being pressed twice
+            if (textRight.substring(0, 4) === '<br>') {
+                //need to remove the last added br tag, and add a new p tag
+                event.preventDefault();
             } else {
                 event.preventDefault();
-                p.parentNode.insertBefore(br, p.nextSibling);
-                //MediumEditor.selection.moveCursor(this.options.ownerDocument, br);
+                newEl = textLeft + '<br/>' + textRight;
+                p.innerHTML = newEl;
+                MediumEditor.selection.moveCursor(this.options.ownerDocument, p, 1);
             }
         } else {
             if (this.options.disableReturn || element.getAttribute('data-disable-return')) {
@@ -151,6 +157,10 @@
     }
 
     function handleKeyup(event) {
+        if (!this.options.singleEnterBlockElement) {
+            return;
+        }
+
         var node = MediumEditor.selection.getSelectionStart(this.options.ownerDocument),
             tagName;
 
@@ -385,7 +395,7 @@
         }
 
         // disabling return or double return
-        if (this.options.disableReturn || this.options.disableDoubleReturn) {
+        if (this.options.disableReturn || this.options.disableDoubleReturn || !this.options.singleEnterBlockElement) {
             this.subscribe('editableKeydownEnter', handleDisabledEnterKeydown.bind(this));
         } else {
             for (i = 0; i < this.elements.length; i += 1) {

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -14,16 +14,33 @@
     }
 
     function handleDisabledEnterKeydown(event, element) {
-        if (this.options.disableReturn || element.getAttribute('data-disable-return')) {
-            event.preventDefault();
-        } else if (this.options.disableDoubleReturn || element.getAttribute('data-disable-double-return')) {
-            var node = MediumEditor.selection.getSelectionStart(this.options.ownerDocument);
+        if (!this.options.singleEnterBlockElement) {
+            var p = MediumEditor.selection.getSelectionStart(this.options.ownerDocument),
+                br = document.createElement('br');
+            //p_tag = document.createElement('p');
 
-            // if current text selection is empty OR previous sibling text is empty OR it is not a list
-            if ((node && node.textContent.trim() === '' && node.nodeName.toLowerCase() !== 'li') ||
-                (node.previousElementSibling && node.previousElementSibling.nodeName.toLowerCase() !== 'br' &&
-                 node.previousElementSibling.textContent.trim() === '')) {
+            if (p.nextSibling.nodeName.toLowerCase() === 'br') {
+
+                p.parentNode.removeChild(p.nextSibling);
+                //p.parentNode.insertBefore(p_tag, p.nextSibling);
+                //MediumEditor.selection.moveCursor(this.options.ownerDocument, p_tag);
+            } else {
                 event.preventDefault();
+                p.parentNode.insertBefore(br, p.nextSibling);
+                //MediumEditor.selection.moveCursor(this.options.ownerDocument, br);
+            }
+        } else {
+            if (this.options.disableReturn || element.getAttribute('data-disable-return')) {
+                event.preventDefault();
+            } else if (this.options.disableDoubleReturn || element.getAttribute('data-disable-double-return')) {
+                var node = MediumEditor.selection.getSelectionStart(this.options.ownerDocument);
+
+                // if current text selection is empty OR previous sibling text is empty OR it is not a list
+                if ((node && node.textContent.trim() === '' && node.nodeName.toLowerCase() !== 'li') ||
+                    (node.previousElementSibling && node.previousElementSibling.nodeName.toLowerCase() !== 'br' &&
+                    node.previousElementSibling.textContent.trim() === '')) {
+                    event.preventDefault();
+                }
             }
         }
     }

--- a/src/js/defaults/options.js
+++ b/src/js/defaults/options.js
@@ -8,6 +8,7 @@
         disableReturn: false,
         disableDoubleReturn: false,
         disableExtraSpaces: false,
+        singleEnterBlockElement: true,
         disableEditing: false,
         autoLink: false,
         elementsContainer: false,


### PR DESCRIPTION
For https://github.com/yabwe/medium-editor/issues/70

Note:
1. Default value of the option ```singleEnterBlockElement``` is ```true```.
2. pressing enter first time adds a ```<br>``` tag.
3. pressing enter again removes the ```<br>``` tag and adds a ```<p>``` element as sibling of the selected node.