### PR TITLE
Destroy ie autolinks

### DIFF
--- a/spec/auto-link.spec.js
+++ b/spec/auto-link.spec.js
@@ -54,6 +54,39 @@ describe('Autolink', function () {
             editor.destroy();
             expect(autoUrlDetectTurnedOn).toBe(true);
         });
+
+        it('should not reset multiple browser auto-links (if supported) during destroy', function () {
+            var autoUrlDetectTurnedOn = true,
+                origExecCommand = document.execCommand,
+                origQCS = document.queryCommandSupported;
+            this.el = this.createElement('div', 'editor2', '');
+            spyOn(document, 'execCommand').and.callFake(function (command, showUi, val) {
+                if (command === 'AutoUrlDetect') {
+                    autoUrlDetectTurnedOn = val;
+                }
+                return origExecCommand.apply(document, arguments);
+            });
+            spyOn(document, 'queryCommandSupported').and.callFake(function (command) {
+                if (command === 'AutoUrlDetect') {
+                    return true;
+                }
+                return origQCS.apply(document, arguments);
+            });
+
+            var
+                editor = this.newMediumEditor('.editor', {
+                    autoLink: true
+                }),
+                editor2 = this.newMediumEditor('.editor2', {
+                    autoLink: true
+                });
+
+            expect(autoUrlDetectTurnedOn).toBe(false);
+            editor.destroy();
+            expect(autoUrlDetectTurnedOn).toBe(false);
+            editor2.destroy();
+            expect(autoUrlDetectTurnedOn).toBe(true);
+        });
     });
 
     describe('integration', function () {

--- a/src/js/extensions/auto-link.js
+++ b/src/js/extensions/auto-link.js
@@ -41,9 +41,20 @@
             this.document.execCommand('AutoUrlDetect', false, false);
         },
 
+        isLastInstance: function () {
+            var activeInstances = 0;
+            for (var i = 0; i < window._mediumEditors.length; i++) {
+                var editor = window._mediumEditors[i];
+                if (editor !== null && editor.getExtensionByName('autoLink') !== undefined) {
+                    activeInstances++;
+                }
+            }
+            return activeInstances === 1;
+        },
+
         destroy: function () {
             // Turn AutoUrlDetect back on
-            if (this.document.queryCommandSupported('AutoUrlDetect')) {
+            if (this.document.queryCommandSupported('AutoUrlDetect') && this.isLastInstance()) {
                 this.document.execCommand('AutoUrlDetect', false, true);
             }
         },

--- a/src/js/extensions/auto-link.js
+++ b/src/js/extensions/auto-link.js
@@ -43,8 +43,8 @@
 
         isLastInstance: function () {
             var activeInstances = 0;
-            for (var i = 0; i < window._mediumEditors.length; i++) {
-                var editor = window._mediumEditors[i];
+            for (var i = 0; i < this.window._mediumEditors.length; i++) {
+                var editor = this.window._mediumEditors[i];
                 if (editor !== null && editor.getExtensionByName('autoLink') !== undefined) {
                     activeInstances++;
                 }


### PR DESCRIPTION
Only re-enable AutoUrlDetect when all auto-link instances have been destroyed -- created an `isLastInstance()` function which checks if all other Medium Editor instances with auto-link enabled have been destroyed.

Fixes #961 