### PR TITLE
Deprecate util.getFirstTextNode

### DIFF
--- a/spec/util.spec.js
+++ b/spec/util.spec.js
@@ -637,4 +637,30 @@ describe('MediumEditor.util', function () {
             expect(textNodes[2].nodeValue).toBe('link');
         });
     });
+
+    // TODO: Remove these tests when getFirstTextNode is deprecated in 6.0.0
+    describe('getFirstTextNode', function () {
+        it('should find the first text node within an element', function () {
+            var el = this.createElement('div', '', '<p><b><i><u><a href="#">First</a> text</u> in</i> editor</b>!</p>'),
+                anchorText = el.querySelector('a').firstChild,
+                firstText = MediumEditor.util.getFirstTextNode(el);
+
+            expect(firstText).toBe(anchorText);
+        });
+
+        it('should return the text node if passed a text node', function () {
+            var el = this.createElement('div', '', '<p>text</p>'),
+                textNode = el.querySelector('p').firstChild,
+                firstText = MediumEditor.util.getFirstTextNode(textNode);
+
+            expect(firstText).toBe(textNode);
+        });
+
+        it('should return null if no text node exists in element', function () {
+            var el = this.createElement('div'),
+                firstText = MediumEditor.util.getFirstTextNode(el);
+
+            expect(firstText).toBeNull();
+        });
+    });
 });

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -940,7 +940,7 @@
             }
 
             for (var i = 0; i < element.childNodes.length; i++) {
-                var textNode = Util.getFirstTextNode(element.childNodes[i]);
+                var textNode = Util._getFirstTextNode(element.childNodes[i]);
                 if (textNode !== null) {
                     return textNode;
                 }

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -928,7 +928,13 @@
             return element;
         },
 
+        // TODO: remove getFirstTextNode AND _getFirstTextNode when jumping in 6.0.0 (no code references)
         getFirstTextNode: function (element) {
+            Util.warn('getFirstTextNode is deprecated and will be removed in version 6.0.0');
+            return Util._getFirstTextNode(element);
+        },
+
+        _getFirstTextNode: function (element) {
             if (element.nodeType === 3) {
                 return element;
             }


### PR DESCRIPTION
Looking at our code coverage numbers, I found a method that is not referenced by our code anymore (`MediumEditor.util.getFirstTextNode()`).  We should get rid of this function since it's not used, however since it changes the API we'll have to settle with just deprecating it for now and remember to remove it in 6.0.0.

Since it's going to be around, and could potentially get used by other code moving forward, we should have coverage of this function.  I've added a few test cases to have 100% coverage of the helper method.