### PR TITLE
Updated checklink function to check if a link is a phone number

### DIFF
--- a/spec/anchor.spec.js
+++ b/spec/anchor.spec.js
@@ -200,7 +200,7 @@ describe('Anchor Button TestCase', function () {
             expect(link).not.toBeNull();
             expect(link.href).toBe('http://test.com/');
         });
- 	it('should add tel: if need be and linkValidation option is set to true', function () {
+        it('should add tel: if need be and linkValidation option is set to true', function () {
             var editor = this.newMediumEditor('.editor', {
                 anchor: {
                     linkValidation: true

--- a/spec/anchor.spec.js
+++ b/spec/anchor.spec.js
@@ -200,6 +200,23 @@ describe('Anchor Button TestCase', function () {
             expect(link).not.toBeNull();
             expect(link.href).toBe('http://test.com/');
         });
+ 	it('should add tel: if need be and linkValidation option is set to true', function () {
+            var editor = this.newMediumEditor('.editor', {
+                anchor: {
+                    linkValidation: true
+                }
+            }),
+                link,
+                anchorExtension = editor.getExtensionByName('anchor');
+
+            selectElementContentsAndFire(editor.elements[0]);
+            anchorExtension.showForm('347-999-9999');
+            fireEvent(anchorExtension.getForm().querySelector('a.medium-editor-toolbar-save'), 'click');
+
+            link = editor.elements[0].querySelector('a');
+            expect(link).not.toBeNull();
+            expect(link.href).toBe('tel:347-999-9999');
+        });
         it('should not change protocol when a valid one is included', function () {
             var editor = this.newMediumEditor('.editor', {
                 anchor: {

--- a/src/js/extensions/anchor.js
+++ b/src/js/extensions/anchor.js
@@ -233,16 +233,14 @@
 
         checkLinkFormat: function (value) {
             // var re is a regex for checking if the string is a web or email link
-            var re = /^(https?|ftps?|rtmpt?):\/\/|mailto:/;
+            var re = /^(https?|ftps?|rtmpt?):\/\/|mailto:/,
             // var te is a regex for checking if the string is a telephone number
-            var te = /^\+?\s?\(?(?:\d\s?\-?\)?){3,20}$/;
-            
-            if (te.test(value)){
-		return 'tel:' + value;
-	    } 
-	    else {
-		return (re.test(value) ? '' : 'http://') + value;
-	    }
+            te = /^\+?\s?\(?(?:\d\s?\-?\)?){3,20}$/;
+            if (te.test(value)) {
+                return 'tel:' + value;
+            } else {
+                return (re.test(value) ? '' : 'http://') + value;
+            }
         },
 
         doFormCancel: function () {

--- a/src/js/extensions/anchor.js
+++ b/src/js/extensions/anchor.js
@@ -232,8 +232,15 @@
         },
 
         checkLinkFormat: function (value) {
+            // var re is a regex for checking if the string is a web or email link
             var re = /^(https?|ftps?|rtmpt?):\/\/|mailto:/;
-            return (re.test(value) ? '' : 'http://') + value;
+            // var te is a regex for checking if the string is a telephone number
+            var te = /^\+?\s?\(?(?:\d\s?\-?\)?){3,20}$/;
+            
+            if (te.test(value))
+		return 'tel:' + value;
+	    else
+		return (re.test(value) ? '' : 'http://') + value;
         },
 
         doFormCancel: function () {

--- a/src/js/extensions/anchor.js
+++ b/src/js/extensions/anchor.js
@@ -237,10 +237,12 @@
             // var te is a regex for checking if the string is a telephone number
             var te = /^\+?\s?\(?(?:\d\s?\-?\)?){3,20}$/;
             
-            if (te.test(value))
+            if (te.test(value)){
 		return 'tel:' + value;
-	    else
+	    } 
+	    else {
 		return (re.test(value) ? '' : 'http://') + value;
+	    }
         },
 
         doFormCancel: function () {


### PR DESCRIPTION
Updated checklink function to check if a link is a valid phone number. The test is quite liberal to allow for US and European phone numbers.
If the string is recognized as a phone number, prepend  'tel:'.
otherwise perform previous https / ftps / rtmpt / mailto check.