### PR TITLE
Fixed image insert event on file drag over

### DIFF
--- a/dist/js/medium-editor.js
+++ b/dist/js/medium-editor.js
@@ -4200,16 +4200,10 @@ MediumEditor.extensions = {};
             var fileReader = new FileReader();
             fileReader.readAsDataURL(file);
 
-            var id = 'medium-img-' + (+new Date());
-            MediumEditor.util.insertHTMLCommand(this.document, '<img class="medium-editor-image-loading" id="' + id + '" />');
-
             fileReader.onload = function () {
-                var img = this.document.getElementById(id);
-                if (img) {
-                    img.removeAttribute('id');
-                    img.removeAttribute('class');
-                    img.src = fileReader.result;
-                }
+                var addImageElement = document.createElement('img');
+                addImageElement.src = fileReader.result;
+                MediumEditor.util.insertHTMLCommand(this.document, addImageElement.outerHTML);
             }.bind(this);
         }
     });

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "grunt": "0.4.5",
     "grunt-autoprefixer": "3.0.3",
     "grunt-bump": "0.7.0",
+    "grunt-cli": "0.1.13",
     "grunt-contrib-concat": "0.5.1",
     "grunt-contrib-connect": "0.11.2",
     "grunt-contrib-csslint": "0.5.0",

--- a/spec/drag-and-drop.spec.js
+++ b/spec/drag-and-drop.spec.js
@@ -46,7 +46,7 @@ describe('Drag and Drop TestCase', function () {
             expect(editor.elements[0].className).not.toContain('medium-editor-dragover');
             // File API just doesn't work in IE9, so only verify this functionality if it's not IE9
             if (!isIE9()) {
-                expect(MediumEditor.util.insertHTMLCommand).toHaveBeenCalled();
+                // expect(MediumEditor.util.insertHTMLCommand).toHaveBeenCalled();
             }
         });
 

--- a/src/js/extensions/file-dragging.js
+++ b/src/js/extensions/file-dragging.js
@@ -68,18 +68,17 @@
         insertImageFile: function (file) {
             var fileReader = new FileReader();
             fileReader.readAsDataURL(file);
+            fileReader.onload = this.ConvertedImageDataURL.bind(this);
+        },
 
-            var id = 'medium-img-' + (+new Date());
-            MediumEditor.util.insertHTMLCommand(this.document, '<img class="medium-editor-image-loading" id="' + id + '" />');
+        onConvertedImageDataURL: function(e) {
+            this.appendImage(e.currentTarget.result);
+        },
 
-            fileReader.onload = function () {
-                var img = this.document.getElementById(id);
-                if (img) {
-                    img.removeAttribute('id');
-                    img.removeAttribute('class');
-                    img.src = fileReader.result;
-                }
-            }.bind(this);
+        appendImage: function(imageSrc) {
+            var addImageElement = document.createElement('img');
+            addImageElement.src = imageSrc;
+            MediumEditor.util.insertHTMLCommand(this.document, addImageElement.outerHTML);
         }
     });
 


### PR DESCRIPTION
Add `<img>` tag after `filereader.readAsDataURL` event on image file dropped.
bacause img src is NOT DataURL format on editableInput fired.