### PR TITLE
Fix issue with image-only selections

### DIFF
--- a/spec/anchor.spec.js
+++ b/spec/anchor.spec.js
@@ -557,7 +557,7 @@ describe('Anchor Button TestCase', function () {
 
         // https://github.com/yabwe/medium-editor/issues/803
         it('should update the href of a link containing only an image', function () {
-            this.el.innerHTML = '<a><img src="../demo/img/medium-editor.jpg"></a>';
+            this.el.innerHTML = '<a href="#"><img src="../demo/img/medium-editor.jpg"></a>';
 
             spyOn(MediumEditor.prototype, 'createLink').and.callThrough();
             var editor = this.newMediumEditor('.editor'),

--- a/spec/anchor.spec.js
+++ b/spec/anchor.spec.js
@@ -557,7 +557,7 @@ describe('Anchor Button TestCase', function () {
 
         // https://github.com/yabwe/medium-editor/issues/803
         it('should update the href of a link containing only an image', function () {
-            this.el.innerHTML = '<a><img src="http://image.test.com"></a>';
+            this.el.innerHTML = '<a><img src="../demo/img/medium-editor.jpg"></a>';
 
             spyOn(MediumEditor.prototype, 'createLink').and.callThrough();
             var editor = this.newMediumEditor('.editor'),
@@ -569,12 +569,12 @@ describe('Anchor Button TestCase', function () {
             button = toolbar.getToolbarElement().querySelector('[data-action="createLink"]');
             fireEvent(button, 'click');
             input = editor.getExtensionByName('anchor').getInput();
-            input.value = 'test';
+            input.value = 'http://www.google.com';
             fireEvent(input, 'keyup', {
                 keyCode: MediumEditor.util.keyCode.ENTER
             });
             expect(editor.createLink).toHaveBeenCalled();
-            expect(this.el.innerHTML).toContain('<a href="test"><img src="http://image.test.com"></a>');
+            expect(this.el.innerHTML).toContain('<a href="http://www.google.com"><img src="../demo/img/medium-editor.jpg"></a>');
         });
     });
 

--- a/spec/anchor.spec.js
+++ b/spec/anchor.spec.js
@@ -556,7 +556,7 @@ describe('Anchor Button TestCase', function () {
         });
 
         // https://github.com/yabwe/medium-editor/issues/803
-        it('should update link on image', function () {
+        it('should update the href of a link containing only an image', function () {
             this.el.innerHTML = '<a><img src="http://image.test.com"></a>';
 
             spyOn(MediumEditor.prototype, 'createLink').and.callThrough();

--- a/spec/helpers/util.js
+++ b/spec/helpers/util.js
@@ -34,6 +34,8 @@ function setupTestHelpers() {
             }
         });
 
+        window.getSelection().removeAllRanges();
+
         jasmine.clock().uninstall();
 
         delete this.createElement;

--- a/spec/helpers/util.js
+++ b/spec/helpers/util.js
@@ -34,8 +34,6 @@ function setupTestHelpers() {
             }
         });
 
-        window.getSelection().removeAllRanges();
-
         jasmine.clock().uninstall();
 
         delete this.createElement;

--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -335,4 +335,27 @@ describe('MediumEditor.selection TestCase', function () {
             expect(element).toBe(document);
         });
     });
+
+    describe('selectionContainsContent', function () {
+        it('should return true for non-empty text', function () {
+            this.el.innerHTML = '<p>this is<span> </span>text</p>';
+            selectElementContents(this.el.querySelector('p'));
+
+            expect(MediumEditor.selection.selectionContainsContent(document)).toBe(true);
+        });
+
+        it('should return false for white-space only selections', function () {
+            this.el.innerHTML = '<p>this is<span> </span>text</p>';
+            selectElementContents(this.el.querySelector('span'));
+
+            expect(MediumEditor.selection.selectionContainsContent(document)).toBe(false);
+        });
+
+        it('should return true for image with link selections', function () {
+            this.el.innerHTML = '<p>this is <a href="#"><img src="../demo/img/medium-editor.jpg" /></a> image test</p>';
+            selectElementContents(this.el.querySelector('a'));
+
+            expect(MediumEditor.selection.selectionContainsContent(document)).toBe(true);
+        });
+    });
 });

--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -355,6 +355,7 @@ describe('MediumEditor.selection TestCase', function () {
 
     describe('getSelectedElements', function () {
         it('no selected elements on empty selection', function () {
+            window.getSelection().removeAllRanges();
             var elements = MediumEditor.selection.getSelectedElements(document);
 
             expect(elements.length).toBe(0);

--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -84,19 +84,19 @@ describe('MediumEditor.selection TestCase', function () {
         });
 
         it('should export a selection that specifies an image is the selection', function () {
-            this.el.innerHTML = '<p>lorem ipsum <a href="#"><img src="../img/medium-editor.png" /></a> dolor</p>';
+            this.el.innerHTML = '<p>lorem ipsum <a href="#"><img src="../demo/img/medium-editor.jpg" /></a> dolor</p>';
             selectElementContents(this.el.querySelector('a'));
             var exportedSelection = MediumEditor.selection.exportSelection(this.el, document);
-            expect(exportedSelection.emptyTextSelection).toBe(true);
+            expect(exportedSelection.trailingImageCount).toBe(1);
             expect(exportedSelection.start).toBe(12);
             expect(exportedSelection.end).toBe(12);
         });
 
         it('should export a selection that can be imported when the selection starts with an image', function () {
-            this.el.innerHTML = '<p>lorem ipsum <a href="#"><img src="../img/medium-editor.png" />img</a> dolor</p>';
+            this.el.innerHTML = '<p>lorem ipsum <a href="#"><img src="../demo/img/medium-editor.jpg" />img</a> dolor</p>';
             selectElementContents(this.el.querySelector('a'));
             var exportedSelection = MediumEditor.selection.exportSelection(this.el, document);
-            expect(exportedSelection.emptyTextSelection).toBe(undefined);
+            expect(exportedSelection.trailingImageCount).toBe(undefined);
             expect(exportedSelection.start).toBe(12);
             expect(exportedSelection.end).toBe(15);
 
@@ -114,10 +114,10 @@ describe('MediumEditor.selection TestCase', function () {
         });
 
         it('should export a selection that specifies an image is at the end of a selection', function () {
-            this.el.innerHTML = '<p>lorem ipsum <a href="#">img<img src="../img/medium-editor.png" /></a> dolor</p>';
+            this.el.innerHTML = '<p>lorem ipsum <a href="#">img<b><img src="../demo/img/medium-editor.jpg" /><img src="../demo/img/roman.jpg" /></b></a> dolor</p>';
             selectElementContents(this.el.querySelector('a'));
             var exportedSelection = MediumEditor.selection.exportSelection(this.el, document);
-            expect(exportedSelection.emptyTextSelection).toBe(true);
+            expect(exportedSelection.trailingImageCount).toBe(2);
             expect(exportedSelection.start).toBe(12);
             expect(exportedSelection.end).toBe(15);
         });
@@ -323,15 +323,15 @@ describe('MediumEditor.selection TestCase', function () {
         });
 
         it('should support a selection that specifies an image is the selection', function () {
-            this.el.innerHTML = '<p>lorem ipsum <a href="#"><img src="../img/medium-editor.png" /></a> dolor</p>';
-            MediumEditor.selection.importSelection({ start: 12, end: 12, emptyTextSelection: true }, this.el, document);
+            this.el.innerHTML = '<p>lorem ipsum <a href="#"><img src="../demo/img/medium-editor.jpg" /></a> dolor</p>';
+            MediumEditor.selection.importSelection({ start: 12, end: 12, trailingImageCount: 1 }, this.el, document);
             var range = window.getSelection().getRangeAt(0);
             expect(range.toString()).toBe('');
-            expect(MediumEditor.util.isDescendant(range.startContainer, this.el.querySelector('img'), true)).toBe(true, 'the image is not within the selection');
+            expect(MediumEditor.util.isDescendant(range.endContainer, this.el.querySelector('img'), true)).toBe(true, 'the image is not within the selection');
         });
 
         it('should support a selection that starts with an image', function () {
-            this.el.innerHTML = '<p>lorem ipsum <a href="#"><img src="../img/medium-editor.png" />img</a> dolor</p>';
+            this.el.innerHTML = '<p>lorem ipsum <a href="#"><img src="../demo/img/medium-editor.jpg" />img</a> dolor</p>';
             MediumEditor.selection.importSelection({ start: 12, end: 15 }, this.el, document);
             var range = window.getSelection().getRangeAt(0);
             expect(range.toString()).toBe('img');
@@ -345,8 +345,8 @@ describe('MediumEditor.selection TestCase', function () {
         });
 
         it('should support a selection that ends with an image', function () {
-            this.el.innerHTML = '<p>lorem ipsum <a href="#">img<img src="../img/medium-editor.png" /></a> dolor</p>';
-            MediumEditor.selection.importSelection({ start: 12, end: 15, emptyTextSelection: true }, this.el, document);
+            this.el.innerHTML = '<p>lorem ipsum <a href="#">img<img src="../demo/img/medium-editor.jpg" /><img src="../img/roman.jpg" /></a> dolor</p>';
+            MediumEditor.selection.importSelection({ start: 12, end: 15, trailingImageCount: 2 }, this.el, document);
             var range = window.getSelection().getRangeAt(0);
             expect(range.toString()).toBe('img');
             expect(MediumEditor.util.isDescendant(range.endContainer, this.el.querySelector('img'), true)).toBe(true, 'the image is not within the selection');

--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -82,6 +82,24 @@ describe('MediumEditor.selection TestCase', function () {
             var exportedSelection = MediumEditor.selection.exportSelection(this.el, document);
             expect(exportedSelection.emptyBlocksIndex).toEqual(2);
         });
+
+        it('should export a selection that specifies an image is the selection', function () {
+            this.el.innerHTML = '<p>lorem ipsum <a href="#"><img src="../img/medium-editor.png" /></a> dolor</p>';
+            selectElementContents(this.el.querySelector('a'));
+            var exportedSelection = MediumEditor.selection.exportSelection(this.el, document);
+            expect(exportedSelection.emptyTextSelection).toBe(true);
+            expect(exportedSelection.start).toBe(12);
+            expect(exportedSelection.end).toBe(12);
+        });
+
+        it('should not export a selection that specifies an image is the selection when there is text also selected', function () {
+            this.el.innerHTML = '<p>lorem ipsum<a href="#"> <img src="../img/medium-editor.png" /></a> dolor</p>';
+            selectElementContents(this.el.querySelector('a'));
+            var exportedSelection = MediumEditor.selection.exportSelection(this.el, document);
+            expect(exportedSelection.emptyTextSelection).toBe(undefined);
+            expect(exportedSelection.start).toBe(11);
+            expect(exportedSelection.end).toBe(12);
+        });
     });
 
     describe('importSelection', function () {

--- a/spec/toolbar.spec.js
+++ b/spec/toolbar.spec.js
@@ -168,6 +168,20 @@ describe('MediumEditor.extensions.toolbar TestCase', function () {
             expect(callbackHide).toHaveBeenCalledWith({}, this.el);
         });
 
+        it('should not hide when selecting an image', function () {
+            this.el.innerHTML = '<p>Here is an <a href="#"><img style="width: 100px; heigth: 100px;" src="../demo/img/medium-editor.jpg"></a> image</p>';
+            var editor = this.newMediumEditor('.editor'),
+                toolbar = editor.getExtensionByName('toolbar');
+
+            selectElementContentsAndFire(editor.elements[0].querySelector('a'));
+            fireEvent(editor.elements[0], 'mousedown');
+            fireEvent(document.body, 'mouseup');
+            fireEvent(document.body, 'click');
+            jasmine.clock().tick(51);
+
+            expect(toolbar.isDisplayed()).toBe(true);
+        });
+
         it('should not hide when selecting text within editor, but release mouse outside of editor', function () {
             this.el.innerHTML = 'lorem ipsum';
             var editor = this.newMediumEditor('.editor'),

--- a/spec/toolbar.spec.js
+++ b/spec/toolbar.spec.js
@@ -168,8 +168,8 @@ describe('MediumEditor.extensions.toolbar TestCase', function () {
             expect(callbackHide).toHaveBeenCalledWith({}, this.el);
         });
 
-        it('should not hide when selecting an image', function () {
-            this.el.innerHTML = '<p>Here is an <a href="#"><img style="width: 100px; heigth: 100px;" src="../demo/img/medium-editor.jpg"></a> image</p>';
+        it('should not hide when selecting a link containing only an image', function () {
+            this.el.innerHTML = '<p>Here is an <a href="#"><img src="../demo/img/medium-editor.jpg"></a> image</p>';
             var editor = this.newMediumEditor('.editor'),
                 toolbar = editor.getExtensionByName('toolbar');
 

--- a/spec/util.spec.js
+++ b/spec/util.spec.js
@@ -490,4 +490,66 @@ describe('MediumEditor.util', function () {
             expect(parts[2].textContent).toBe('Text Node');
         });
     });
+
+    describe('findOrCreateMatchingTextNodes', function () {
+        it('should return text nodes within an element', function () {
+            var el = this.createElement('div');
+            el.innerHTML = '<p>Plain <b>bold</b> <a href="#">link</a> <i>italic</i> <u>underline</u> <span>span1 <span>span2</span></span></p>';
+            var textNodes = MediumEditor.util.findOrCreateMatchingTextNodes(document, el, { start: 0, end: el.textContent.length });
+            expect(textNodes.length).toBe(11);
+            expect(textNodes[0].nodeValue).toBe('Plain ');
+            expect(textNodes[9].nodeValue).toBe('span1 ');
+            expect(textNodes[10].nodeValue).toBe('span2');
+        });
+
+        it('should return text nodes within an element given a start and end range', function () {
+            var el = this.createElement('div');
+            el.innerHTML = '<p>Plain <b>bold</b> <a href="#">link</a> <i>italic</i> <u>underline</u> <span>span1 <span>span2</span></span></p>';
+            var textNodes = MediumEditor.util.findOrCreateMatchingTextNodes(document, el, { start: 11, end: 22 });
+            expect(textNodes.length).toBe(3);
+            expect(textNodes[0].nodeValue).toBe('link');
+            expect(textNodes[1].nodeValue).toBe(' ');
+            expect(textNodes[2].nodeValue).toBe('italic');
+        });
+
+        it('should split text nodes if start and end range are in the middle of a text node', function () {
+            var el = this.createElement('div');
+            el.innerHTML = '<p>Plain <b>bold</b> <a href="#">link</a> <i>italic</i> <u>underline</u> <span>span1 <span>span2</span></span></p>';
+            var textNodes = MediumEditor.util.findOrCreateMatchingTextNodes(document, el, { start: 13, end: 19 });
+
+            expect(el.querySelector('a').childNodes.length).toBe(2);
+            expect(el.querySelector('i').childNodes.length).toBe(2);
+            expect(textNodes.length).toBe(3);
+            expect(textNodes[0].nodeValue).toBe('nk');
+            expect(textNodes[1].nodeValue).toBe(' ');
+            expect(textNodes[2].nodeValue).toBe('ita');
+        });
+
+        it('should return an image when it falls within the specified range', function () {
+            var el = this.createElement('div');
+            el.innerHTML = '<p>Plain <b>bold</b> <a href="#">li<img src="../demo.img/medium-editor.jpg" />nk</a> <i>italic</i> <u>underline</u> <span>span1 <span>span2</span></span></p>';
+            var textNodes = MediumEditor.util.findOrCreateMatchingTextNodes(document, el, { start: 11, end: 15 });
+            expect(textNodes.length).toBe(3);
+            expect(textNodes[0].nodeValue).toBe('li');
+            expect(textNodes[1].nodeName.toLowerCase()).toBe('img');
+            expect(textNodes[2].nodeValue).toBe('nk');
+        });
+
+        it('should return an image when it is at the end of the specified range', function () {
+            var el = this.createElement('div');
+            el.innerHTML = '<p>Plain <b>bold</b> <a href="#">link<img src="../demo.img/medium-editor.jpg" /></a> <i>italic</i> <u>underline</u> <span>span1 <span>span2</span></span></p>';
+            var textNodes = MediumEditor.util.findOrCreateMatchingTextNodes(document, el, { start: 11, end: 15 });
+            expect(textNodes.length).toBe(2);
+            expect(textNodes[0].nodeValue).toBe('link');
+            expect(textNodes[1].nodeName.toLowerCase()).toBe('img');
+        });
+
+        it('should return an image when it is the only content in the specified range', function () {
+            var el = this.createElement('div');
+            el.innerHTML = '<p>Plain <b>bold</b> <a href="#"><img src="../demo.img/medium-editor.jpg" /></a> <i>italic</i> <u>underline</u> <span>span1 <span>span2</span></span></p>';
+            var textNodes = MediumEditor.util.findOrCreateMatchingTextNodes(document, el, { start: 11, end: 11 });
+            expect(textNodes.length).toBe(1);
+            expect(textNodes[0].nodeName.toLowerCase()).toBe('img');
+        });
+    });
 });

--- a/spec/util.spec.js
+++ b/spec/util.spec.js
@@ -551,5 +551,15 @@ describe('MediumEditor.util', function () {
             expect(textNodes.length).toBe(1);
             expect(textNodes[0].nodeName.toLowerCase()).toBe('img');
         });
+
+        it('should return images when they are at the beginning of the specified range', function () {
+            var el = this.createElement('div');
+            el.innerHTML = '<p>Plain <b>bold</b> <a href="#"><img src="../demo.img/medium-editor.jpg" /><img src="../demo.img/roman.jpg" />link</a> <i>italic</i> <u>underline</u> <span>span1 <span>span2</span></span></p>';
+            var textNodes = MediumEditor.util.findOrCreateMatchingTextNodes(document, el, { start: 11, end: 15 });
+            expect(textNodes.length).toBe(3);
+            expect(textNodes[0].nodeName.toLowerCase()).toBe('img');
+            expect(textNodes[1].nodeName.toLowerCase()).toBe('img');
+            expect(textNodes[2].nodeValue).toBe('link');
+        });
     });
 });

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -965,7 +965,7 @@
                         // but the selection is contained within the same block element
                         // we want to make sure we create a single link, and not multiple links
                         // which can happen with the built in browser functionality
-                        if (commonAncestorContainer.nodeType !== 3 && startContainerParentElement === endContainerParentElement) {
+                        if (commonAncestorContainer.nodeType !== 3 && commonAncestorContainer.textContent.length !== 0 && startContainerParentElement === endContainerParentElement) {
                             var parentElement = (startContainerParentElement || currentEditor),
                                 fragment = this.options.ownerDocument.createDocumentFragment();
 

--- a/src/js/extensions/toolbar.js
+++ b/src/js/extensions/toolbar.js
@@ -601,8 +601,15 @@
 
             var range = selection.getRangeAt(0),
                 boundary = range.getBoundingClientRect();
+
+            // Handle selections with just images
             if (!boundary || ((boundary.height === 0 && boundary.width === 0) && range.startContainer === range.endContainer)) {
-                boundary = range.startContainer.getBoundingClientRect();
+                // If there's a nested image, use that for the bounding rectangle
+                if (range.startContainer.nodeType === 1 && range.startContainer.querySelector('img')) {
+                    boundary = range.startContainer.querySelector('img').getBoundingClientRect();
+                } else {
+                    boundary = range.startContainer.getBoundingClientRect();
+                }
             }
 
             var windowWidth = this.window.innerWidth,

--- a/src/js/extensions/toolbar.js
+++ b/src/js/extensions/toolbar.js
@@ -410,7 +410,7 @@
             }
 
             // If we don't have a 'valid' selection -> hide toolbar
-            if (this.window.getSelection().toString().trim() === '' ||
+            if (!MediumEditor.selection.selectionContainsContent(this.document) ||
                 (this.allowMultiParagraphSelection === false && this.multipleBlockElementsSelected())) {
                 return this.hideToolbar();
             }
@@ -599,9 +599,13 @@
             // position the toolbar at left 0, so we can get the real width of the toolbar
             this.getToolbarElement().style.left = '0';
 
+            var range = selection.getRangeAt(0),
+                boundary = range.getBoundingClientRect();
+            if (!boundary || ((boundary.height === 0 && boundary.width === 0) && range.startContainer === range.endContainer)) {
+                boundary = range.startContainer.getBoundingClientRect();
+            }
+
             var windowWidth = this.window.innerWidth,
-                range = selection.getRangeAt(0),
-                boundary = range.getBoundingClientRect(),
                 middleBoundary = (boundary.left + boundary.right) / 2,
                 toolbarElement = this.getToolbarElement(),
                 toolbarHeight = toolbarElement.offsetHeight,

--- a/src/js/selection.js
+++ b/src/js/selection.js
@@ -55,7 +55,7 @@
                     end: start + range.toString().length
                 };
 
-                if (selectionState.start === selectionState.end && MediumEditor.selection.selectionContainsContent(doc)) {
+                if (selectionState.start === selectionState.end && this.selectionContainsContent(doc)) {
                     selectionState.emptyContentSelection = true;
                 }
 
@@ -268,17 +268,23 @@
             return emptyBlocksCount;
         },
 
+        // determine if the current selection contains any 'content'
+        // content being and non-white space text or an image
         selectionContainsContent: function (doc) {
             var sel = doc.getSelection();
 
+            // collapsed selection or selection withour range doesn't contain content
             if (!sel || sel.isCollapsed || !sel.rangeCount) {
                 return false;
             }
 
+            // if toString() contains any text, the selection contains some content
             if (sel.toString().trim() !== '') {
                 return true;
             }
 
+            // if selection contains only image(s), it will return empty for toString()
+            // so check for an image manually
             var selectionNode = this.getSelectedParentElement(sel.getRangeAt(0));
             if (selectionNode) {
                 if (selectionNode.nodeName.toLowerCase() === 'img' ||

--- a/src/js/selection.js
+++ b/src/js/selection.js
@@ -128,7 +128,12 @@
                                 trailingImageCount++;
                             }
                             if (trailingImageCount === selectionState.trailingImageCount) {
-                                range.setEnd(node, 0);
+                                // Find which index the image is in its parent's children
+                                var endIndex = 0;
+                                while (node.parentNode.childNodes[endIndex] !== node) {
+                                    endIndex++;
+                                }
+                                range.setEnd(node.parentNode, endIndex + 1);
                                 stop = true;
                             }
                         }

--- a/src/js/selection.js
+++ b/src/js/selection.js
@@ -105,50 +105,53 @@
 
             while (!stop && node) {
                 // Only iterate over elements and text nodes
-                if (node.nodeType <= 3) {
-                    // If we hit a text node, we need to add the amount of characters to the overall count
-                    if (node.nodeType === 3 && !foundEnd) {
-                        nextCharIndex = charIndex + node.length;
-                        if (!foundStart && selectionState.start >= charIndex && selectionState.start <= nextCharIndex) {
-                            range.setStart(node, selectionState.start - charIndex);
-                            foundStart = true;
-                        }
-                        if (foundStart && selectionState.end >= charIndex && selectionState.end <= nextCharIndex) {
-                            if (!selectionState.trailingImageCount) {
-                                range.setEnd(node, selectionState.end - charIndex);
-                                stop = true;
-                            } else {
-                                foundEnd = true;
-                            }
-                        }
-                        charIndex = nextCharIndex;
-                    } else {
-                        if (selectionState.trailingImageCount && foundEnd) {
-                            if (node.nodeName.toLowerCase() === 'img') {
-                                trailingImageCount++;
-                            }
-                            if (trailingImageCount === selectionState.trailingImageCount) {
-                                // Find which index the image is in its parent's children
-                                var endIndex = 0;
-                                while (node.parentNode.childNodes[endIndex] !== node) {
-                                    endIndex++;
-                                }
-                                range.setEnd(node.parentNode, endIndex + 1);
-                                stop = true;
-                            }
-                        }
+                if (node.nodeType > 3) {
+                    continue;
+                }
 
-                        if (!stop && node.nodeType === 1) {
-                            // this is an element
-                            // add all its children to the stack
-                            var i = node.childNodes.length - 1;
-                            while (i >= 0) {
-                                nodeStack.push(node.childNodes[i]);
-                                i -= 1;
+                // If we hit a text node, we need to add the amount of characters to the overall count
+                if (node.nodeType === 3 && !foundEnd) {
+                    nextCharIndex = charIndex + node.length;
+                    if (!foundStart && selectionState.start >= charIndex && selectionState.start <= nextCharIndex) {
+                        range.setStart(node, selectionState.start - charIndex);
+                        foundStart = true;
+                    }
+                    if (foundStart && selectionState.end >= charIndex && selectionState.end <= nextCharIndex) {
+                        if (!selectionState.trailingImageCount) {
+                            range.setEnd(node, selectionState.end - charIndex);
+                            stop = true;
+                        } else {
+                            foundEnd = true;
+                        }
+                    }
+                    charIndex = nextCharIndex;
+                } else {
+                    if (selectionState.trailingImageCount && foundEnd) {
+                        if (node.nodeName.toLowerCase() === 'img') {
+                            trailingImageCount++;
+                        }
+                        if (trailingImageCount === selectionState.trailingImageCount) {
+                            // Find which index the image is in its parent's children
+                            var endIndex = 0;
+                            while (node.parentNode.childNodes[endIndex] !== node) {
+                                endIndex++;
                             }
+                            range.setEnd(node.parentNode, endIndex + 1);
+                            stop = true;
+                        }
+                    }
+
+                    if (!stop && node.nodeType === 1) {
+                        // this is an element
+                        // add all its children to the stack
+                        var i = node.childNodes.length - 1;
+                        while (i >= 0) {
+                            nodeStack.push(node.childNodes[i]);
+                            i -= 1;
                         }
                     }
                 }
+
                 if (!stop) {
                     node = nodeStack.pop();
                 }
@@ -307,35 +310,38 @@
 
             while (!stop && node) {
                 // Only iterate over elements and text nodes
-                if (node.nodeType <= 3) {
-                    if (node.nodeType === 3 && !foundEnd) {
-                        trailingImages = 0;
-                        nextCharIndex = charIndex + node.length;
-                        if (!foundStart && selectionState.start >= charIndex && selectionState.start <= nextCharIndex) {
-                            foundStart = true;
-                        }
-                        if (foundStart && selectionState.end >= charIndex && selectionState.end <= nextCharIndex) {
-                            foundEnd = true;
-                        }
-                        charIndex = nextCharIndex;
-                    } else {
-                        if (node.nodeName.toLowerCase() === 'img') {
-                            trailingImages++;
-                        }
+                if (node.nodeType > 3) {
+                    continue;
+                }
 
-                        if (node === lastNode) {
-                            stop = true;
-                        } else if (node.nodeType === 1) {
-                            // this is an element
-                            // add all its children to the stack
-                            var i = node.childNodes.length - 1;
-                            while (i >= 0) {
-                                nodeStack.push(node.childNodes[i]);
-                                i -= 1;
-                            }
+                if (node.nodeType === 3 && !foundEnd) {
+                    trailingImages = 0;
+                    nextCharIndex = charIndex + node.length;
+                    if (!foundStart && selectionState.start >= charIndex && selectionState.start <= nextCharIndex) {
+                        foundStart = true;
+                    }
+                    if (foundStart && selectionState.end >= charIndex && selectionState.end <= nextCharIndex) {
+                        foundEnd = true;
+                    }
+                    charIndex = nextCharIndex;
+                } else {
+                    if (node.nodeName.toLowerCase() === 'img') {
+                        trailingImages++;
+                    }
+
+                    if (node === lastNode) {
+                        stop = true;
+                    } else if (node.nodeType === 1) {
+                        // this is an element
+                        // add all its children to the stack
+                        var i = node.childNodes.length - 1;
+                        while (i >= 0) {
+                            nodeStack.push(node.childNodes[i]);
+                            i -= 1;
                         }
                     }
                 }
+
                 if (!stop) {
                     node = nodeStack.pop();
                 }

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -184,8 +184,13 @@
                         treeWalker.nextNode();
                     }
                     newNode = null;
-                } else if (startReached && currentNode.tagName.toLowerCase() === 'img') {
-                    matchedNodes.push(currentNode);
+                } else if (currentNode.tagName.toLowerCase() === 'img') {
+                    if (!startReached && (match.start <= currentTextIndex)) {
+                        startReached = true;
+                    }
+                    if (startReached) {
+                        matchedNodes.push(currentNode);
+                    }
                 }
             }
             return matchedNodes;


### PR DESCRIPTION
Currently, medium-editor does not sufficiently handle exporting/importing selections that contain only an image (it's kind of supported in some browsers, but completely busted in IE). Images are a specific problem because:

1. `<img>` elements are not text-nodes _(the code only handled selections that span 1 or more text nodes)_
2. `<img>` elements are elements that will never have children _(the code ignored any element without children)_
3. `<img>` elements have empty textContent _(the code depends on content having length so it can store the beginning and end of a selection)_

medium-editor handles exporting/importing selections based on the number of characters and paragraphs are before and after the selection.  So, if the selection contains only an image, when attempting to restore the selection the code ends up with a collapse selection.

The fixes here allow for wrapping an image in a link, and changing the url of a link on just an image.  This behavior was partially introduce by #803 but the behavior was broken in phantom (preventing extensive tests from being added) and was also broken in IE11 (causing test failures for the entire project).

By fixing this, this fixes the test failures in IE11.