### PR TITLE
Fix #834 - Don't call formatblock when cursor is within block element

### DIFF
--- a/spec/content.spec.js
+++ b/spec/content.spec.js
@@ -308,16 +308,58 @@ describe('Content TestCase', function () {
         });
 
         it('should call formatBlock when inside a non-header and non-anchor', function () {
-            this.el.innerHTML = '<p>lorem ipsum</p>';
+            this.el.innerHTML = '<p>lorem <span>ipsum</span></p>';
             var editor = this.newMediumEditor('.editor'),
-                targetNode = editor.elements[0].querySelector('p');
+                targetNode = editor.elements[0].querySelector('span').firstChild;
             spyOn(document, 'execCommand').and.callThrough();
-            placeCursorInsideElement(targetNode, 0);
+            placeCursorInsideElement(targetNode, targetNode.textContent.length - 1);
             fireEvent(targetNode, 'keyup', {
                 keyCode: MediumEditor.util.keyCode.ENTER
             });
             expect(document.execCommand).toHaveBeenCalledWith('formatBlock', false, 'p');
-            expect(this.el.innerHTML).toBe('<p>lorem ipsum</p>');
+        });
+
+        it('should not call formatBlock when inside an anchor', function () {
+            var html = '<p>lorem <a href="#">ipsum</a></p>';
+            this.el.innerHTML = html;
+            var editor = this.newMediumEditor('.editor'),
+                targetNode = editor.elements[0].querySelector('a').firstChild;
+            spyOn(document, 'execCommand').and.callThrough();
+            placeCursorInsideElement(targetNode, targetNode.textContent.length - 1);
+            fireEvent(targetNode, 'keyup', {
+                keyCode: MediumEditor.util.keyCode.ENETER
+            });
+            expect(document.execCommand).not.toHaveBeenCalled();
+            expect(this.el.innerHTML).toBe(html);
+        });
+
+        // https://github.com/yabwe/medium-editor/issues/834
+        it('should not call formatBlock when inside a figCaption', function () {
+            var html = '<figure><img src="../demo/img/medium-editor.jpg"><figcaption>ipsum</figcaption></figure>';
+            this.el.innerHTML = html;
+            var editor = this.newMediumEditor('.editor'),
+                targetNode = editor.elements[0].querySelector('figCaption').firstChild;
+            spyOn(document, 'execCommand').and.callThrough();
+            placeCursorInsideElement(targetNode, targetNode.textContent.length - 1);
+            fireEvent(targetNode, 'keyup', {
+                keyCode: MediumEditor.util.keyCode.ENETER
+            });
+            expect(document.execCommand).not.toHaveBeenCalled();
+            expect(this.el.innerHTML).toBe(html);
+        });
+
+        it('should not call formatBlock when inside a header', function () {
+            var html = '<h1>lorem ipsum</h1>';
+            this.el.innerHTML = html;
+            var editor = this.newMediumEditor('.editor'),
+                targetNode = editor.elements[0].querySelector('h1').firstChild;
+            spyOn(document, 'execCommand').and.callThrough();
+            placeCursorInsideElement(targetNode, targetNode.textContent.length - 1);
+            fireEvent(targetNode, 'keyup', {
+                keyCode: MediumEditor.util.keyCode.ENETER
+            });
+            expect(document.execCommand).not.toHaveBeenCalled();
+            expect(this.el.innerHTML).toBe(html);
         });
 
         it('with ctrl key, should not call formatBlock', function () {

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -165,9 +165,7 @@
             if (tagName === 'a') {
                 this.options.ownerDocument.execCommand('unlink', false, null);
             } else if (!event.shiftKey && !event.ctrlKey) {
-                if (!/h\d|figCaption/i.test(tagName)) {
-                    this.options.ownerDocument.execCommand('formatBlock', false, 'p');
-                }
+                this.options.ownerDocument.execCommand('formatBlock', false, 'p');
             }
         }
     }

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -153,15 +153,18 @@
             this.options.ownerDocument.execCommand('formatBlock', false, 'p');
         }
 
-        if (MediumEditor.util.isKey(event, MediumEditor.util.keyCode.ENTER) && !MediumEditor.util.isListItem(node)) {
+        // https://github.com/yabwe/medium-editor/issues/834
+        // https://github.com/yabwe/medium-editor/pull/382
+        // Don't call format block if this is a block element (ie h1, figCaption, etc.)
+        if (MediumEditor.util.isKey(event, MediumEditor.util.keyCode.ENTER) &&
+            !MediumEditor.util.isListItem(node) &&
+            !MediumEditor.util.isBlockContainer(node)) {
+
             tagName = node.nodeName.toLowerCase();
             // For anchor tags, unlink
             if (tagName === 'a') {
                 this.options.ownerDocument.execCommand('unlink', false, null);
             } else if (!event.shiftKey && !event.ctrlKey) {
-                // only format block if this is not a header tag
-                // calling formatBlock on firefox will cause incoorect layout if pressed enter in the figcaption
-                // #https://github.com/orthes/medium-editor-insert-plugin/issues/230
                 if (!/h\d|figCaption/i.test(tagName)) {
                     this.options.ownerDocument.execCommand('formatBlock', false, 'p');
                 }


### PR DESCRIPTION
This is a continuation of @ryandh 's work in #835.

When the cursor is directly within a block element (ie `<figcaption>`, `<h1>`, etc.), when the code calls `document.execCommand('formatBlock', null, 'p')` it did some unsavory things to the html, and in the case of `<figcaption>` in Firefox, it actually would keep moving the cursor to the beginning of the line after each keystroke, which presented your text in reverse order.