### PR TITLE
Trim src when using the image toolbar button

### DIFF
--- a/spec/buttons.spec.js
+++ b/spec/buttons.spec.js
@@ -736,13 +736,13 @@ describe('Buttons TestCase', function () {
                 button = toolbar.getToolbarElement().querySelector('[data-action="image"]');
             spyOn(document, 'execCommand').and.callThrough();
 
-            this.el.innerHTML = '<span id="span-image">http://i.imgur.com/twlXfUq.jpg</span>';
+            this.el.innerHTML = '<span id="span-image">http://i.imgur.com/twlXfUq.jpg  \n\n</span>';
             selectElementContentsAndFire(document.getElementById('span-image'));
 
             fireEvent(button, 'click');
 
             expect(this.el.innerHTML).toContain('<img src="http://i.imgur.com/twlXfUq.jpg">');
-            expect(document.execCommand).toHaveBeenCalledWith('insertImage', false, window.getSelection());
+            expect(document.execCommand).toHaveBeenCalledWith('insertImage', false, 'http://i.imgur.com/twlXfUq.jpg');
         });
     });
 

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -515,7 +515,8 @@
         }
 
         if (action === 'image') {
-            return this.options.ownerDocument.execCommand('insertImage', false, this.options.contentWindow.getSelection());
+            var src = this.options.contentWindow.getSelection().toString().trim();
+            return this.options.ownerDocument.execCommand('insertImage', false, src);
         }
 
         /* Issue: https://github.com/yabwe/medium-editor/issues/595


### PR DESCRIPTION
This PR trims trailing whitespace and newlines from image urls before inserting them into an `<img>` tag.

**The issue this PR fixes**:
If the src has trailing newlines (it's pretty easy to accidentally select an empty line after the url) browsers display the image just fine, but most email clients do not (i.e. gmail) if the content is used in an email later.