### PR TITLE
Update OS X to 10.11 in Sauce Labs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,7 +63,7 @@ module.exports = function (grunt) {
             platform: 'Windows 10'
         }, {
             browserName: 'googlechrome',
-            platform: 'OS X 10.10'
+            platform: 'OS X 10.11'
         }, {
             browserName: 'firefox',
             platform: 'WIN8.1'
@@ -72,10 +72,10 @@ module.exports = function (grunt) {
             platform: 'Windows 10'
         }, {
             browserName: 'firefox',
-            platform: 'OS X 10.10'
+            platform: 'OS X 10.11'
         }, {
             browserName: 'safari',
-            platform: 'OS X 10.10'
+            platform: 'OS X 10.11'
         }];
 
     gruntConfig.connect = {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -75,6 +75,9 @@ module.exports = function (grunt) {
             platform: 'OS X 10.11'
         }, {
             browserName: 'safari',
+            platform: 'OS X 10.10'
+        }, {
+            browserName: 'safari',
             platform: 'OS X 10.11'
         }];
 


### PR DESCRIPTION
Just a cosmetic change. I've noticed that we're not testing against the latest OS X 10.11 which causes that we're not testing against the latest Safari 9, but against Safari 8 ([the only version supported in OS X 10.10 by Sauce Labs](https://saucelabs.com/platforms/#osx))