### PR TITLE
Fix auto linking with comments

### DIFF
--- a/spec/util.spec.js
+++ b/spec/util.spec.js
@@ -489,5 +489,20 @@ describe('MediumEditor.util', function () {
             expect(parts[2].nodeName.toLowerCase()).toBe('#text');
             expect(parts[2].textContent).toBe('Text Node');
         });
+
+        it('should ignore comments', function () {
+            var comment = document.createComment('comment'),
+                parts = MediumEditor.util.splitByBlockElements(comment);
+            expect(parts.length).toBe(0);
+        });
+
+        it('should ignore nested comments', function () {
+            var el = this.createElement('div');
+            el.innerHTML = '' +
+                  '<p>Text</p>' +
+                  '<!---->';
+            var parts = MediumEditor.util.splitByBlockElements(el);
+            expect(parts.length).toBe(1);
+        });
     });
 });

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -248,6 +248,10 @@
          * <blockquote> container, they are the elements returned.
          */
         splitByBlockElements: function (element) {
+            if (element.nodeType !== 3 && element.nodeType !== 1) {
+                return [];
+            }
+
             var toRet = [],
                 blockElementQuery = MediumEditor.util.blockContainerElementNames.join(',');
 
@@ -259,7 +263,7 @@
                 var child = element.childNodes[i];
                 if (child.nodeType === 3) {
                     toRet.push(child);
-                } else {
+                } else if (child.nodeType === 1) {
                     var blockElements = child.querySelectorAll(blockElementQuery);
                     if (blockElements.length === 0) {
                         toRet.push(child);


### PR DESCRIPTION
This fixes an issue that caused a `child.querySelectorAll is not a function` error when using `autoLink: true` on content with comments.

Closes https://github.com/yabwe/medium-editor/issues/897