### PR TITLE
fixed 143 👊

### DIFF
--- a/spec/content.spec.js
+++ b/spec/content.spec.js
@@ -475,6 +475,32 @@ describe('Content TestCase', function () {
         expect(this.el.innerHTML).toMatch(/(<p><br><\/p>)?/);
     });
 
+    describe('when pressing backspace key on blockquote element', function () {
+        it('should remove the blockquote tag and replace it with p tag when cursor is at the start of the blockquote content', function () {
+            this.el.innerHTML = '<blockquote>lorem ipsum</blockquote>';
+            var editor = this.newMediumEditor('.editor'),
+                target = editor.elements[0].querySelector('blockquote');
+
+            placeCursorInsideElement(target, 0);
+            fireEvent(target, 'keydown', {
+                keyCode: MediumEditor.util.keyCode.BACKSPACE
+            });
+            expect(this.el.innerHTML).toBe('<p>lorem ipsum</p>');
+        });
+
+        it('should not change any formatting when cursor is not at the start of the blockquote content', function () {
+            this.el.innerHTML = '<blockquote>lorem ipsum</blockquote>';
+            var editor = this.newMediumEditor('.editor'),
+                target = editor.elements[0].querySelector('blockquote');
+
+            placeCursorInsideElement(target, 1);
+            fireEvent(target, 'keydown', {
+                keyCode: MediumEditor.util.keyCode.BACKSPACE
+            });
+            expect(this.el.innerHTML).toBe('<blockquote>lorem ipsum</blockquote>');
+        });
+    });
+
     describe('when deleting an empty first list item via backspace', function () {
         it('should insert a paragraph before the list if it is the first element in the editor', function () {
             this.el.innerHTML = '<ul><li></li><li>lorem ipsum</li></ul>';

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -131,23 +131,13 @@
 
             event.preventDefault();
         } else if (MediumEditor.util.isKey(event, MediumEditor.util.keyCode.BACKSPACE) &&
-                (tagName === 'blockquote' || node.parentElement.nodeName.toLowerCase() === 'blockquote') &&
+                (MediumEditor.util.getClosestTag(node, 'blockquote') !== false) &&
                 MediumEditor.selection.getCaretOffsets(node).left === 0) {
 
             // when cursor is at the begining of the element and the element is <blockquote>
             // then pressing backspace key should change the <blockquote> to a <p> tag
             event.preventDefault();
-
-            //if <blockquote> is the parent element, then make it the current node
-            if (node.parentElement.nodeName.toLowerCase() === 'blockquote') {
-                node = node.parentElement;
-            }
-
-            p = this.options.ownerDocument.createElement('p');
-            p.innerHTML = node.innerHTML;
-            node.parentElement.insertBefore(p, node);
-            node.parentElement.removeChild(node);
-            MediumEditor.selection.moveCursor(this.options.ownerDocument, p, 0);
+            MediumEditor.util.execFormatBlock(this.options.ownerDocument, 'p');
         }
     }
 

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -130,6 +130,24 @@
             node.parentElement.removeChild(node);
 
             event.preventDefault();
+        } else if (MediumEditor.util.isKey(event, MediumEditor.util.keyCode.BACKSPACE) &&
+                (tagName === 'blockquote' || node.parentElement.nodeName.toLowerCase() === 'blockquote') &&
+                MediumEditor.selection.getCaretOffsets(node).left === 0) {
+
+            // when cursor is at the begining of the element and the element is <blockquote>
+            // then pressing backspace key should change the <blockquote> to a <p> tag
+            event.preventDefault();
+
+            //if <blockquote> is the parent element, then make it the current node
+            if (node.parentElement.nodeName.toLowerCase() === 'blockquote') {
+                node = node.parentElement;
+            }
+
+            p = this.options.ownerDocument.createElement('p');
+            p.innerHTML = node.innerHTML;
+            node.parentElement.insertBefore(p, node);
+            node.parentElement.removeChild(node);
+            MediumEditor.selection.moveCursor(this.options.ownerDocument, p, 0);
         }
     }
 

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -496,7 +496,8 @@
 
             // When FF, we have to handle blockquote node seperately as 'formatblock' does not work.
             // https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand#Commands
-            if (Util.isFF && blockContainer && blockContainer.nodeName.toLowerCase() === 'blockquote' && tagName === 'p') {
+            if (blockContainer && blockContainer.nodeName.toLowerCase() === 'blockquote' && ((Util.isFF && tagName === 'p') ||
+              (Util.isIE && tagName === '<p>'))) {
                 return doc.execCommand('outdent', false, tagName);
             }
 

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -40,6 +40,9 @@
         // by rg89
         isIE: ((navigator.appName === 'Microsoft Internet Explorer') || ((navigator.appName === 'Netscape') && (new RegExp('Trident/.*rv:([0-9]{1,}[.0-9]{0,})').exec(navigator.userAgent) !== null))),
 
+        // if firefox
+        isFF: (navigator.userAgent.toLowerCase().indexOf('firefox') > -1),
+
         // http://stackoverflow.com/a/11752084/569101
         isMac: (window.navigator.platform.toUpperCase().indexOf('MAC') >= 0),
 
@@ -490,6 +493,13 @@
             if (Util.isIE) {
                 tagName = '<' + tagName + '>';
             }
+
+            // When FF, we have to handle blockquote node seperately as 'formatblock' does not work.
+            // https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand#Commands
+            if (Util.isFF && blockContainer && blockContainer.nodeName.toLowerCase() === 'blockquote' && tagName === 'p') {
+                return doc.execCommand('outdent', false, tagName);
+            }
+
             return doc.execCommand('formatBlock', false, tagName);
         },
 


### PR DESCRIPTION
Fixed https://github.com/yabwe/medium-editor/issues/143

Upon pressing backspace key at the start of the ```blockquote``` tag, changes it to ```p``` tag.
Upon pressing backspace key at any position other than start of the element, default action continues.