### PR TITLE
Use function as keyboard command

### DIFF
--- a/spec/keyboard-commands.spec.js
+++ b/spec/keyboard-commands.spec.js
@@ -82,6 +82,41 @@ describe('KeyboardCommands TestCase', function () {
             expect(editor.execAction).toHaveBeenCalledWith('superscript');
         });
 
+        it('should execute custom command functions', function () {
+            var foo, editor;
+
+            foo = {
+                bar: function () {
+                    return true;
+                }
+            };
+
+            spyOn(foo, 'bar');
+
+            editor = this.newMediumEditor('.editor', {
+                keyboardCommands: {
+                    commands: [
+                        {
+                            command: foo.bar,
+                            key: 'f',
+                            meta: true,
+                            shift: false,
+                            alt: false
+                        }
+                    ]
+                }
+            });
+
+            selectElementContentsAndFire(editor.elements[0]);
+            fireEvent(editor.elements[0], 'keydown', {
+                keyCode: 'f'.charCodeAt(0),
+                ctrlKey: true,
+                metaKey: true,
+                shiftKey: false
+            });
+            expect(foo.bar).toHaveBeenCalled();
+        });
+
         // TODO: remove this test when jumping in 6.0.0
         it('should be executed for custom command without alt defined', function () {
             spyOn(MediumEditor.prototype, 'execAction');

--- a/src/js/extensions/keyboard-commands.js
+++ b/src/js/extensions/keyboard-commands.js
@@ -71,8 +71,12 @@
                     event.preventDefault();
                     event.stopPropagation();
 
+                    // command can be a function to execute
+                    if (typeof data.command === 'function') {
+                        data.command.apply(this);
+                    }
                     // command can be false so the shortcut is just disabled
-                    if (false !== data.command) {
+                    else if (false !== data.command) {
                         this.execAction(data.command);
                     }
                 }


### PR DESCRIPTION
Allows you to set a function as "command" option for keyboard commands.

Use case: triggering custom buttons using keyboard shortcuts.

Example config:

```js
            var options = {
                toolbar: {
                    buttons: [
                        'b',
                    ]
                },
                keyboardCommands: {
                    commands: [
                        {
                            key: 'B',
                            meta: true,
                            shift: false,
                            alt: false,
                            command: function() {
                                editor.getExtensionByName('b').button.onclick();
                            },
                        }
                    ]
                },
                extensions: {
                    'b': new MediumButton({
                        label: '<i class="fa fa-bold"></i>',
                        start: '<strong>',
                        end: '</strong>'
                    })
                }
            }
```