### PR TITLE
Fix 1014 - Convert spaces to %20 in links if linkValidation is true for the anchor extension

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -434,7 +434,7 @@ Text to be shown in the checkbox when the __customClassOption__ is being used.
 #### `linkValidation`
 **Default:** `false`
 
-Enables/disables check for common URL protocols on anchor links.
+Enables/disables check for common URL protocols on anchor links. Converts invalid url characters (ie spaces) to valid characters using `encodeURI`
 
 ***
 #### `placeholderText`

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ var editor = new MediumEditor('.editable', {
 
 * __customClassOption__: custom class name the user can optionally have added to their created links (ie 'button').  If passed as a non-empty string, a checkbox will be displayed allowing the user to choose whether to have the class added to the created link or not. Default: `null`
 * __customClassOptionText__: text to be shown in the checkbox when the __customClassOption__ is being used. Default: `'Button'`
-* __linkValidation__: enables/disables check for common URL protocols on anchor links. Default: `false`
+* __linkValidation__: enables/disables check for common URL protocols on anchor links. Converts invalid url characters (ie spaces) to valid characters using `encodeURI`. Default: `false`
 * __placeholderText__: text to be shown as placeholder of the anchor input. Default: `'Paste or type a link'`
 * __targetCheckbox__: enables/disables displaying a "Open in new window" checkbox, which when checked changes the `target` attribute of the created link. Default: `false`
 * __targetCheckboxText__: text to be shown in the checkbox enabled via the __targetCheckbox__ option. Default: `'Open in new window'`

--- a/spec/anchor.spec.js
+++ b/spec/anchor.spec.js
@@ -345,7 +345,25 @@ describe('Anchor Button TestCase', function () {
 
             link = editor.elements[0].querySelector('a');
             expect(link).not.toBeNull();
-            expect(link.href).toBe(validUrl.toLowerCase());
+            expect(link.href).toBe(validUrl);
+        });
+        it('should not change spaces to %20 if linkValidation is set to false', function () {
+            var editor = this.newMediumEditor('.editor', {
+                anchor: {
+                    linkValidation: false
+                }
+            }),
+                link,
+                anchorExtension = editor.getExtensionByName('anchor'),
+                validUrl = 'http://te%20s%20t.com/';
+
+            selectElementContentsAndFire(editor.elements[0]);
+            anchorExtension.showForm('http://te s t.com/');
+            fireEvent(anchorExtension.getForm().querySelector('a.medium-editor-toolbar-save'), 'click');
+
+            link = editor.elements[0].querySelector('a');
+            expect(link).not.toBeNull();
+            expect(link.href).not.toBe(validUrl);
         });
         it('should add target="_blank" when "open in a new window" checkbox is checked', function () {
             var editor = this.newMediumEditor('.editor', {

--- a/spec/anchor.spec.js
+++ b/spec/anchor.spec.js
@@ -329,6 +329,24 @@ describe('Anchor Button TestCase', function () {
             expect(link).not.toBeNull();
             expect(link.href).toBe(validUrl.toLowerCase());
         });
+        it('should change spaces to %20 for a valid url if linkValidation options is set to true', function () {
+            var editor = this.newMediumEditor('.editor', {
+                anchor: {
+                    linkValidation: true
+                }
+            }),
+                link,
+                anchorExtension = editor.getExtensionByName('anchor'),
+                validUrl = 'http://te%20s%20t.com/';
+
+            selectElementContentsAndFire(editor.elements[0]);
+            anchorExtension.showForm('te s t.com');
+            fireEvent(anchorExtension.getForm().querySelector('a.medium-editor-toolbar-save'), 'click');
+
+            link = editor.elements[0].querySelector('a');
+            expect(link).not.toBeNull();
+            expect(link.href).toBe(validUrl.toLowerCase());
+        });
         it('should add target="_blank" when "open in a new window" checkbox is checked', function () {
             var editor = this.newMediumEditor('.editor', {
                 anchor: {

--- a/src/js/extensions/anchor.js
+++ b/src/js/extensions/anchor.js
@@ -242,7 +242,7 @@
                 return 'tel:' + value;
             } else {
                 // Check for URL scheme and default to http:// if none found
-                return (urlSchemeRegex.test(value) ? '' : 'http://') + value.replace(/\s/g, '%20');
+                return (urlSchemeRegex.test(value) ? '' : 'http://') + encodeURI(value);
             }
         },
 

--- a/src/js/extensions/anchor.js
+++ b/src/js/extensions/anchor.js
@@ -242,7 +242,7 @@
                 return 'tel:' + value;
             } else {
                 // Check for URL scheme and default to http:// if none found
-                return (urlSchemeRegex.test(value) ? '' : 'http://') + value;
+                return (urlSchemeRegex.test(value) ? '' : 'http://') + value.replace(/\s/g, '%20');
             }
         },
 


### PR DESCRIPTION
Converts all instances of spaces to url friendly %20 if linkValidation for anchors is enabled. Example in screenshot mirrors same test case from the issue.
![image](https://cloud.githubusercontent.com/assets/7939025/14068660/68e7c15a-f458-11e5-910f-73eab1e820fb.png)

Fixes #1014 