### PR TITLE
Remove hardcoded inlined display style for anchor editor

### DIFF
--- a/spec/anchor.spec.js
+++ b/spec/anchor.spec.js
@@ -14,6 +14,23 @@ describe('Anchor Button TestCase', function () {
     });
 
     describe('Anchor Form', function () {
+        it('should add class for visible state and remove it for invisivble', function () {
+            var editor = this.newMediumEditor('.editor', {
+                    buttonLabels: 'fontawesome'
+                }),
+                anchorExtension = editor.getExtensionByName('anchor'),
+                toolbar = editor.getExtensionByName('toolbar'),
+                activeClass = anchorExtension.activeClass;
+
+            selectElementContentsAndFire(editor.elements[0]);
+            var button = toolbar.getToolbarElement().querySelector('[data-action="createLink"]');
+            fireEvent(button, 'click');
+            expect(anchorExtension.getForm().classList.contains(activeClass)).toBe(true);
+
+            fireEvent(anchorExtension.getForm().querySelector('a.medium-editor-toolbar-save'), 'click');
+            expect(anchorExtension.getForm().classList.contains(activeClass)).toBe(false);
+        });
+
         it('should not hide the toolbar when mouseup fires inside the anchor form', function () {
             var editor = this.newMediumEditor('.editor', {
                     buttonLabels: 'fontawesome'

--- a/src/js/extensions/anchor.js
+++ b/src/js/extensions/anchor.js
@@ -137,11 +137,11 @@
 
         // Used by medium-editor when the default toolbar is to be displayed
         isDisplayed: function () {
-            return this.getForm().style.display === 'block';
+            return MediumEditor.extensions.form.prototype.isDisplayed.apply(this);
         },
 
         hideForm: function () {
-            this.getForm().style.display = 'none';
+            MediumEditor.extensions.form.prototype.hideForm.apply(this);
             this.getInput().value = '';
         },
 
@@ -161,7 +161,6 @@
 
             this.base.saveSelection();
             this.hideToolbarDefaultActions();
-            this.getForm().style.display = 'block';
             this.setToolbarPosition();
 
             input.value = opts.url;
@@ -179,6 +178,7 @@
                 var classList = opts.buttonClass ? opts.buttonClass.split(' ') : [];
                 buttonCheckbox.checked = (classList.indexOf(this.customClassOption) !== -1);
             }
+            MediumEditor.extensions.form.prototype.showForm.apply(this);
         },
 
         // Called by core when tearing down medium-editor (destroy)

--- a/src/js/extensions/form.js
+++ b/src/js/extensions/form.js
@@ -14,6 +14,11 @@
         formSaveLabel: '&#10003;',
         formCloseLabel: '&times;',
 
+        /* activeClass: [string]
+         * set class which added to shown form
+         */
+        activeClass: 'medium-editor-toolbar-form-active',
+
         /* hasForm: [boolean]
          *
          * Setting this to true will cause getForm() to be called
@@ -36,14 +41,34 @@
          * This function should return true/false reflecting
          * whether the form is currently displayed
          */
-        isDisplayed: function () {},
+        isDisplayed: function () {
+            if (this.hasForm) {
+                return this.getForm().classList.contains(this.activeClass);
+            }
+            return false;
+        },
+
+        /* hideForm: [function ()]
+         *
+         * This function should show the form element inside
+         * the toolbar container
+         */
+        showForm: function () {
+            if (this.hasForm) {
+                this.getForm().classList.add(this.activeClass);
+            }
+        },
 
         /* hideForm: [function ()]
          *
          * This function should hide the form element inside
          * the toolbar container
          */
-        hideForm: function () {},
+        hideForm: function () {
+            if (this.hasForm) {
+                this.getForm().classList.remove(this.activeClass);
+            }
+        },
 
         /************************ Helpers ************************
          * The following are helpers that are either set by MediumEditor

--- a/src/sass/components/_toolbar-form.scss
+++ b/src/sass/components/_toolbar-form.scss
@@ -38,3 +38,7 @@
         text-decoration: none;
     }
 }
+
+.medium-editor-toolbar-form-active {
+    display: block;
+}


### PR DESCRIPTION
For better forms customization with CSS it's better to handle show|hide
state by class.
I've appended additional class for visible form and remove inline style
modifications.
Also I't moved show/hide form functional to form implementation.