### PR TITLE
Updated test - Made the diff between input and validUrl only spaces

### DIFF
--- a/spec/anchor.spec.js
+++ b/spec/anchor.spec.js
@@ -340,7 +340,7 @@ describe('Anchor Button TestCase', function () {
                 validUrl = 'http://te%20s%20t.com/';
 
             selectElementContentsAndFire(editor.elements[0]);
-            anchorExtension.showForm('te s t.com');
+            anchorExtension.showForm('http://te s t.com/');
             fireEvent(anchorExtension.getForm().querySelector('a.medium-editor-toolbar-save'), 'click');
 
             link = editor.elements[0].querySelector('a');


### PR DESCRIPTION
Made sure the only differences between input and validUrl are the spaces, since the tests are specifically for converting spaces -- hope this fixes the SauceLabs failures.