### PR TITLE
fix for #939 🔨

### DIFF
--- a/spec/anchor.spec.js
+++ b/spec/anchor.spec.js
@@ -392,6 +392,35 @@ describe('Anchor Button TestCase', function () {
             expect(link.classList.contains('btn-default')).toBe(true);
         });
 
+        it('should remove the target _blank from the anchor tag when the open in a new window checkbox,' +
+                ' is unchecked and the form is saved', function () {
+            var editor = this.newMediumEditor('.editor', {
+                anchor: {
+                    targetCheckbox: true
+                }
+            }),
+                anchorExtension = editor.getExtensionByName('anchor'),
+                targetCheckbox,
+                link;
+
+            selectElementContentsAndFire(editor.elements[0]);
+            anchorExtension.showForm('http://test.com');
+            expect(anchorExtension.isDisplayed()).toBe(true);
+            targetCheckbox = anchorExtension.getForm().querySelector('input.medium-editor-toolbar-anchor-target');
+            targetCheckbox.checked = true;
+            fireEvent(anchorExtension.getForm().querySelector('a.medium-editor-toolbar-save'), 'click');
+            link = editor.elements[0].querySelector('a');
+            expect(link.target).toBe('_blank');
+
+            selectElementContentsAndFire(editor.elements[0]);
+            anchorExtension.showForm('http://test.com');
+            targetCheckbox = anchorExtension.getForm().querySelector('input.medium-editor-toolbar-anchor-target');
+            targetCheckbox.checked = false;
+            fireEvent(anchorExtension.getForm().querySelector('a.medium-editor-toolbar-save'), 'click');
+            link = editor.elements[0].querySelector('a');
+            expect(link.target).toBe('');
+        });
+
         it('should fire editableInput only once when the user creates a link open to a new window,' +
                 ' and it should fire at the end of the DOM and selection modifications', function () {
             spyOn(MediumEditor.prototype, 'createLink').and.callThrough();

--- a/spec/anchor.spec.js
+++ b/spec/anchor.spec.js
@@ -68,7 +68,7 @@ describe('Anchor Button TestCase', function () {
             });
             expect(editor.createLink).toHaveBeenCalled();
             // A trailing <br> may be added when insertHTML is used to add the link internally.
-            expect(this.el.innerHTML.indexOf('<a href="http://test.com">lorem ipsum</a>')).toBe(0);
+            expect(this.el.innerHTML.indexOf('<a href="http://test.com" target="_self">lorem ipsum</a>')).toBe(0);
         });
 
         it('should remove the extra white spaces in the link when user presses enter', function () {
@@ -87,7 +87,7 @@ describe('Anchor Button TestCase', function () {
             });
             expect(editor.createLink).toHaveBeenCalled();
             // A trailing <br> may be added when insertHTML is used to add the link internally.
-            expect(this.el.innerHTML.indexOf('<a href="test">lorem ipsum</a>')).toBe(0);
+            expect(this.el.innerHTML.indexOf('<a href="test" target="_self">lorem ipsum</a>')).toBe(0);
         });
 
         it('should not set any href if all user passes is spaces in the link when user presses enter', function () {
@@ -126,7 +126,7 @@ describe('Anchor Button TestCase', function () {
                 keyCode: MediumEditor.util.keyCode.ENTER
             });
             expect(editor.createLink).toHaveBeenCalled();
-            expect(this.el.innerHTML).toMatch(/^Hello world, <a href="http:\/\/test\.com\/?">this <strong>will become a link<\/strong><\/a><strong>, but this part won\'t\.<\/strong>(<br>|<strong><\/strong>)?$/);
+            expect(this.el.innerHTML).toMatch(/^Hello world, <a href="http:\/\/test\.com\/?" target="_self">this <strong>will become a link<\/strong><\/a><strong>, but this part won\'t\.<\/strong>(<br>|<strong><\/strong>)?$/);
         });
 
         it('should create a link when the user selects text within two paragraphs', function () {
@@ -582,7 +582,7 @@ describe('Anchor Button TestCase', function () {
             // TODO: Find a better way to fix this issue if Edge 12 is going to matter
             var edgeVersion = getEdgeVersion();
             if (!edgeVersion || edgeVersion >= 13) {
-                expect(this.el.innerHTML).toContain('<a href="http://www.google.com"><img src="../demo/img/medium-editor.jpg"></a>');
+                expect(this.el.innerHTML).toContain('<a href="http://www.google.com" target="_self"><img src="../demo/img/medium-editor.jpg"></a>');
             }
         });
     });

--- a/spec/anchor.spec.js
+++ b/spec/anchor.spec.js
@@ -1,5 +1,5 @@
 /*global fireEvent, selectElementContents,
-         selectElementContentsAndFire, getEdgeVersion*/
+         selectElementContentsAndFire, getEdgeVersion */
 
 describe('Anchor Button TestCase', function () {
     'use strict';

--- a/spec/anchor.spec.js
+++ b/spec/anchor.spec.js
@@ -1,6 +1,5 @@
 /*global fireEvent, selectElementContents,
-         selectElementContentsAndFire, getEdgeVersion,
-         isFirefox*/
+         selectElementContentsAndFire, getEdgeVersion*/
 
 describe('Anchor Button TestCase', function () {
     'use strict';
@@ -69,11 +68,7 @@ describe('Anchor Button TestCase', function () {
             });
             expect(editor.createLink).toHaveBeenCalled();
             // A trailing <br> may be added when insertHTML is used to add the link internally.
-            if (!isFirefox()) {
-                expect(this.el.innerHTML.indexOf('<a href="http://test.com" target="_self">lorem ipsum</a>')).toBe(0);
-            } else {
-                expect(this.el.innerHTML.indexOf('<a target="_self" href="http://test.com">lorem ipsum</a>')).toBe(0);
-            }
+            expect(this.el.innerHTML.indexOf('<a href="http://test.com">lorem ipsum</a>')).toBe(0);
         });
 
         it('should remove the extra white spaces in the link when user presses enter', function () {
@@ -92,11 +87,7 @@ describe('Anchor Button TestCase', function () {
             });
             expect(editor.createLink).toHaveBeenCalled();
             // A trailing <br> may be added when insertHTML is used to add the link internally.
-            if (!isFirefox()) {
-                expect(this.el.innerHTML.indexOf('<a href="test" target="_self">lorem ipsum</a>')).toBe(0);
-            } else {
-                expect(this.el.innerHTML.indexOf('<a target="_self" href="test">lorem ipsum</a>')).toBe(0);
-            }
+            expect(this.el.innerHTML.indexOf('<a href="test">lorem ipsum</a>')).toBe(0);
         });
 
         it('should not set any href if all user passes is spaces in the link when user presses enter', function () {
@@ -135,11 +126,7 @@ describe('Anchor Button TestCase', function () {
                 keyCode: MediumEditor.util.keyCode.ENTER
             });
             expect(editor.createLink).toHaveBeenCalled();
-            if (!isFirefox()) {
-                expect(this.el.innerHTML).toMatch(/^Hello world, <a href="http:\/\/test\.com\/?" target="_self">this <strong>will become a link<\/strong><\/a><strong>, but this part won\'t\.<\/strong>(<br>|<strong><\/strong>)?$/);
-            } else {
-                expect(this.el.innerHTML).toMatch(/^Hello world, <a target="_self" href="http:\/\/test\.com\/?">this <strong>will become a link<\/strong><\/a><strong>, but this part won\'t\.<\/strong>(<br>|<strong><\/strong>)?$/);
-            }
+            expect(this.el.innerHTML).toMatch(/^Hello world, <a href="http:\/\/test\.com\/?">this <strong>will become a link<\/strong><\/a><strong>, but this part won\'t\.<\/strong>(<br>|<strong><\/strong>)?$/);
         });
 
         it('should create a link when the user selects text within two paragraphs', function () {
@@ -594,10 +581,8 @@ describe('Anchor Button TestCase', function () {
             // So for the sake of sanity, disabling this check for Edge 12.
             // TODO: Find a better way to fix this issue if Edge 12 is going to matter
             var edgeVersion = getEdgeVersion();
-            if (isFirefox()) {
-                expect(this.el.innerHTML).toContain('<a target="_self" href="http://www.google.com"><img src="../demo/img/medium-editor.jpg"></a>');
-            } else if (!edgeVersion || edgeVersion >= 13) {
-                expect(this.el.innerHTML).toContain('<a href="http://www.google.com" target="_self"><img src="../demo/img/medium-editor.jpg"></a>');
+            if (!edgeVersion || edgeVersion >= 13) {
+                expect(this.el.innerHTML).toContain('<a href="http://www.google.com"><img src="../demo/img/medium-editor.jpg"></a>');
             }
         });
     });

--- a/spec/anchor.spec.js
+++ b/spec/anchor.spec.js
@@ -1,5 +1,6 @@
 /*global fireEvent, selectElementContents,
-         selectElementContentsAndFire, getEdgeVersion */
+         selectElementContentsAndFire, getEdgeVersion,
+         isFirefox*/
 
 describe('Anchor Button TestCase', function () {
     'use strict';
@@ -68,7 +69,11 @@ describe('Anchor Button TestCase', function () {
             });
             expect(editor.createLink).toHaveBeenCalled();
             // A trailing <br> may be added when insertHTML is used to add the link internally.
-            expect(this.el.innerHTML.indexOf('<a href="http://test.com" target="_self">lorem ipsum</a>')).toBe(0);
+            if (!isFirefox()) {
+                expect(this.el.innerHTML.indexOf('<a href="http://test.com" target="_self">lorem ipsum</a>')).toBe(0);
+            } else {
+                expect(this.el.innerHTML.indexOf('<a target="_self" href="http://test.com">lorem ipsum</a>')).toBe(0);
+            }
         });
 
         it('should remove the extra white spaces in the link when user presses enter', function () {
@@ -87,7 +92,11 @@ describe('Anchor Button TestCase', function () {
             });
             expect(editor.createLink).toHaveBeenCalled();
             // A trailing <br> may be added when insertHTML is used to add the link internally.
-            expect(this.el.innerHTML.indexOf('<a href="test" target="_self">lorem ipsum</a>')).toBe(0);
+            if (!isFirefox()) {
+                expect(this.el.innerHTML.indexOf('<a href="test" target="_self">lorem ipsum</a>')).toBe(0);
+            } else {
+                expect(this.el.innerHTML.indexOf('<a target="_self" href="test">lorem ipsum</a>')).toBe(0);
+            }
         });
 
         it('should not set any href if all user passes is spaces in the link when user presses enter', function () {
@@ -126,7 +135,11 @@ describe('Anchor Button TestCase', function () {
                 keyCode: MediumEditor.util.keyCode.ENTER
             });
             expect(editor.createLink).toHaveBeenCalled();
-            expect(this.el.innerHTML).toMatch(/^Hello world, <a href="http:\/\/test\.com\/?" target="_self">this <strong>will become a link<\/strong><\/a><strong>, but this part won\'t\.<\/strong>(<br>|<strong><\/strong>)?$/);
+            if (!isFirefox()) {
+                expect(this.el.innerHTML).toMatch(/^Hello world, <a href="http:\/\/test\.com\/?" target="_self">this <strong>will become a link<\/strong><\/a><strong>, but this part won\'t\.<\/strong>(<br>|<strong><\/strong>)?$/);
+            } else {
+                expect(this.el.innerHTML).toMatch(/^Hello world, <a target="_self" href="http:\/\/test\.com\/?">this <strong>will become a link<\/strong><\/a><strong>, but this part won\'t\.<\/strong>(<br>|<strong><\/strong>)?$/);
+            }
         });
 
         it('should create a link when the user selects text within two paragraphs', function () {
@@ -581,7 +594,9 @@ describe('Anchor Button TestCase', function () {
             // So for the sake of sanity, disabling this check for Edge 12.
             // TODO: Find a better way to fix this issue if Edge 12 is going to matter
             var edgeVersion = getEdgeVersion();
-            if (!edgeVersion || edgeVersion >= 13) {
+            if (isFirefox()) {
+                expect(this.el.innerHTML).toContain('<a target="_self" href="http://www.google.com"><img src="../demo/img/medium-editor.jpg"></a>');
+            } else if (!edgeVersion || edgeVersion >= 13) {
                 expect(this.el.innerHTML).toContain('<a href="http://www.google.com" target="_self"><img src="../demo/img/medium-editor.jpg"></a>');
             }
         });

--- a/spec/util.spec.js
+++ b/spec/util.spec.js
@@ -99,6 +99,28 @@ describe('MediumEditor.util', function () {
         });
     });
 
+    describe('settargetself', function () {
+        it('sets target self on a A element from a A element', function () {
+            var el = this.createElement('a', '', 'lorem ipsum');
+            el.attributes.href = 'http://0.0.0.0/bar.html';
+
+            MediumEditor.util.setTargetSelf(el, 'http://0.0.0.0/bar.html');
+
+            expect(el.target).toBe('_self');
+        });
+
+        it('sets target blank on a A element from a DIV element', function () {
+            var el = this.createElement('div', '', '<a href="http://1.1.1.1/foo.html">foo</a> <a href="http://0.0.0.0/bar.html">bar</a>');
+
+            MediumEditor.util.setTargetSelf(el, 'http://0.0.0.0/bar.html');
+
+            var nodes = el.getElementsByTagName('a');
+
+            expect(nodes[0].target).not.toBe('_self');
+            expect(nodes[1].target).toBe('_self');
+        });
+    });
+
     describe('addClassToAnchors', function () {
         it('add class to anchors on a A element from a A element', function () {
             var el = this.createElement('a', '', 'lorem ipsum');

--- a/spec/util.spec.js
+++ b/spec/util.spec.js
@@ -99,25 +99,26 @@ describe('MediumEditor.util', function () {
         });
     });
 
-    describe('settargetself', function () {
+    describe('removetargetblank', function () {
         it('sets target self on a A element from a A element', function () {
             var el = this.createElement('a', '', 'lorem ipsum');
             el.attributes.href = 'http://0.0.0.0/bar.html';
+            el.attributes.target = '_blank';
 
-            MediumEditor.util.setTargetSelf(el, 'http://0.0.0.0/bar.html');
+            MediumEditor.util.removeTargetBlank(el, 'http://0.0.0.0/bar.html');
 
-            expect(el.target).toBe('_self');
+            expect(el.target).toBe('');
         });
 
         it('sets target blank on a A element from a DIV element', function () {
-            var el = this.createElement('div', '', '<a href="http://1.1.1.1/foo.html">foo</a> <a href="http://0.0.0.0/bar.html">bar</a>');
+            var el = this.createElement('div', '', '<a href="http://1.1.1.1/foo.html" target="_blank">foo</a> <a href="http://0.0.0.0/bar.html" target="_blank">bar</a>');
 
-            MediumEditor.util.setTargetSelf(el, 'http://0.0.0.0/bar.html');
+            MediumEditor.util.removeTargetBlank(el, 'http://0.0.0.0/bar.html');
 
             var nodes = el.getElementsByTagName('a');
 
-            expect(nodes[0].target).not.toBe('_self');
-            expect(nodes[1].target).toBe('_self');
+            expect(nodes[0].target).toBe('_blank');
+            expect(nodes[1].target).toBe('');
         });
     });
 

--- a/spec/util.spec.js
+++ b/spec/util.spec.js
@@ -100,7 +100,7 @@ describe('MediumEditor.util', function () {
     });
 
     describe('removetargetblank', function () {
-        it('sets target self on a A element from a A element', function () {
+        it('removes target blank from a A element', function () {
             var el = this.createElement('a', '', 'lorem ipsum');
             el.attributes.href = 'http://0.0.0.0/bar.html';
             el.attributes.target = '_blank';
@@ -110,7 +110,7 @@ describe('MediumEditor.util', function () {
             expect(el.target).toBe('');
         });
 
-        it('sets target blank on a A element from a DIV element', function () {
+        it('removes target blank on a A element from a DIV element', function () {
             var el = this.createElement('div', '', '<a href="http://1.1.1.1/foo.html" target="_blank">foo</a> <a href="http://0.0.0.0/bar.html" target="_blank">bar</a>');
 
             MediumEditor.util.removeTargetBlank(el, 'http://0.0.0.0/bar.html');

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -1046,7 +1046,7 @@
                         if (this.options.targetBlank || opts.target === '_blank') {
                             MediumEditor.util.setTargetBlank(MediumEditor.selection.getSelectionStart(this.options.ownerDocument), opts.url);
                         } else {
-                            MediumEditor.util.setTargetSelf(MediumEditor.selection.getSelectionStart(this.options.ownerDocument), opts.url);
+                            MediumEditor.util.removeTargetBlank(MediumEditor.selection.getSelectionStart(this.options.ownerDocument), opts.url);
                         }
 
                         if (opts.buttonClass) {

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -1045,6 +1045,8 @@
 
                         if (this.options.targetBlank || opts.target === '_blank') {
                             MediumEditor.util.setTargetBlank(MediumEditor.selection.getSelectionStart(this.options.ownerDocument), opts.url);
+                        } else {
+                            MediumEditor.util.setTargetSelf(MediumEditor.selection.getSelectionStart(this.options.ownerDocument), opts.url);
                         }
 
                         if (opts.buttonClass) {

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -585,8 +585,8 @@
         },
 
         /*
-         * this function is called to explicitly remove the target='_blank' and set it to '_self'
-         * as FF holds on to _blank value even after unchecking the checkbox on anchor form
+         * this function is called to explicitly remove the target='_blank' as FF holds on to _blank value even
+         * after unchecking the checkbox on anchor form
          */
         removeTargetBlank: function (el, anchorUrl) {
             var i;

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -584,6 +584,25 @@
             }
         },
 
+        /*
+         * this function is called to explicitly remove the target='_blank' and set it to '_self'
+         * as FF holds on to _blank value even after unchecking the checkbox on anchor form
+         */
+        setTargetSelf: function (el, anchorUrl) {
+            var i;
+            if (el.nodeName.toLowerCase() === 'a') {
+                el.target = '_self';
+            } else {
+                el = el.getElementsByTagName('a');
+
+                for (i = 0; i < el.length; i += 1) {
+                    if (anchorUrl === el[i].attributes.href.value) {
+                        el[i].target = '_self';
+                    }
+                }
+            }
+        },
+
         addClassToAnchors: function (el, buttonClass) {
             var classes = buttonClass.split(' '),
                 i,

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -588,16 +588,16 @@
          * this function is called to explicitly remove the target='_blank' and set it to '_self'
          * as FF holds on to _blank value even after unchecking the checkbox on anchor form
          */
-        setTargetSelf: function (el, anchorUrl) {
+        removeTargetBlank: function (el, anchorUrl) {
             var i;
             if (el.nodeName.toLowerCase() === 'a') {
-                el.target = '_self';
+                el.removeAttribute('target');
             } else {
                 el = el.getElementsByTagName('a');
 
                 for (i = 0; i < el.length; i += 1) {
                     if (anchorUrl === el[i].attributes.href.value) {
-                        el[i].target = '_self';
+                        el[i].removeAttribute('target');
                     }
                 }
             }


### PR DESCRIPTION
Added a function `setTargetSelf` along the lines of `setTargetBlank`.

It is called whenever target is not suppose to be blank. The need to do this came up because of #939 . It worked well on all browsers except Firefox. So had to specifically remove target blank from the anchor tags. And one of the way I think to remove is to set it to `_self`.