### PR TITLE
Fix some bad image references in tests

### DIFF
--- a/spec/placeholder.spec.js
+++ b/spec/placeholder.spec.js
@@ -24,7 +24,7 @@ describe('MediumEditor.extensions.placeholder TestCase', function () {
     });
 
     it('should not set a placeholder for elements with images only', function () {
-        this.el.innerHTML = '<img src="foo.jpg">';
+        this.el.innerHTML = '<img src="../demo/img/roman.jpg">';
         var editor = this.newMediumEditor('.editor');
         expect(editor.elements[0].className).not.toContain('medium-editor-placeholder');
     });

--- a/spec/selection.spec.js
+++ b/spec/selection.spec.js
@@ -367,7 +367,7 @@ describe('MediumEditor.selection TestCase', function () {
         });
 
         it('should support a selection that ends with an image', function () {
-            this.el.innerHTML = '<p>lorem ipsum <a href="#">img<img src="../demo/img/medium-editor.jpg" /><img src="../img/roman.jpg" /></a> dolor</p>';
+            this.el.innerHTML = '<p>lorem ipsum <a href="#">img<img src="../demo/img/medium-editor.jpg" /><img src="../demo/img/roman.jpg" /></a> dolor</p>';
             MediumEditor.selection.importSelection({ start: 12, end: 15, trailingImageCount: 2 }, this.el, document);
             var range = window.getSelection().getRangeAt(0);
             expect(range.toString()).toBe('img');

--- a/spec/util.spec.js
+++ b/spec/util.spec.js
@@ -602,7 +602,7 @@ describe('MediumEditor.util', function () {
 
         it('should return an image when it falls within the specified range', function () {
             var el = this.createElement('div');
-            el.innerHTML = '<p>Plain <b>bold</b> <a href="#">li<img src="../demo.img/medium-editor.jpg" />nk</a> <i>italic</i> <u>underline</u> <span>span1 <span>span2</span></span></p>';
+            el.innerHTML = '<p>Plain <b>bold</b> <a href="#">li<img src="../demo/img/medium-editor.jpg" />nk</a> <i>italic</i> <u>underline</u> <span>span1 <span>span2</span></span></p>';
             var textNodes = MediumEditor.util.findOrCreateMatchingTextNodes(document, el, { start: 11, end: 15 });
             expect(textNodes.length).toBe(3);
             expect(textNodes[0].nodeValue).toBe('li');
@@ -612,7 +612,7 @@ describe('MediumEditor.util', function () {
 
         it('should return an image when it is at the end of the specified range', function () {
             var el = this.createElement('div');
-            el.innerHTML = '<p>Plain <b>bold</b> <a href="#">link<img src="../demo.img/medium-editor.jpg" /></a> <i>italic</i> <u>underline</u> <span>span1 <span>span2</span></span></p>';
+            el.innerHTML = '<p>Plain <b>bold</b> <a href="#">link<img src="../demo/img/medium-editor.jpg" /></a> <i>italic</i> <u>underline</u> <span>span1 <span>span2</span></span></p>';
             var textNodes = MediumEditor.util.findOrCreateMatchingTextNodes(document, el, { start: 11, end: 15 });
             expect(textNodes.length).toBe(2);
             expect(textNodes[0].nodeValue).toBe('link');
@@ -621,7 +621,7 @@ describe('MediumEditor.util', function () {
 
         it('should return an image when it is the only content in the specified range', function () {
             var el = this.createElement('div');
-            el.innerHTML = '<p>Plain <b>bold</b> <a href="#"><img src="../demo.img/medium-editor.jpg" /></a> <i>italic</i> <u>underline</u> <span>span1 <span>span2</span></span></p>';
+            el.innerHTML = '<p>Plain <b>bold</b> <a href="#"><img src="../demo/img/medium-editor.jpg" /></a> <i>italic</i> <u>underline</u> <span>span1 <span>span2</span></span></p>';
             var textNodes = MediumEditor.util.findOrCreateMatchingTextNodes(document, el, { start: 11, end: 11 });
             expect(textNodes.length).toBe(1);
             expect(textNodes[0].nodeName.toLowerCase()).toBe('img');
@@ -629,7 +629,7 @@ describe('MediumEditor.util', function () {
 
         it('should return images when they are at the beginning of the specified range', function () {
             var el = this.createElement('div');
-            el.innerHTML = '<p>Plain <b>bold</b> <a href="#"><img src="../demo.img/medium-editor.jpg" /><img src="../demo.img/roman.jpg" />link</a> <i>italic</i> <u>underline</u> <span>span1 <span>span2</span></span></p>';
+            el.innerHTML = '<p>Plain <b>bold</b> <a href="#"><img src="../demo/img/medium-editor.jpg" /><img src="../demo/img/roman.jpg" />link</a> <i>italic</i> <u>underline</u> <span>span1 <span>span2</span></span></p>';
             var textNodes = MediumEditor.util.findOrCreateMatchingTextNodes(document, el, { start: 11, end: 15 });
             expect(textNodes.length).toBe(3);
             expect(textNodes[0].nodeName.toLowerCase()).toBe('img');


### PR DESCRIPTION
Some of our tests had broken references to images, this should be fixed now (and there shouldn't be any 404s when running tests in a browser).