### PR TITLE
Fix #935 - Fix a variety of issues related to selection imports/exports

### DIFF
--- a/spec/helpers/util.js
+++ b/spec/helpers/util.js
@@ -64,6 +64,10 @@ function isFirefox() {
     return navigator.userAgent.toLowerCase().indexOf('firefox') !== -1;
 }
 
+function isSafari() {
+    return navigator.userAgent.toLowerCase().indexOf('safari') !== -1;
+}
+
 function dataURItoBlob(dataURI) {
     // convert base64/URLEncoded data component to raw binary data held in a string
     var byteString,

--- a/spec/helpers/util.js
+++ b/spec/helpers/util.js
@@ -64,10 +64,6 @@ function isFirefox() {
     return navigator.userAgent.toLowerCase().indexOf('firefox') !== -1;
 }
 
-function isPhantom() {
-    return navigator.userAgent.toLowerCase().indexOf('phantomjs') !== -1;
-}
-
 function dataURItoBlob(dataURI) {
     // convert base64/URLEncoded data component to raw binary data held in a string
     var byteString,

--- a/spec/helpers/util.js
+++ b/spec/helpers/util.js
@@ -64,6 +64,10 @@ function isFirefox() {
     return navigator.userAgent.toLowerCase().indexOf('firefox') !== -1;
 }
 
+function isPhantom() {
+    return navigator.userAgent.toLowerCase().indexOf('phantomjs') !== -1;
+}
+
 function dataURItoBlob(dataURI) {
     // convert base64/URLEncoded data component to raw binary data held in a string
     var byteString,

--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -1,4 +1,4 @@
-/*global selectElementContents, placeCursorInsideElement */
+/*global selectElementContents, placeCursorInsideElement, isSafari */
 
 describe('MediumEditor.selection TestCase', function () {
     'use strict';
@@ -164,6 +164,12 @@ describe('MediumEditor.selection TestCase', function () {
             var range = window.getSelection().getRangeAt(0),
                 node = range.startContainer;
 
+            // For some reason, Safari mucks with the selection range and makes this case not hold
+            // since we only really care about whether this works in IE, and it works as expected
+            // in other browsers, just skip this assertion for Safari
+            if (!isSafari()) {
+                expect(MediumEditor.util.isDescendant(link, node, true)).toBe(false);
+            }
             // Even though we set the range to use the P tag as the start container, Safari normalizes the range
             // down to the text node. Setting the range to use the P tag for the start is necessary to support
             // MSIE, where it removes the link when the cursor is placed at the end of the text node in the anchor.
@@ -397,8 +403,6 @@ describe('MediumEditor.selection TestCase', function () {
             MediumEditor.selection.importSelection(exported, this.el, document);
             range = window.getSelection().getRangeAt(0);
             expect(range.collapsed).toBe(true);
-            window.console.log('Start: ' + range.startContainer.nodeName + ' | ' + range.startContainer.nodeValue + ' | ' + range.startOffset);
-            window.console.log('End: ' + range.endContainer.nodeName + ' | ' + range.endContainer.nodeValue + ' | ' + range.endOffset);
             expect(MediumEditor.util.isDescendant(boldText.parentNode, range.startContainer, true)).toBe(true);
             expect(MediumEditor.util.isDescendant(boldText.parentNode, range.endContainer, true)).toBe(true);
         });

--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -385,6 +385,29 @@ describe('MediumEditor.selection TestCase', function () {
             var range = window.getSelection().getRangeAt(0);
             expect(range.toString()).toBe('one');
         });
+
+        it('should support importing a collapsed selection at the end of all content', function () {
+            this.el.innerHTML = '<p>lorem ipsum <b>dolor</b></p>';
+            var boldText = this.el.querySelector('b').firstChild;
+
+            placeCursorInsideElement(boldText, boldText.length);
+            var range = window.getSelection().getRangeAt(0);
+            expect(range.collapsed).toBe(true);
+            expect(MediumEditor.util.isDescendant(boldText.parentNode, range.startContainer, true)).toBe(true);
+            expect(MediumEditor.util.isDescendant(boldText.parentNode, range.endContainer, true)).toBe(true);
+
+            var exported = MediumEditor.selection.exportSelection(this.el, document);
+            expect(exported.start).toBe('lorem ipsum dolor'.length);
+            expect(exported.end).toBe('lorem ipsum dolor'.length);
+
+            MediumEditor.selection.importSelection(exported, this.el, document);
+            range = window.getSelection().getRangeAt(0);
+            expect(range.collapsed).toBe(true);
+            window.console.log('Start: ' + range.startContainer.nodeName + ' | ' + range.startContainer.nodeValue + ' | ' + range.startOffset);
+            window.console.log('End: ' + range.endContainer.nodeName + ' | ' + range.endContainer.nodeValue + ' | ' + range.endOffset);
+            expect(MediumEditor.util.isDescendant(boldText.parentNode, range.startContainer, true)).toBe(true);
+            expect(MediumEditor.util.isDescendant(boldText.parentNode, range.endContainer, true)).toBe(true);
+        });
     });
 
     describe('getSelectedElements', function () {

--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -326,7 +326,7 @@ describe('MediumEditor.selection TestCase', function () {
             selectElementContents(lastLi.firstChild);
 
             var selectionData = MediumEditor.selection.exportSelection(this.el, document);
-            expect(selectionData.emptyBlocksIndex).toBe(0);
+            expect(selectionData.emptyBlocksIndex).toBeUndefined();
 
             MediumEditor.selection.importSelection(selectionData, this.el, document);
             var range = window.getSelection().getRangeAt(0);
@@ -368,7 +368,7 @@ describe('MediumEditor.selection TestCase', function () {
 
         // https://github.com/yabwe/medium-editor/issues/935
         it('should support a selection that is after white-space at the beginning of a paragraph', function () {
-            this.el.innerHTML = ' <p>one two<br><a href="transindex.hu">three</a><br></p><p><a href="amazon.com">one</a> two three</p>';
+            this.el.innerHTML = '   <p>one two<br><a href="transindex.hu">three</a><br></p><p><a href="amazon.com">one</a> two three</p>';
             this.newMediumEditor(this.el);
             var firstText = this.el.querySelector('p').firstChild;
             MediumEditor.selection.select(document, firstText, 0, firstText, 'one'.length);

--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -1,4 +1,4 @@
-/*global selectElementContents, placeCursorInsideElement, isPhantom */
+/*global selectElementContents, placeCursorInsideElement */
 
 describe('MediumEditor.selection TestCase', function () {
     'use strict';
@@ -164,12 +164,6 @@ describe('MediumEditor.selection TestCase', function () {
             var range = window.getSelection().getRangeAt(0),
                 node = range.startContainer;
 
-            // For some reason, phantom mucks with the selection range and makes this case not hold
-            // since we only really care about whether this works in actual browsers, it's ok to
-            // skip this assertion unless we're running in a real browser
-            if (!isPhantom()) {
-                expect(MediumEditor.util.isDescendant(link, node, true)).toBe(false);
-            }
             // Even though we set the range to use the P tag as the start container, Safari normalizes the range
             // down to the text node. Setting the range to use the P tag for the start is necessary to support
             // MSIE, where it removes the link when the cursor is placed at the end of the text node in the anchor.

--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -365,6 +365,18 @@ describe('MediumEditor.selection TestCase', function () {
             expect(range.toString()).toBe('img');
             expect(MediumEditor.util.isDescendant(range.endContainer, this.el.querySelector('img'), true)).toBe(true, 'the image is not within the selection');
         });
+
+        // https://github.com/yabwe/medium-editor/issues/935
+        it('should support a selection that is after white-space at the beginning of a paragraph', function () {
+            this.el.innerHTML = ' <p>one two<br><a href="transindex.hu">three</a><br></p><p><a href="amazon.com">one</a> two three</p>';
+            this.newMediumEditor(this.el);
+            var firstText = this.el.querySelector('p').firstChild;
+            MediumEditor.selection.select(document, firstText, 0, firstText, 'one'.length);
+            var exported = MediumEditor.selection.exportSelection(this.el, document);
+            MediumEditor.selection.importSelection(exported, this.el, document);
+            var range = window.getSelection().getRangeAt(0);
+            expect(range.toString()).toBe('one');
+        });
     });
 
     describe('getSelectedElements', function () {

--- a/spec/util.spec.js
+++ b/spec/util.spec.js
@@ -540,6 +540,32 @@ describe('MediumEditor.util', function () {
         });
     });
 
+    describe('findPreviousSibling', function () {
+        it('should return the previous sibling of an element if it exists', function () {
+            var el = this.createElement('div', '', '<p>first <b>second </b><i>third</i></p><ul><li>fourth</li></ul>'),
+                second = el.querySelector('b'),
+                third = el.querySelector('i'),
+                prevSibling = MediumEditor.util.findPreviousSibling(third);
+            expect(prevSibling).toBe(second);
+        });
+
+        it('should return the previous sibling on an ancestor if a previous sibling does not exist', function () {
+            var el = this.createElement('div', '', '<p>first <b>second </b><i>third</i></p><ul><li>fourth</li></ul>'),
+                fourth = el.querySelector('li').firstChild,
+                p = el.querySelector('p'),
+                prevSibling = MediumEditor.util.findPreviousSibling(fourth);
+            expect(prevSibling).toBe(p);
+        });
+
+        it('should not find a previous sibling if the element is at the beginning of an editor element', function () {
+            var el = this.createElement('div', 'editable', '<p>first <b>second </b><i>third</i></p><ul><li>fourth</li></ul>'),
+                first = el.querySelector('p').firstChild;
+            this.newMediumEditor('.editable');
+            var prevSibling = MediumEditor.util.findPreviousSibling(first);
+            expect(prevSibling).toBeFalsy();
+        });
+    });
+
     describe('findOrCreateMatchingTextNodes', function () {
         it('should return text nodes within an element', function () {
             var el = this.createElement('div');

--- a/spec/util.spec.js
+++ b/spec/util.spec.js
@@ -506,6 +506,40 @@ describe('MediumEditor.util', function () {
         });
     });
 
+    describe('getClosestBlockContainer', function () {
+        it('should return the closest block container', function () {
+            var el = this.createElement('div', '', '<blockquote><p>paragraph</p><ul><li><span>list item</span></li></ul></blockquote>'),
+                span = el.querySelector('span'),
+                container = MediumEditor.util.getClosestBlockContainer(span);
+            expect(container).toBe(el.querySelector('li'));
+        });
+
+        it('should return the parent editable if element is a text node child of the editor', function () {
+            var el = this.createElement('div', 'editable', ' <p>text</p>'),
+                emptyTextNode = el.firstChild;
+            this.newMediumEditor('.editable');
+            var container = MediumEditor.util.getClosestBlockContainer(emptyTextNode);
+            expect(container).toBe(el);
+        });
+    });
+
+    describe('getTopBlockContainer', function () {
+        it('should return the highest level block container', function () {
+            var el = this.createElement('div', '', '<blockquote><p>paragraph</p><ul><li><span>list item</span></li></ul></blockquote>'),
+                span = el.querySelector('span'),
+                container = MediumEditor.util.getTopBlockContainer(span);
+            expect(container).toBe(el.querySelector('blockquote'));
+        });
+
+        it('should return the parent editable if element is a text node child of the editor', function () {
+            var el = this.createElement('div', 'editable', ' <p>text</p>'),
+                emptyTextNode = el.firstChild;
+            this.newMediumEditor('.editable');
+            var container = MediumEditor.util.getTopBlockContainer(emptyTextNode);
+            expect(container).toBe(el);
+        });
+    });
+
     describe('findOrCreateMatchingTextNodes', function () {
         it('should return text nodes within an element', function () {
             var el = this.createElement('div');

--- a/src/js/selection.js
+++ b/src/js/selection.js
@@ -114,8 +114,13 @@
                 if (node.nodeType === 3 && !foundEnd) {
                     nextCharIndex = charIndex + node.length;
                     if (!foundStart && selectionState.start >= charIndex && selectionState.start <= nextCharIndex) {
-                        range.setStart(node, selectionState.start - charIndex);
-                        foundStart = true;
+                        if (node.parentNode === root && selectionState.start === nextCharIndex && node.nextSibling) {
+                            range.setStart(node.nextSibling, 0);
+                            foundStart = true;
+                        } else {
+                            range.setStart(node, selectionState.start - charIndex);
+                            foundStart = true;
+                        }
                     }
                     if (foundStart && selectionState.end >= charIndex && selectionState.end <= nextCharIndex) {
                         if (!selectionState.trailingImageCount) {
@@ -273,8 +278,21 @@
             if (node.nodeType !== 3) {
                 node = cursorContainer.childNodes[cursorOffset];
             }
-            if (node && !MediumEditor.util.isElementAtBeginningOfBlock(node)) {
-                return -1;
+            if (node) {
+                // The element isn't at the beginning of a block, so it has content before it
+                if (!MediumEditor.util.isElementAtBeginningOfBlock(node)) {
+                    return -1;
+                }
+
+                var previousSibling = MediumEditor.util.findPreviousSibling(node);
+                // If there is no previous sibling, this is the first text element in the editor
+                if (!previousSibling) {
+                    return -1;
+                }
+                // If the previous sibling has text, then there are no empty blocks before this
+                else if (previousSibling.nodeValue) {
+                    return -1;
+                }
             }
 
             // Walk over block elements, counting number of empty blocks between last piece of text

--- a/src/js/selection.js
+++ b/src/js/selection.js
@@ -113,8 +113,12 @@
                 // If we hit a text node, we need to add the amount of characters to the overall count
                 if (node.nodeType === 3 && !foundEnd) {
                     nextCharIndex = charIndex + node.length;
+                    // Check if we're at or beyond the start of the selection we're importing
                     if (!foundStart && selectionState.start >= charIndex && selectionState.start <= nextCharIndex) {
-                        if (node.parentNode === root && selectionState.start === nextCharIndex && node.nextSibling) {
+                        // If the start of the selection we're importing is at the end of this text node,
+                        // it's more desirable to have the selection beging at the front of the next node
+                        // rather than the end of this node.
+                        if (selectionState.start === nextCharIndex && node.nextSibling) {
                             range.setStart(node.nextSibling, 0);
                             foundStart = true;
                         } else {
@@ -122,6 +126,7 @@
                             foundStart = true;
                         }
                     }
+                    // We've found the start of the selection, check if we're at or beyond the end of the selection we're importing
                     if (foundStart && selectionState.end >= charIndex && selectionState.end <= nextCharIndex) {
                         if (!selectionState.trailingImageCount) {
                             range.setEnd(node, selectionState.end - charIndex);
@@ -375,7 +380,7 @@
         },
 
         // determine if the current selection contains any 'content'
-        // content being and non-white space text or an image
+        // content being any non-white space text or an image
         selectionContainsContent: function (doc) {
             var sel = doc.getSelection();
 

--- a/src/js/selection.js
+++ b/src/js/selection.js
@@ -246,6 +246,10 @@
                 }
             }
 
+            if (!targetNode) {
+                targetNode = startBlock;
+            }
+
             // We're selecting a high-level block node, so make sure the cursor gets moved into the deepest
             // element at the beginning of the block
             range.setStart(MediumEditor.util.getFirstSelectableLeafNode(targetNode), 0);

--- a/src/js/selection.js
+++ b/src/js/selection.js
@@ -108,7 +108,8 @@
                 trailingImageCount = 0,
                 stop = false,
                 nextCharIndex,
-                allowRangeToStartAtEndOfNode = false;
+                allowRangeToStartAtEndOfNode = false,
+                lastTextNode = null;
 
             // When importing selection, the start of the selection may lie at the end of an element
             // or at the beginning of an element.  Since visually there is no difference between these 2
@@ -138,13 +139,20 @@
                 if (node.nodeType === 3 && !foundEnd) {
                     nextCharIndex = charIndex + node.length;
                     // Check if we're at or beyond the start of the selection we're importing
-                    if (!foundStart &&
-                        selectionState.start >= charIndex &&
-                        (selectionState.start < nextCharIndex || (allowRangeToStartAtEndOfNode && selectionState.start === nextCharIndex))) {
+                    if (!foundStart && selectionState.start >= charIndex && selectionState.start <= nextCharIndex) {
                         // NOTE: We only want to allow a selection to start at the END of an element if
                         //  allowRangeToStartAtEndOfNode is true
-                        range.setStart(node, selectionState.start - charIndex);
-                        foundStart = true;
+                        if (allowRangeToStartAtEndOfNode || selectionState.start < nextCharIndex) {
+                            range.setStart(node, selectionState.start - charIndex);
+                            foundStart = true;
+                        }
+                        // We're at the end of a text node where the selection could start but we shouldn't
+                        // make the selection start here because allowRangeToStartAtEndOfNode is false.
+                        // However, we should keep a reference to this node in case there aren't any more
+                        // text nodes after this, so that we have somewhere to import the selection to
+                        else {
+                            lastTextNode = node;
+                        }
                     }
                     // We've found the start of the selection, check if we're at or beyond the end of the selection we're importing
                     if (foundStart && selectionState.end >= charIndex && selectionState.end <= nextCharIndex) {
@@ -186,6 +194,14 @@
                 if (!stop) {
                     node = nodeStack.pop();
                 }
+            }
+
+            // If we've gone through the entire text but didn't find the beginning of a text node
+            // to make the selection start at, we should fall back to starting the selection
+            // at the END of the last text node we found
+            if (!foundStart && lastTextNode) {
+                range.setStart(lastTextNode, lastTextNode.length);
+                range.setEnd(lastTextNode, lastTextNode.length);
             }
 
             if (typeof selectionState.emptyBlocksIndex !== 'undefined') {

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -864,17 +864,29 @@
             return element && element.nodeType !== 3 && Util.blockContainerElementNames.indexOf(element.nodeName.toLowerCase()) !== -1;
         },
 
+        /* Finds the closest ancestor which is a block container element
+         * If element is within editor element but not within any other block element,
+         * the editor element is returned
+         */
         getClosestBlockContainer: function (node) {
             return Util.traverseUp(node, function (node) {
-                return Util.isBlockContainer(node);
+                return Util.isBlockContainer(node) || Util.isMediumEditorElement(node);
             });
         },
 
+        /* Finds highest level ancestor element which is a block container element
+         * If element is within editor element but not within any other block element,
+         * the editor element is returned
+         */
         getTopBlockContainer: function (element) {
-            var topBlock = element;
+            var topBlock = Util.isBlockContainer(element) ? element : false;
             Util.traverseUp(element, function (el) {
                 if (Util.isBlockContainer(el)) {
                     topBlock = el;
+                }
+                if (!topBlock && Util.isMediumEditorElement(el)) {
+                    topBlock = el;
+                    return true;
                 }
                 return false;
             });

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -316,6 +316,22 @@
             return nextNode;
         },
 
+        // Find an element's previous sibling within a medium-editor element
+        // If one doesn't exist, find the closest ancestor's previous sibling
+        findPreviousSibling: function (node) {
+            if (!node || Util.isMediumEditorElement(node)) {
+                return false;
+            }
+
+            var previousSibling = node.previousSibling;
+            while (!previousSibling && !Util.isMediumEditorElement(node.parentNode)) {
+                node = node.parentNode;
+                previousSibling = node.previousSibling;
+            }
+
+            return previousSibling;
+        },
+
         isDescendant: function isDescendant(parent, child, checkEquality) {
             if (!parent || !child) {
                 return false;


### PR DESCRIPTION
While investigation #935, I found a variety of issues:

* If a selection began in the first `<p>` after some lingering white space, exporting and then importing the selection was busted, as in the selection would not be restored correctly. The result was #935, where trying to create a link within that `<p>` caused an exception to be thrown.
* Previously, `util.getClosestBlockContainer()` and `util. getTopBlockContainer()` would return `false` if the passed in parameter was a node without any block containers other than the editor element.  Thus, the code could return `false` when it really should have been returning the actual editor element (since the editor element is the 'block container' that contains everything).  Our code expected there to be an element, an instead was getting `false`, which was the cause of the previous exception.

After fixing the issue and adding some better tests, more issues popped up:
* When importing a selection, the code should always try to have the range start at the beginning of an element rather than the end of an element.  It wasn't doing this before.
* Importing/exporting selection was broken when the selection began with an `<img>` tag.
* Importing/exporting a collapsed selection at the end of the editor was not working and wasn't be tested.

So after these fixes, in cases where a selection starts in between elements, importing/exporting a selection will always try to make the selection start at the beginning of an element instead of always having it start at the end of an element.  Example:

```html
<p>This is <i>italic text </i><b>and bold text</b></p>
```
If you select the word 'and' inside of the `<b>` tag, and then exported/import selection, the previous code would have the selection start at the end of the 'italic text ' inside of the `<i>` tag.  From a visual standpoint, this is equivalent to having the selection start at the beginning of the `<b>` tag, but from a programatic standpoint there are definite advantages to having the selection be enclosed within the `<b>` tag, not to mention that this is almost always what the user intended.

The code now will have the selection be restored at start at the beginning of the `<b>` tag.  The edge cases where we would want to have the selection start at the end of the `<i>` tag are now treated as edge cases and handle correctly, instead of having all cases behave that way.
