### PR TITLE
Use editableInput instead of input event for textarea syncing

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -330,6 +330,8 @@
     }
 
     function initElements() {
+        var isTextareaUsed = false;
+
         this.elements.forEach(function (element, index) {
             if (!this.options.disableEditing && !element.getAttribute('data-disable-editing')) {
                 element.setAttribute('contentEditable', true);
@@ -339,14 +341,20 @@
             element.setAttribute('role', 'textbox');
             element.setAttribute('aria-multiline', true);
             element.setAttribute('medium-editor-index', index);
+
+            if (element.hasAttribute('medium-editor-textarea-id')) {
+                isTextareaUsed = true;
+            }
         }, this);
 
-        this.subscribe('editableInput', function (event, editable) {
-            var textarea = editable.parentNode.querySelector('textarea[medium-editor-textarea-id="' + editable.getAttribute('medium-editor-textarea-id') + '"]');
-            if (textarea) {
-                textarea.value = this.serialize()[editable.id].value;
-            }
-        }.bind(this));
+        if (isTextareaUsed) {
+            this.subscribe('editableInput', function (event, editable) {
+                var textarea = editable.parentNode.querySelector('textarea[medium-editor-textarea-id="' + editable.getAttribute('medium-editor-textarea-id') + '"]');
+                if (textarea) {
+                    textarea.value = this.serialize()[editable.id].value;
+                }
+            }.bind(this));
+        }
     }
 
     function attachHandlers() {

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -339,17 +339,14 @@
             element.setAttribute('role', 'textbox');
             element.setAttribute('aria-multiline', true);
             element.setAttribute('medium-editor-index', index);
-
-            if (element.hasAttribute('medium-editor-textarea-id')) {
-                this.on(element, 'input', function (event) {
-                    var target = event.target,
-                        textarea = target.parentNode.querySelector('textarea[medium-editor-textarea-id="' + target.getAttribute('medium-editor-textarea-id') + '"]');
-                    if (textarea) {
-                        textarea.value = this.serialize()[target.id].value;
-                    }
-                }.bind(this));
-            }
         }, this);
+
+        this.subscribe('editableInput', function (event, editable) {
+            var textarea = editable.parentNode.querySelector('textarea[medium-editor-textarea-id="' + editable.getAttribute('medium-editor-textarea-id') + '"]');
+            if (textarea) {
+                textarea.value = this.serialize()[editable.id].value;
+            }
+        }.bind(this));
     }
 
     function attachHandlers() {


### PR DESCRIPTION
Is there a reason why a basic ```input``` event is used for textarea syncing? [My plugin](https://github.com/orthes/medium-editor-insert-plugin) fires your custom ```editableInput``` event everytime an image is added/deleted and this causes a problem when using textareas, because ```input``` event is never fired and textarea is not sycned (https://github.com/orthes/medium-editor-insert-plugin/issues/238).

```editor.serliaze()``` returns correct content, ```editor.subscribe('editableInput')``` is fired, but textarea is not synced.

I also noticed that the editor usually never fires ```input``` event or listens for it. Instead you always use ```editableInput```.

So in this small PR I simply replaced ```input``` event with ```editableInput```. 