### PR TITLE
Pre clean replacements

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,8 @@ var editor = new MediumEditor('.editable', {
 
 * __forcePlainText__: Forces pasting as plain text. Default: `true`
 * __cleanPastedHTML__: cleans pasted content from different sources, like google docs etc. Default: `false`
-* __cleanReplacements__: custom pairs (2 element arrays) of RegExp and replacement text to use during paste when __forcePlainText__ or __cleanPastedHTML__ are `true` OR when calling `cleanPaste(text)` helper method. Default: `[]`
+* __preCleanReplacements__: custom pairs (2 element arrays) of RegExp and replacement text to use during paste when __forcePlainText__ or __cleanPastedHTML__ are `true` OR when calling `cleanPaste(text)` helper method.  These replacements are executed _before_ builtin replacements.  Default: `[]`
+* __cleanReplacements__: custom pairs (2 element arrays) of RegExp and replacement text to use during paste when __forcePlainText__ or __cleanPastedHTML__ are `true` OR when calling `cleanPaste(text)` helper method.  These replacements are executed _after_ builtin replacements.  Default: `[]`
 * __cleanAttrs__: list of element attributes to remove during paste when __cleanPastedHTML__ is `true` or when calling `cleanPaste(text)` or `pasteHTML(html,options)` helper methods. Default: `['class', 'style', 'dir']`
 * __cleanTags__: list of element tag names to remove during paste when __cleanPastedHTML__ is `true` or when calling `cleanPaste(text)` or `pasteHTML(html,options)` helper methods. Default: `['meta']`
 

--- a/spec/paste.spec.js
+++ b/spec/paste.spec.js
@@ -285,6 +285,26 @@ describe('Pasting content', function () {
             expect(this.el.innerHTML).toMatch(new RegExp('^Before(&nbsp;|\\s)(<span id="editor-inner">)?<sub>div one</sub><sub>div two</sub>(</span>)?(&nbsp;|\\s)after\\.$'));
         });
 
+        it('should respect custom replacements before builtin replacements.', function () {
+            var editor = this.newMediumEditor('.editor', {
+                paste: {
+                    forcePlainText: false,
+                    cleanPastedHTML: true,
+                    preCleanReplacements: [[new RegExp(/<\/?o:[a-z]*>/gi), 'foo']]
+                }
+            });
+
+            this.el.innerHTML = 'Before&nbsp;<span id="editor-inner">&nbsp;</span>&nbsp;after.';
+            selectElementContents(document.getElementById('editor-inner'));
+
+            // Normally, the paste extension's regular expressions would clear the `<o:p></o:p>` tags,
+            // but our `preCleanReplacements` should transform them each to "foo" before the default
+            // cleanReplacement has a chance to see it.
+            editor.cleanPaste('<div><o:p></o:p></div>');
+
+            expect(this.el.innerHTML).toMatch(new RegExp('foofoo'));
+        });
+
         it('should cleanup only pasted element on multi-line when nothing is selected', function () {
             var editor = this.newMediumEditor('.editor', {
                 paste: {

--- a/src/js/extensions/paste.js
+++ b/src/js/extensions/paste.js
@@ -60,9 +60,17 @@
          */
         cleanPastedHTML: false,
 
+        /* preCleanReplacements: [Array]
+         * custom pairs (2 element arrays) of RegExp and replacement text to use during past when
+         * __forcePlainText__ or __cleanPastedHTML__ are `true` OR when calling `cleanPaste(text)` helper method.
+         * These replacements are executed before any medium editor defined replacements.
+         */
+        preCleanReplacements: [],
+
         /* cleanReplacements: [Array]
          * custom pairs (2 element arrays) of RegExp and replacement text to use during paste when
          * __forcePlainText__ or __cleanPastedHTML__ are `true` OR when calling `cleanPaste(text)` helper method.
+         * These replacements are executed after any medium editor defined replacements.
          */
         cleanReplacements: [],
 
@@ -140,7 +148,10 @@
         cleanPaste: function (text) {
             var i, elList, tmp, workEl,
                 multiline = /<p|<br|<div/.test(text),
-                replacements = createReplacements().concat(this.cleanReplacements || []);
+                replacements = [].concat(
+                    this.preCleanReplacements || [],
+                    createReplacements(),
+                    this.cleanReplacements || []);
 
             for (i = 0; i < replacements.length; i += 1) {
                 text = text.replace(replacements[i][0], replacements[i][1]);


### PR DESCRIPTION
Allow an Array of `cleanReplacements` to execute before builtin replacements.

See #925.