### PR TITLE
Add/remove elements to existing instance

### DIFF
--- a/API.md
+++ b/API.md
@@ -8,6 +8,8 @@
   - [`MediumEditor(elements, options)`](#mediumeditorelements-options)
   - [`destroy()`](#destroy)
   - [`setup()`](#setup)
+  - [`addElements()`](#addelementselements)
+  - [`removeElements()`](#removeelementselements)
 - [Event Functions](#event-functions)
   - [`on(targets, event, listener, useCapture)`](#ontargets-event-listener-usecapture)
   - [`off(targets, event, listener, useCapture)`](#offtargets-event-listener-usecapture)
@@ -47,14 +49,17 @@
 
 Creating an instance of MediumEditor will:
 * Convert all passed in elements into `contenteditable` elements.
-* For any `<textarea>` elements, hide the `<textarea>`, create a new `<div contenteditable=true>` element, and ensure the 2 elements remain sync'd.
+* For any `<textarea>` elements:
+  * Hide the `<textarea>`
+  * Create a new `<div contenteditable=true>` element and add it to the elements array.
+  * Ensure the 2 elements remain sync'd.
 * Initialize any custom extensions or buttons passed in.
 * Create any additional elements needed.
 * Setup all event handling needed to monitor the editable elements.
 
 **Arguments**
 
-_**elements** (`String` | `HTMLElement` | `Array`)_:
+_**elements** (`String` | `HTMLElement` | `Array` | `NodeList` | `HTMLCollection`)_:
 
 1. `String`: If passed as a string, this is used as a selector in a call to `document.querySelectorAll()` to find elements on the page.  All results are stored in the internal list of **elements**.
 
@@ -80,6 +85,55 @@ Tear down the editor if already setup by doing the following:
 ### `setup()`
 
 Initialize this instance of the editor if it has been destroyed.  This will reuse the `elements` selector and `options` object passed in when the editor was instantiated.
+
+***
+### `addElements(elements)`
+
+Dynamically add one or more elements to an already initialized instance of MediumEditor.
+
+Passing an elements or array of elements to `addElements(elements)` will:
+* Add the given element or array of elements to the editor **elements**
+* Ensure the element(s) are initialized with the proper attributes and event handlers as if the element had been passed during instantiation of the editor
+* For any `<textarea>` elements:
+  * Hide the `<textarea>`
+  * Create a new `<div contenteditable=true>` element and add it to the editor **elements**
+  * Ensure the 2 elements remain sync'd.
+* Be intelligent enough to run the necessary code only once per element, no matter how often you will call it
+
+So, every element you pass to `addElements` will turn into a fully supported contenteditable too - even earlier calls to `editor.subscribe(..)`
+for custom events will work on the newly added element(s).
+
+**Arguments**
+
+_**elements** (`String` | `HTMLElement` | `Array` | `NodeList` | `HTMLCollection`)_:
+
+1. `String`: If passed as a string, this is used as a selector in a call to `document.querySelectorAll()` to find elements on the page.
+
+2. `HTMLElement`: If passed as a single element, this will be the only element added to the editor **elements**.
+
+3. `Array` | `NodeList` | `HTMLCollection`: If passed as an `Array`-like collection of `HTMLElement`s, all of these elements will be added to the editor **elements**.
+
+***
+### `removeElements(elements)`
+
+Remove one or more elements from an already initialized instance of MediumEditor.
+
+Passing an elements or array of elements to `removeElements(elements)` will:
+* Remove the given element or array of elements from the internal `this.elements` array.
+* Remove any added event handlers or attributes (with the exception of `contenteditable`).
+* Unhide any `<textarea>` elements and remove any created `<div>` elements created for `<textarea>` elements.
+
+Each element itself will remain a contenteditable - it will just remove all event handlers and all references to it so you can safely remove it from DOM.
+
+**Arguments**
+
+_**elements** (`String` | `HTMLElement` | `Array` | `NodeList` | `HTMLCollection`)_:
+
+1. `String`: If passed as a string, this is used as a selector in a call to `document.querySelectorAll()` to find elements on the page.
+
+2. `HTMLElement`: If passed as a single element, this will be the only element removed from the editor **elements**.
+
+3. `Array` | `NodeList` | `HTMLCollection`: If passed as an `Array`-like collection of `HTMLElement`s, all of these elements will be removed from the edtior **elements**.
 
 ***
 ## Event Functions

--- a/README.md
+++ b/README.md
@@ -569,7 +569,9 @@ editor.subscribe('editableInput', this._handleEditableInput.bind(this));
 
 // imagine an ajax fetch/any other dynamic functionality which will add new '.editable' elements to dom
 
-editor.addElements(document.querySelectorAll('.editable'));
+editor.addElements('.editable');
+// OR editor.addElements(document.getElementsByClassName('editable'));
+// OR editor.addElements(document.querySelectorAll('.editable'));
 ```
 
 Passing an elements or array of elements to `addElements(elements)` will:
@@ -587,6 +589,8 @@ Straight forward, just call `removeElements` with the elemnt or array of element
 
 ```javascript
 editor.removeElements(document.querySelector('#myElement'));
+// OR editor.removeElements(document.getElementById('myElement'));
+// OR editor.removeElements('#myElement');
 
 // in case you have jQuery and don't exactly know when an element was removed, for example after routing state change
 var removedElements = [];

--- a/README.md
+++ b/README.md
@@ -478,20 +478,20 @@ editor.subscribe('editableInput', this._handleEditableInput.bind(this));
 editor.addElements(document.querySelectorAll('.editable'));
 ```
 
-The `addElement` function will add the given element or array of elements to the internal `this.elements` array and he 
+The `addElements` function will add the given element or array of elements to the internal `this.elements` array and he 
 will take care of all the attributes and event handler initialization of the newly added element. He is intelligent enough
 to run the necessary code only once on a given element, no matter how often you will call it.
 
-So, every element you pass to `addElement` will turn into a fully supported contenteditable too - even a earlier `editor.subscribe(..)`
+So, every element you pass to `addElements` will turn into a fully supported contenteditable too - even a earlier `editor.subscribe(..)`
 for a custom event will work on the new added element.
 
 #### Removing elements dynamically
 
-Straight forward, just call `removeElement` for the element to want to tear down. The element itself will remain a contenteditable - 
+Straight forward, just call `removeElements` for the element to want to tear down. The element itself will remain a contenteditable - 
 it will only remove all event handlers and all references to it so you can safely remove it from DOM.
 
 ```javascript
-editor.removeElement(document.querySelector('#myElement'));
+editor.removeElements(document.querySelector('#myElement'));
 
 // in case you have jQuery and don't exactly now when an element was removed, for example after routing state change
 var removedElements = [];

--- a/README.md
+++ b/README.md
@@ -465,46 +465,6 @@ var editor = new MediumEditor('.editable', {
 });
 ```
 
-### Dynamically add elements to your instance
-
-It is possible to dynamically add new elements to your existing MediumtEditor instance:
-
-```javascript
-var editor = new MedtiumEditor('.editable', { ... });
-editor.subscribe('editableInput', this._handleEditableInput.bind(this));
-
-// imagine an ajax fetch/any other dynamic functionality which will add new '.editable' elements to dom
-
-editor.addElements(document.querySelectorAll('.editable'));
-```
-
-The `addElements` function will add the given element or array of elements to the internal `this.elements` array and he 
-will take care of all the attributes and event handler initialization of the newly added element. He is intelligent enough
-to run the necessary code only once on a given element, no matter how often you will call it.
-
-So, every element you pass to `addElements` will turn into a fully supported contenteditable too - even a earlier `editor.subscribe(..)`
-for a custom event will work on the new added element.
-
-#### Removing elements dynamically
-
-Straight forward, just call `removeElements` for the element to want to tear down. The element itself will remain a contenteditable - 
-it will only remove all event handlers and all references to it so you can safely remove it from DOM.
-
-```javascript
-editor.removeElements(document.querySelector('#myElement'));
-
-// in case you have jQuery and don't exactly now when an element was removed, for example after routing state change
-var removedElements = [];
-editor.elements.forEach(function (element) {
-    // check if the element is still available in current DOM
-    if (!$(element).parents('body').length) {
-        removedElements.push(element);
-    }
-});
-
-editor.removeElements(removedElements);
-```
-
 ## Buttons
 
 By default, MediumEditor supports buttons for most of the commands for `document.execCommand()` that are well-supported across all its supported browsers.
@@ -563,6 +523,8 @@ View the [MediumEditor Object API documentation](API.md) on the Wiki for details
 * __MediumEditor(elements, options)__:  Creates an instance of MediumEditor
 * __.destroy()__: tears down the editor if already setup, removing all DOM elements and event handlers
 * __.setup()__: rebuilds the editor if it has already been destroyed, recreating DOM elements and attaching event handlers
+* __.addElements()__: add elements to an already initialized instance of MediumEditor
+* __.removeElements()__: remove elements from an already initialized instance of MediumEditor
 
 ### Event Methods
 * __.on(target, event, listener, useCapture)__: attach a listener to a DOM event which will be detached when MediumEditor is deactivated
@@ -596,6 +558,47 @@ View the [MediumEditor Object API documentation](API.md) on the Wiki for details
 * __.getExtensionByName(name)__: get a reference to an extension with the specified name
 * __.serialize()__: returns a JSON object with elements contents
 * __.setContent(html, index)__: sets the `innerHTML` to `html` of the element at `index`
+
+## Dynamically add/remove elements to your instance
+
+It is possible to dynamically add new elements to your existing MediumtEditor instance:
+
+```javascript
+var editor = new MediumEditor('.editable');
+editor.subscribe('editableInput', this._handleEditableInput.bind(this));
+
+// imagine an ajax fetch/any other dynamic functionality which will add new '.editable' elements to dom
+
+editor.addElements(document.querySelectorAll('.editable'));
+```
+
+Passing an elements or array of elements to `addElements(elements)` will:
+* Add the given element or array of elements to the internal `this.elements` array.
+* Ensure the element(s) are initialized with the proper attributes and event handlers as if the element had been passed during instantiation of the editor.
+* For any `<textarea>` elements:
+  * Hide the `<textarea>`
+  * Create a new `<div contenteditable=true>` element and add it to the elements array.
+  * Ensure the 2 elements remain sync'd.
+* Be intelligent enough to run the necessary code only once per element, no matter how often you will call it.
+
+### Removing elements dynamically
+
+Straight forward, just call `removeElements` with the elemnt or array of elements you to want to tear down. Each element itself will remain a contenteditable - it will just remove all event handlers and all references to it so you can safely remove it from DOM.
+
+```javascript
+editor.removeElements(document.querySelector('#myElement'));
+
+// in case you have jQuery and don't exactly know when an element was removed, for example after routing state change
+var removedElements = [];
+editor.elements.forEach(function (element) {
+    // check if the element is still available in current DOM
+    if (!$(element).parents('body').length) {
+        removedElements.push(element);
+    }
+});
+
+editor.removeElements(removedElements);
+```
 
 ## Capturing DOM changes
 

--- a/README.md
+++ b/README.md
@@ -465,6 +465,45 @@ var editor = new MediumEditor('.editable', {
 });
 ```
 
+### Dynamically add elements to your instance
+
+It is possible to dynamically add new elements to your existing MediumtEditor instance:
+
+```javascript
+var editor = new MedtiumEditor('.editable', { ... });
+editor.subscribe('editableInput', this._handleEditableInput.bind(this));
+
+// imagine an ajax fetch/any other dynamic functionality which will add new '.editable' elements to dom
+
+editor.addElements(document.querySelectorAll('.editable'));
+```
+
+The `addElement` function will add the given element or array of elements to the internal `this.elements` array and he 
+will take care of all the attributes and event handler initialization of the newly added element. He is intelligent enough
+to run the necessary code only once on a given element, no matter how often you will call it.
+
+So, every element you pass to `addElement` will turn into a fully supported contenteditable too - even a earlier `editor.subscribe(..)`
+for a custom event will work on the new added element.
+
+#### Removing elements dynamically
+
+Straight forward, just call `removeElement` for the element to want to tear down. The element itself will remain a contenteditable - 
+it will only remove all event handlers and all references to it so you can safely remove it from DOM.
+
+```javascript
+editor.removeElement(document.querySelector('#myElement'));
+
+// in case you have jQuery and don't exactly now when an element was removed, for example after routing state change
+var removedElements = [];
+editor.elements.forEach(function (element) {
+    // check if the element is still available in current DOM
+    if (!$(element).parents('body').length) {
+        removedElements.push(element);
+    }
+});
+
+editor.removeElements(removedElements);
+```
 
 ## Buttons
 

--- a/demo/multi-one-instance.html
+++ b/demo/multi-one-instance.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>medium editor | demo</title>
+    <link rel="stylesheet" href="css/demo.css">
+    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.css">
+    <link rel="stylesheet" href="../dist/css/medium-editor.css">
+    <link rel="stylesheet" href="../dist/css/themes/default.css" id="medium-editor-theme">
+</head>
+<body>
+    <a href="https://github.com/yabwe/medium-editor" class="github-link"><img style="z-index: 100;position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub"></a>
+    <div class="top-bar">
+        Theme:
+        <select id="sel-themes">
+            <option value="themes/default" selected>default</option>
+            <option value="themes/roman">roman</option>
+            <option value="themes/mani">mani</option>
+            <option value="themes/flat">flat</option>
+            <option value="themes/bootstrap">bootstrap</option>
+            <option value="themes/tim">tim</option>
+            <option value="themes/beagle">beagle</option>
+        </select>
+    </div>
+    <div id="container">
+        <h1>Medium Editor</h1>
+        <div class="editable">
+            <p>My father’s family name being <a href="https://en.wikipedia.org/wiki/Pip_(Great_Expectations)">Pirrip</a>, and my Christian name Philip, my infant tongue could make of both names nothing longer or more explicit than Pip. So, I called myself Pip, and came to be called Pip.</p>
+            <p>I give Pirrip as my father’s family name, on the authority of his tombstone and my sister,—Mrs. Joe Gargery, who married the blacksmith. As I never saw my father or my mother, and never saw any likeness of either of them (for their days were long before the days of photographs), my first fancies regarding what they were like were unreasonably derived from their tombstones. The shape of the letters on my father’s, gave me an odd idea that he was a square, stout, dark man, with curly black hair. From the character and turn of the inscription, “Also Georgiana Wife of the Above,” I drew a childish conclusion that my mother was freckled and sickly. To five little stone lozenges, each about a foot and a half long, which were arranged in a neat row beside their grave, and were sacred to the memory of five little brothers of mine,—who gave up trying to get a living, exceedingly early in that universal struggle,—I am indebted for a belief I religiously entertained that they had all been born on their backs with their hands in their trousers-pockets, and had never taken them out in this state of existence.</p>
+            <p>Ours was the marsh country, down by the river, within, as the river wound, twenty miles of the sea. My first most vivid and broad impression of the identity of things seems to me to have been gained on a memorable raw afternoon towards evening. At such a time I found out for certain that this bleak place overgrown with nettles was the churchyard; and that Philip Pirrip, late of this parish, and also Georgiana wife of the above, were dead and buried; and that Alexander, Bartholomew, Abraham, Tobias, and Roger, infant children of the aforesaid, were also dead and buried; and that the dark flat wilderness beyond the churchyard, intersected with dikes and mounds and gates, with scattered cattle feeding on it, was the marshes; and that the low leaden line beyond was the river; and that the distant savage lair from which the wind was rushing was the sea; and that the small bundle of shivers growing afraid of it all and beginning to cry, was Pip.</p>
+        </div>
+        <div class="editable2">
+            <p>My father’s family name being <a href="https://en.wikipedia.org/wiki/Pip_(Great_Expectations)">Pirrip</a>, and my Christian name Philip, my infant tongue could make of both names nothing longer or more explicit than Pip. So, I called myself Pip, and came to be called Pip.</p>
+            <p>I give Pirrip as my father’s family name, on the authority of his tombstone and my sister,—Mrs. Joe Gargery, who married the blacksmith. As I never saw my father or my mother, and never saw any likeness of either of them (for their days were long before the days of photographs), my first fancies regarding what they were like were unreasonably derived from their tombstones. The shape of the letters on my father’s, gave me an odd idea that he was a square, stout, dark man, with curly black hair. From the character and turn of the inscription, “Also Georgiana Wife of the Above,” I drew a childish conclusion that my mother was freckled and sickly. To five little stone lozenges, each about a foot and a half long, which were arranged in a neat row beside their grave, and were sacred to the memory of five little brothers of mine,—who gave up trying to get a living, exceedingly early in that universal struggle,—I am indebted for a belief I religiously entertained that they had all been born on their backs with their hands in their trousers-pockets, and had never taken them out in this state of existence.</p>
+            <p>Ours was the marsh country, down by the river, within, as the river wound, twenty miles of the sea. My first most vivid and broad impression of the identity of things seems to me to have been gained on a memorable raw afternoon towards evening. At such a time I found out for certain that this bleak place overgrown with nettles was the churchyard; and that Philip Pirrip, late of this parish, and also Georgiana wife of the above, were dead and buried; and that Alexander, Bartholomew, Abraham, Tobias, and Roger, infant children of the aforesaid, were also dead and buried; and that the dark flat wilderness beyond the churchyard, intersected with dikes and mounds and gates, with scattered cattle feeding on it, was the marshes; and that the low leaden line beyond was the river; and that the distant savage lair from which the wind was rushing was the sea; and that the small bundle of shivers growing afraid of it all and beginning to cry, was Pip.</p>
+        </div>
+    </div>
+    <p style="text-align: center;"><small><a style="color: #333;" target="_blank" href="http://www.goodreads.com/reader/475-great-expectations">Source</a></small></p>
+    <script src="../dist/js/medium-editor.js"></script>
+    <script>
+        var editor = new MediumEditor('.editable', {
+            buttonLabels: 'fontawesome'
+        }),
+        cssLink = document.getElementById('medium-editor-theme');
+
+        editor.subscribe('editableInput', function(event, editable) {
+            console.info('editableInput fired!', editable);
+        });
+
+        document.getElementById('sel-themes').addEventListener('change', function () {
+            cssLink.href = '../dist/css/' + this.value + '.css';
+        });
+
+        editor.addElement(document.querySelector('.editable2'));
+    </script>
+</body>
+</html>

--- a/demo/multi-one-instance.html
+++ b/demo/multi-one-instance.html
@@ -51,7 +51,7 @@
             cssLink.href = '../dist/css/' + this.value + '.css';
         });
 
-        editor.addElement(document.querySelector('.editable2'));
+        editor.addElements(document.querySelector('.editable2'));
     </script>
 </body>
 </html>

--- a/spec/dyn-elements.spec.js
+++ b/spec/dyn-elements.spec.js
@@ -14,7 +14,7 @@ describe('MediumEditor.DynamicElements TestCase', function () {
         this.cleanupTest();
     });
 
-    describe('Add elements after creation of MediumEditor instance', function () {
+    describe('addElements', function () {
         it('should initialize dom element properly when adding dynamically', function () {
             var editor = this.newMediumEditor('.editor'),
             focusedEditable,
@@ -43,6 +43,27 @@ describe('MediumEditor.DynamicElements TestCase', function () {
             fireEvent(document.body, 'mouseup');
             fireEvent(document.body, 'click');
             expect(blurredEditable).toBe(this.addOne);
+        });
+
+        it('should accept a selector to specify elements to add', function () {
+            var editor = this.newMediumEditor('.editor');
+            expect(editor.elements.length).toBe(1);
+            editor.addElements('.add-one');
+            expect(editor.elements.length).toBe(2);
+        });
+
+        it('should accept a NodeList to specify elements to add', function () {
+            var editor = this.newMediumEditor('.editor');
+            expect(editor.elements.length).toBe(1);
+            editor.addElements(document.getElementsByClassName('add-one'));
+            expect(editor.elements.length).toBe(2);
+        });
+
+        it('should not add an element that is already an editor element', function () {
+            var editor = this.newMediumEditor('.editor');
+            expect(editor.elements.length).toBe(1);
+            editor.addElements('.editor');
+            expect(editor.elements.length).toBe(1);
         });
 
         function runAddTest(inputSupported) {
@@ -105,6 +126,26 @@ describe('MediumEditor.DynamicElements TestCase', function () {
 
         runAddTest(true);
         runAddTest(false);
+    });
+
+    describe('removeElements', function () {
+        it('should accept a selector to specify elements to remove', function () {
+            var editor = this.newMediumEditor('.editor, .add-one');
+            expect(editor.elements.length).toBe(2);
+            editor.removeElements('.editor');
+            expect(editor.elements.length).toBe(1);
+            editor.removeElements('.add-one');
+            expect(editor.elements.length).toBe(0);
+        });
+
+        it('should accept a NodeList to specify elements to remove', function () {
+            var editor = this.newMediumEditor('.editor, .add-one');
+            expect(editor.elements.length).toBe(2);
+            editor.removeElements(document.getElementsByClassName('editor'));
+            expect(editor.elements.length).toBe(1);
+            editor.removeElements(document.getElementsByClassName('add-one'));
+            expect(editor.elements.length).toBe(0);
+        });
     });
 });
 

--- a/spec/dyn-elements.spec.js
+++ b/spec/dyn-elements.spec.js
@@ -106,6 +106,15 @@ describe('MediumEditor.DynamicElements TestCase', function () {
             expect(editor.elements.length).toBe(1);
         });
 
+        it('should attach editableKeydownEnter to the editor when adding an element with a data-disable-return attribute', function () {
+            var editor = this.newMediumEditor('.editor');
+            expect(editor.events.customEvents['editableKeydownEnter'].length).toBe(1);
+
+            this.addOne.setAttribute('data-disable-return', true);
+            editor.addElements(this.addOne);
+            expect(editor.events.customEvents['editableKeydownEnter'].length).toBe(2, 'editableKeydownEnter should be subscribed to when adding a data-disbale-return element');
+        });
+
         function runAddTest(inputSupported) {
             it('should re-attach element properly when removed from dom, cleaned up and injected to dom again', function () {
                 var originalInputSupport = MediumEditor.Events.prototype.InputEventOnContenteditableSupported;

--- a/spec/dyn-elements.spec.js
+++ b/spec/dyn-elements.spec.js
@@ -1,0 +1,138 @@
+/*global fireEvent */
+
+describe('MediumEditor.DynamicElements TestCase', function () {
+    'use strict';
+
+    beforeEach(function () {
+        setupTestHelpers.call(this);
+        this.el = this.createElement('div', 'editor', 'lore ipsum');
+        this.addOne = this.createElement('div', 'add-one', 'lore ipsum dolor');
+        this.addTwo = this.createElement('div', 'add-two', 'lore ipsum dollar');
+    });
+
+    afterEach(function () {
+        this.cleanupTest();
+    });
+
+    describe('Add elements after creation of MediumEditor instance', function () {
+        it('should initialize dom element properly when adding dynamically', function () {
+            var editor = this.newMediumEditor('.editor'),
+            focusedEditable,
+            blurredEditable,
+            focusListener = function (event, editable) {
+                focusedEditable = editable;
+            },
+            blurListener = function (event, editable) {
+                blurredEditable = editable;
+            };
+            editor.subscribe('focus', focusListener);
+            editor.subscribe('blur', blurListener);
+
+            editor.addElement(this.addOne);
+            expect(this.addOne.getAttribute('data-medium-editor-element')).toBeDefined();
+            expect(editor.elements.length).toBe(2);
+
+            editor.addElement(this.addOne);
+            expect(editor.elements.length).toBe(2);
+
+            editor.selectElement(this.addOne.firstChild);
+            expect(focusedEditable).toBe(this.addOne);
+            expect(blurredEditable).toBeUndefined();
+
+            fireEvent(document.body, 'mousedown');
+            fireEvent(document.body, 'mouseup');
+            fireEvent(document.body, 'click');
+            expect(blurredEditable).toBe(this.addOne);
+        });
+
+        function runAddTest(inputSupported) {
+            it('should re-attach element properly when removed from dom, cleaned up and injected to dom again', function () {
+                var originalInputSupport = MediumEditor.Events.prototype.InputEventOnContenteditableSupported;
+                MediumEditor.Events.prototype.InputEventOnContenteditableSupported = inputSupported;
+
+                var editor = this.newMediumEditor('.editor'),
+                focusedEditable,
+                firedTarget,
+                firedCounter,
+                handler = function (event, editable) {
+                    firedTarget = editable;
+                    firedCounter++;
+                },
+                focusListener = function (event, editable) {
+                    focusedEditable = editable;
+                };
+
+                firedCounter = 0;
+
+                editor.subscribe('focus', focusListener);
+                editor.subscribe('editableInput', handler);
+
+                editor.addElement(this.addOne);
+                expect(this.addOne.getAttribute('data-medium-editor-element')).toBeDefined();
+                expect(editor.elements.length).toBe(2);
+
+                // Detach + exec fn + reattach, asynchronous.
+                detach(this.addOne, true, function (reattach) {
+                    editor.removeElement(this.addOne);
+                    expect(editor.elements.length).toBe(1);
+
+                    reattach();
+
+                    editor.addElement(this.addTwo);
+                    expect(editor.elements.length).toBe(2);
+                    expect(this.addTwo.getAttribute('data-medium-editor-element')).toBeDefined();
+
+                    editor.selectElement(this.addTwo.firstChild);
+                    expect(focusedEditable).toBe(this.addTwo);
+
+                    editor.selectElement(this.addTwo.firstChild);
+                    this.addTwo.textContent = 'lore ipsum!';
+
+                    // trigger onInput
+                    fireEvent(this.addTwo, 'input');
+
+                    // trigger faked 'selectionchange' event
+                    fireEvent(document, 'selectionchange', { target: document, currentTarget: this.addTwo });
+
+                    jasmine.clock().tick(1);
+                    expect(firedTarget).toBe(this.addTwo);
+                    expect(firedCounter).toBe(1);
+
+                    MediumEditor.Events.prototype.InputEventOnContenteditableSupported = originalInputSupport;
+                }.bind(this));
+            });
+        }
+
+        runAddTest(true);
+        runAddTest(false);
+    });
+});
+
+function detach(node, async, fn) {
+    var parent = node.parentNode,
+        next = node.nextSibling;
+    // No parent node? Abort!
+    if (!parent) {
+        return;
+    }
+    // Detach node from DOM.
+    parent.removeChild(node);
+    // Handle case where optional `async` argument is omitted.
+    if (typeof async !== 'boolean') {
+        fn = async;
+        async = false;
+    }
+    // Note that if a function wasn't passed, the node won't be re-attached!
+    if (fn && async) {
+        // If async == true, reattach must be called manually.
+        fn.call(node, reattach);
+    } else if (fn) {
+        // If async != true, reattach will happen automatically.
+        fn.call(node);
+        reattach();
+    }
+    // Re-attach node to DOM.
+    function reattach() {
+        parent.insertBefore(node, next);
+    }
+}

--- a/spec/dyn-elements.spec.js
+++ b/spec/dyn-elements.spec.js
@@ -28,11 +28,11 @@ describe('MediumEditor.DynamicElements TestCase', function () {
             editor.subscribe('focus', focusListener);
             editor.subscribe('blur', blurListener);
 
-            editor.addElement(this.addOne);
+            editor.addElements(this.addOne);
             expect(this.addOne.getAttribute('data-medium-editor-element')).toBeDefined();
             expect(editor.elements.length).toBe(2);
 
-            editor.addElement(this.addOne);
+            editor.addElements(this.addOne);
             expect(editor.elements.length).toBe(2);
 
             editor.selectElement(this.addOne.firstChild);
@@ -67,18 +67,18 @@ describe('MediumEditor.DynamicElements TestCase', function () {
                 editor.subscribe('focus', focusListener);
                 editor.subscribe('editableInput', handler);
 
-                editor.addElement(this.addOne);
+                editor.addElements(this.addOne);
                 expect(this.addOne.getAttribute('data-medium-editor-element')).toBeDefined();
                 expect(editor.elements.length).toBe(2);
 
                 // Detach + exec fn + reattach, asynchronous.
                 detach(this.addOne, true, function (reattach) {
-                    editor.removeElement(this.addOne);
+                    editor.removeElements(this.addOne);
                     expect(editor.elements.length).toBe(1);
 
                     reattach();
 
-                    editor.addElement(this.addTwo);
+                    editor.addElements(this.addTwo);
                     expect(editor.elements.length).toBe(2);
                     expect(this.addTwo.getAttribute('data-medium-editor-element')).toBeDefined();
 

--- a/spec/init.spec.js
+++ b/spec/init.spec.js
@@ -186,8 +186,8 @@ describe('Initialization TestCase', function () {
         it('should set the ID according to the numbers of editors instantiated', function () {
             var editor1 = this.newMediumEditor('.editor'),
                 firstId = editor1.id,
-                editor2 = this.newMediumEditor('.editor'),
-                editor3 = this.newMediumEditor('.editor');
+                editor2 = this.newMediumEditor(this.createElement('div')),
+                editor3 = this.newMediumEditor(this.createElement('div'));
 
             expect(editor2.id).toBe(firstId + 1);
             expect(editor3.id).toBe(firstId + 2);

--- a/spec/init.spec.js
+++ b/spec/init.spec.js
@@ -92,32 +92,6 @@ describe('Initialization TestCase', function () {
             editor.setup();
             expect(editor.elements.length).toBe(1);
         });
-
-        it('should contain dynamically added elements after calling destory and setup again', function () {
-            var editor = this.newMediumEditor('.editor');
-            expect(editor.elements.length).toBe(1);
-            var otherElement = this.createElement('div', '', 'other');
-            editor.addElements(otherElement);
-            expect(editor.elements.length).toBe(2);
-            editor.destroy();
-            expect(editor.elements.length).toBe(0);
-            editor.setup();
-            expect(editor.elements.indexOf(document.querySelector('.editor'))).not.toBe(-1);
-            expect(editor.elements.indexOf(otherElement)).not.toBe(-1, 'The dynamically added element was not preserved after calling destory() -> setup()');
-        });
-
-        it('should not contain dynamically removed elements after calling destory and setup again', function () {
-            this.createElement('div', 'editor', 'other content');
-            var editor = this.newMediumEditor('.editor'),
-                firstElement = editor.elements[0];
-            expect(editor.elements.length).toBe(2);
-            editor.removeElements(firstElement);
-            expect(editor.elements.length).toBe(1);
-            editor.destroy();
-            expect(editor.elements.length).toBe(0);
-            editor.setup();
-            expect(editor.elements.indexOf(firstElement)).toBe(-1, 'The dynamically removed element was added back to elements after calling destroy() -> setup()');
-        });
     });
 
     describe('With a valid element', function () {

--- a/spec/init.spec.js
+++ b/spec/init.spec.js
@@ -92,6 +92,32 @@ describe('Initialization TestCase', function () {
             editor.setup();
             expect(editor.elements.length).toBe(1);
         });
+
+        it('should contain dynamically added elements after calling destory and setup again', function () {
+            var editor = this.newMediumEditor('.editor');
+            expect(editor.elements.length).toBe(1);
+            var otherElement = this.createElement('div', '', 'other');
+            editor.addElements(otherElement);
+            expect(editor.elements.length).toBe(2);
+            editor.destroy();
+            expect(editor.elements.length).toBe(0);
+            editor.setup();
+            expect(editor.elements.indexOf(document.querySelector('.editor'))).not.toBe(-1);
+            expect(editor.elements.indexOf(otherElement)).not.toBe(-1, 'The dynamically added element was not preserved after calling destory() -> setup()');
+        });
+
+        it('should not contain dynamically removed elements after calling destory and setup again', function () {
+            this.createElement('div', 'editor', 'other content');
+            var editor = this.newMediumEditor('.editor'),
+                firstElement = editor.elements[0];
+            expect(editor.elements.length).toBe(2);
+            editor.removeElements(firstElement);
+            expect(editor.elements.length).toBe(1);
+            editor.destroy();
+            expect(editor.elements.length).toBe(0);
+            editor.setup();
+            expect(editor.elements.indexOf(firstElement)).toBe(-1, 'The dynamically removed element was added back to elements after calling destroy() -> setup()');
+        });
     });
 
     describe('With a valid element', function () {

--- a/spec/textarea.spec.js
+++ b/spec/textarea.spec.js
@@ -205,4 +205,56 @@ describe('Textarea TestCase', function () {
             expect(this.el.classList.contains('medium-editor-hidden')).toBe(false);
         });
     });
+
+    describe('Calling removeElements', function () {
+        beforeEach(function () {
+            setupTestHelpers.call(this);
+            this.div = this.createElement('div', 'editable-div', 'sample div');
+            this.el = this.createElement('textarea', 'editor');
+            this.el.value = 'test content';
+            this.el.id = 'editor-textarea';
+        });
+
+        afterEach(function () {
+            this.cleanupTest();
+        });
+
+        it('should remove the created div and show the textarea when passed a div created for a textarea', function () {
+            var editor = this.newMediumEditor('.editor'),
+                createdDiv = editor.elements[0],
+                divParent = createdDiv.parentNode;
+            expect(editor.elements.length).toBe(1);
+            expect(this.el.classList.contains('medium-editor-hidden')).toBe(true);
+
+            editor.addElements(this.div);
+            expect(editor.elements.length).toBe(2);
+
+            editor.removeElements(createdDiv);
+            expect(editor.elements.length).toBe(1);
+            expect(createdDiv.parentNode).not.toBe(divParent, 'The div created for the textarea should have been removed');
+            expect(this.el.hasAttribute('medium-editor-textarea-id')).toBe(false,
+                'The textarea should not have a medium-editor-textarea-id attribute when its editor div is removed');
+            expect(this.el.classList.contains('medium-editor-hidden')).toBe(false,
+                'The textarea should be hidden when its editor div is removed');
+        });
+
+        it('should remove the created div and show the textaarea when passed the actual textarea', function () {
+            var editor = this.newMediumEditor('.editor'),
+                createdDiv = editor.elements[0],
+                divParent = createdDiv.parentNode;
+            expect(editor.elements.length).toBe(1);
+            expect(this.el.classList.contains('medium-editor-hidden')).toBe(true);
+
+            editor.addElements(this.div);
+            expect(editor.elements.length).toBe(2);
+
+            editor.removeElements(this.el);
+            expect(editor.elements.length).toBe(1);
+            expect(createdDiv.parentNode).not.toBe(divParent, 'The div created for the textarea should have been removed');
+            expect(this.el.hasAttribute('medium-editor-textarea-id')).toBe(false,
+                'The textarea should not have a medium-editor-textarea-id attribute when its editor div is removed');
+            expect(this.el.classList.contains('medium-editor-hidden')).toBe(false,
+                'The textarea should be hidden when its editor div is removed');
+        });
+    });
 });

--- a/spec/textarea.spec.js
+++ b/spec/textarea.spec.js
@@ -3,93 +3,206 @@
 describe('Textarea TestCase', function () {
     'use strict';
 
-    beforeEach(function () {
-        setupTestHelpers.call(this);
-        this.el = document.createElement('textarea');
-        this.el.className = 'editor';
-        this.el.value = 'test content';
-        this.el.setAttribute('data-disable-toolbar', false);
-        this.el.setAttribute('data-placeholder', 'Something');
-        this.el.setAttribute('data-disable-return', false);
-        this.el.setAttribute('data-disable-double-return', false);
-        this.el.setAttribute('data-disable-preview', false);
-        this.el.setAttribute('spellcheck', true);
-        this.el.setAttribute('data-imhere', 'ohyeah');
-        document.body.appendChild(this.el);
-    });
+    describe('MediumEditor constructor', function () {
+        beforeEach(function () {
+            setupTestHelpers.call(this);
+            this.el = this.createElement('textarea', 'editor');
+            this.el.value = 'test content';
+            this.el.setAttribute('data-disable-toolbar', false);
+            this.el.setAttribute('data-placeholder', 'Something');
+            this.el.setAttribute('data-disable-return', false);
+            this.el.setAttribute('data-disable-double-return', false);
+            this.el.setAttribute('data-disable-preview', false);
+            this.el.setAttribute('spellcheck', true);
+            this.el.setAttribute('data-imhere', 'ohyeah');
+        });
 
-    afterEach(function () {
-        document.body.removeChild(this.el);
-        this.cleanupTest();
-    });
+        afterEach(function () {
+            this.cleanupTest();
+        });
 
-    it('should accept a textarea element and "convert" it to a div, preserving all attributes', function () {
-        var editor = this.newMediumEditor('.editor'),
-            textarea = this.el;
-        expect(editor.elements[0].nodeName.toLowerCase()).toBe('div');
+        it('should accept a textarea element and "convert" it to a div, preserving all attributes', function () {
+            var editor = this.newMediumEditor('.editor'),
+                textarea = this.el;
+            expect(editor.elements[0].nodeName.toLowerCase()).toBe('div');
 
-        var attributes = [
-            'data-disable-editing',
-            'data-disable-toolbar',
-            'data-placeholder',
-            'data-disable-return',
-            'data-disable-double-return',
-            'data-disable-preview',
-            'spellcheck',
-            'data-imhere'
-        ];
-        attributes.forEach(function (attr) {
-            expect(editor.elements[0].getAttribute(attr)).toBe(textarea.getAttribute(attr));
+            var attributes = [
+                'data-disable-editing',
+                'data-disable-toolbar',
+                'data-placeholder',
+                'data-disable-return',
+                'data-disable-double-return',
+                'data-disable-preview',
+                'spellcheck',
+                'data-imhere'
+            ];
+            attributes.forEach(function (attr) {
+                expect(editor.elements[0].getAttribute(attr)).toBe(textarea.getAttribute(attr));
+            });
+        });
+
+        it('should sync editor changes with the original textarea element', function () {
+            var editor = this.newMediumEditor('.editor');
+            expect(this.el.value).toEqual('test content');
+            editor.elements[0].innerHTML = 'new content';
+            fireEvent(editor.elements[0], 'input');
+            fireEvent(editor.elements[0], 'keypress');
+            jasmine.clock().tick(1);
+            expect(this.el.value).toEqual('new content');
+        });
+
+        it('should preserve textarea className', function () {
+            this.el.className += ' test-class test-class-2';
+            var editor = this.newMediumEditor('.editor');
+            expect(editor.elements[0].className).toBe('editor test-class test-class-2');
+        });
+
+        it('should create unique div ids for multiple textareas', function () {
+            for (var i = 0; i < 12; i++) {
+                var ta = this.createElement('textarea', 'editor');
+                ta.value = 'test content';
+            }
+            var editor = this.newMediumEditor('.editor');
+            editor.elements.forEach(function (el) {
+                expect(document.querySelectorAll('div#' + el.id).length).toEqual(1);
+            });
+        });
+
+        it('should create unique medium-editor-textarea-ids across all editor instances', function () {
+            var tas = [];
+            for (var i = 0; i < 12; i++) {
+                var ta = this.createElement('textarea', 'editor');
+                ta.value = 'test content';
+                tas.push(ta);
+            }
+            tas.forEach(function (el) {
+                this.newMediumEditor(el);
+            }, this);
+            this.editors.forEach(function (editor) {
+                expect(document.querySelectorAll('textarea[medium-editor-textarea-id="' +
+                    editor.elements[0].getAttribute('medium-editor-textarea-id') + '"]').length).toEqual(1);
+            });
+        });
+
+        it('should cleanup after destroy', function () {
+            var editor = this.newMediumEditor('.editor');
+            expect(this.el.classList.contains('medium-editor-hidden')).toBe(true);
+            editor.destroy();
+            expect(this.el.classList.contains('medium-editor-hidden')).toBe(false);
         });
     });
 
-    it('should sync editor changes with the original textarea element', function () {
-        var editor = this.newMediumEditor('.editor');
-        expect(this.el.value).toEqual('test content');
-        editor.elements[0].innerHTML = 'new content';
-        fireEvent(editor.elements[0], 'input');
-        fireEvent(editor.elements[0], 'keypress');
-        jasmine.clock().tick(1);
-        expect(this.el.value).toEqual('new content');
-    });
-
-    it('should preserver textarea className', function () {
-        this.el.className += ' test-class test-class-2';
-        var editor = this.newMediumEditor('.editor');
-        expect(editor.elements[0].className).toBe('editor test-class test-class-2');
-    });
-
-    it('should create unique div ids for multiple textareas', function () {
-        for (var i = 0; i < 12; i++) {
-            var ta = this.createElement('textarea', 'editor');
-            ta.value = 'test content';
-        }
-        var editor = this.newMediumEditor('.editor');
-        editor.elements.forEach(function (el) {
-            expect(document.querySelectorAll('div#' + el.id).length).toEqual(1);
+    describe('Dynamically adding textarea elements to the editor', function () {
+        beforeEach(function () {
+            setupTestHelpers.call(this);
+            this.div = this.createElement('div', 'editable-div', 'sample div');
+            this.el = this.createElement('textarea', 'editor');
+            this.el.value = 'test content';
+            this.el.setAttribute('data-disable-toolbar', false);
+            this.el.setAttribute('data-placeholder', 'Something');
+            this.el.setAttribute('data-disable-return', false);
+            this.el.setAttribute('data-disable-double-return', false);
+            this.el.setAttribute('data-disable-preview', false);
+            this.el.setAttribute('spellcheck', true);
+            this.el.setAttribute('data-imhere', 'ohyeah');
         });
-    });
 
-    it('should create unique medium-editor-textarea-ids across all editor instances', function () {
-        var tas = [];
-        for (var i = 0; i < 12; i++) {
-            var ta = this.createElement('textarea', 'editor');
-            ta.value = 'test content';
-            tas.push(ta);
-        }
-        tas.forEach(function (el) {
-            this.newMediumEditor(el);
-        }, this);
-        this.editors.forEach(function (editor) {
-            expect(document.querySelectorAll('textarea[medium-editor-textarea-id="' +
-                editor.elements[0].getAttribute('medium-editor-textarea-id') + '"]').length).toEqual(1);
+        afterEach(function () {
+            this.cleanupTest();
         });
-    });
 
-    it('should cleanup after destroy', function () {
-        var editor = this.newMediumEditor('.editor');
-        expect(this.el.classList.contains('medium-editor-hidden')).toBe(true);
-        editor.destroy();
-        expect(this.el.classList.contains('medium-editor-hidden')).toBe(false);
+        it('should "convert" it to a div, preserving all attributes', function () {
+            var editor = this.newMediumEditor('.editable-div'),
+                textarea = this.el;
+            expect(editor.elements[0]).toBe(this.div);
+            expect(editor.elements.length).toBe(1);
+
+            editor.addElements(this.el);
+            expect(editor.elements.length).toBe(2);
+
+            var attributes = [
+                    'data-disable-editing',
+                    'data-disable-toolbar',
+                    'data-placeholder',
+                    'data-disable-return',
+                    'data-disable-double-return',
+                    'data-disable-preview',
+                    'spellcheck',
+                    'data-imhere'
+                ],
+                tempDiv = editor.elements[1];
+
+            attributes.forEach(function (attr) {
+                expect(tempDiv.getAttribute(attr)).toBe(textarea.getAttribute(attr));
+            });
+        });
+
+        it('should sync editor changes with the original textarea element', function () {
+            var editor = this.newMediumEditor('.editable-div');
+            editor.addElements(this.el);
+
+            expect(this.el.value).toEqual('test content');
+            expect(editor.elements[1].innerHTML).toEqual('test content');
+
+            editor.elements[1].innerHTML = 'new content';
+            fireEvent(editor.elements[1], 'input');
+            fireEvent(editor.elements[1], 'keypress');
+            jasmine.clock().tick(1);
+            expect(this.el.value).toEqual('new content');
+        });
+
+        it('should preserve textarea className', function () {
+            this.el.className += ' test-class test-class-2';
+            var editor = this.newMediumEditor('.editable-div');
+            editor.addElements(this.el);
+            expect(editor.elements[1].className).toBe('editor test-class test-class-2');
+        });
+
+        it('should create unique div ids for multiple textareas', function () {
+            this.div.setAttribute('id', 'medium-editor-12345');
+            for (var i = 0; i < 12; i++) {
+                var ta = this.createElement('textarea', 'editor');
+                ta.value = 'test content';
+            }
+            var editor = this.newMediumEditor('.editable-div');
+            expect(editor.elements.length).toBe(1);
+
+            editor.addElements(document.querySelectorAll('.editor'));
+            expect(editor.elements.length).toBe(14);
+
+            editor.elements.forEach(function (el) {
+                expect(document.querySelectorAll('div#' + el.id).length).toEqual(1);
+            });
+        });
+
+        it('should create unique medium-editor-textarea-ids across all editor instances', function () {
+            var tas = [];
+            for (var i = 0; i < 12; i++) {
+                var ta = this.createElement('textarea', 'editor');
+                ta.value = 'test content';
+                tas.push(ta);
+
+                var div = this.createElement('div', 'editable-div');
+                div.innerHTML = 'test div';
+                this.newMediumEditor(div);
+            }
+
+            tas.forEach(function (el, idx) {
+                this.editors[idx].addElements(el);
+            }, this);
+            this.editors.forEach(function (editor) {
+                expect(document.querySelectorAll('textarea[medium-editor-textarea-id="' +
+                    editor.elements[1].getAttribute('medium-editor-textarea-id') + '"]').length).toEqual(1);
+            });
+        });
+
+        it('should cleanup after destroy', function () {
+            var editor = this.newMediumEditor('.editable-div');
+            expect(this.el.classList.contains('medium-editor-hidden')).toBe(false);
+            editor.addElements(this.el);
+            expect(this.el.classList.contains('medium-editor-hidden')).toBe(true);
+            editor.destroy();
+            expect(this.el.classList.contains('medium-editor-hidden')).toBe(false);
+        });
     });
 });

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -205,13 +205,13 @@
         win._mediumEditors[this.id] = null;
     }
 
-    function createElementsArray(selector) {
+    function createElementsArray(selector, doc) {
         if (!selector) {
             selector = [];
         }
         // If string, use as query selector
         if (typeof selector === 'string') {
-            selector = this.options.ownerDocument.querySelectorAll(selector);
+            selector = doc.querySelectorAll(selector);
         }
         // If element, put into array
         if (MediumEditor.util.isElement(selector)) {
@@ -221,17 +221,17 @@
         var elements = Array.prototype.slice.apply(selector);
 
         // Loop through elements and convert textarea's into divs
-        this.elements = convertTextareas.call(this, elements);
+        return convertTextareas(elements, doc);
     }
 
-    function convertTextareas(elements) {
+    function convertTextareas(elements, doc) {
         return elements.map(function (element, index) {
             if (element.nodeName.toLowerCase() === 'textarea') {
-                return createContentEditable.call(this, element, index);
+                return createContentEditable(element, index, doc);
             } else {
                 return element;
             }
-        }, this);
+        });
     }
 
     function setExtensionDefaults(extension, defaults) {
@@ -309,15 +309,15 @@
         return !this.options.extensions['imageDragging'];
     }
 
-    function createContentEditable(textarea, id) {
-        var div = this.options.ownerDocument.createElement('div'),
+    function createContentEditable(textarea, id, doc) {
+        var div = doc.createElement('div'),
             now = Date.now(),
             uniqueId = 'medium-editor-' + now + '-' + id,
             atts = textarea.attributes;
 
         // Some browsers can move pretty fast, since we're using a timestamp
         // to make a unique-id, ensure that the id is actually unique on the page
-        while (this.options.ownerDocument.getElementById(uniqueId)) {
+        while (doc.getElementById(uniqueId)) {
             now++;
             uniqueId = 'medium-editor-' + now + '-' + id;
         }
@@ -621,7 +621,7 @@
                 return;
             }
 
-            createElementsArray.call(this, this.origElements);
+            this.elements = createElementsArray(this.origElements, this.options.ownerDocument);
 
             if (this.elements.length === 0) {
                 return;
@@ -1156,7 +1156,7 @@
 
             // Initialize all new elements (we check that in those functions don't worry)
             initElements.call(this);
-            this.elements = convertTextareas.call(this, this.elements);
+            this.elements = convertTextareas(this.elements, this.options.ownerDocument);
 
             filtered.forEach(function (element) {
                 reAttachHandlers.apply(this, [element]);

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -1130,15 +1130,6 @@
             this.events.updateInput(editable, { target: editable, currentTarget: editable });
         },
 
-        addElement: function (element) {
-            if (element.length) {
-                // it is already an array..
-                return this.addElements(element);
-            }
-
-            this.addElements([element]);
-        },
-
         addElements: function (selector) {
             // Convert elements into an array
             var elements = createElementsArray(selector, this.options.ownerDocument, true);

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -363,7 +363,7 @@
             element.setAttribute('data-medium-editor-element', true);
             element.setAttribute('role', 'textbox');
             element.setAttribute('aria-multiline', true);
-            element.setAttribute('medium-editor-index', this.guid());
+            element.setAttribute('medium-editor-index', MediumEditor.util.guid());
 
             if (element.hasAttribute('medium-editor-textarea-id')) {
                 isTextareaUsed = true;
@@ -427,7 +427,7 @@
             }
         }
 
-        this.events.reAttachCustomEvents(element);
+        this.events.reAttachCustomEventsOnElement(element);
     }
 
     function initExtensions() {
@@ -669,7 +669,6 @@
                 element.removeAttribute('role');
                 element.removeAttribute('aria-multiline');
                 element.removeAttribute('medium-editor-index');
-                element.removeAttribute('medium-editor-uid');
 
                 // Remove any elements created for textareas
                 if (element.hasAttribute('medium-editor-textarea-id')) {
@@ -1142,6 +1141,8 @@
         },
 
         addElements: function (elements) {
+            elements = elements.length ? elements : [elements];
+
             var filtered = [];
 
             // Filter the input, we want to include every element only once!
@@ -1170,40 +1171,27 @@
             }.bind(this));
         },
 
-        removeElement: function (elementToRemove) {
-            if (elementToRemove.length) {
-                // it is already an array..
-                return this.removeElements(elementToRemove);
-            }
-
-            var filtered = [];
-
-            this.elements.forEach(function (element) {
-                if (element.getAttribute('medium-editor-index') !== elementToRemove.getAttribute('medium-editor-index')) {
-                    filtered.push(element);
-                } else {
-                    this.events.cleanupElement(element);
-                }
-            }.bind(this));
-
-            this.elements = filtered;
-        },
-
         removeElements: function (elements) {
+            elements = elements.length ? elements : [elements];
+
+            var _this = this,
+                _removeElement = function (elementToRemove) {
+                    var filtered = [];
+
+                    _this.elements.forEach(function (element) {
+                        if (element.getAttribute('medium-editor-index') !== elementToRemove.getAttribute('medium-editor-index')) {
+                            filtered.push(element);
+                        } else {
+                            _this.events.cleanupElement(element);
+                        }
+                    });
+
+                    _this.elements = filtered;
+                };
+
             elements.forEach(function (element) {
-                this.removeElement(element);
-            }.bind(this));
-        },
-
-        guid: function () {
-            function _s4() {
-                return Math
-                    .floor((1 + Math.random()) * 0x10000)
-                    .toString(16)
-                    .substring(1);
-            }
-
-            return _s4() + _s4() + '-' + _s4() + '-' + _s4() + '-' + _s4() + '-' + _s4() + _s4() + _s4();
+                _removeElement(element);
+            });
         }
     };
 }());

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -1138,7 +1138,8 @@
         },
 
         addElements: function (elements) {
-            elements = elements.length ? elements : [elements];
+            // Convert elements into an array
+            elements = elements.length ? Array.prototype.slice.call(elements) : [elements];
 
             // Filter the input, we want to include every element only once!
             var filtered = elements.filter(function (element) {
@@ -1163,7 +1164,8 @@
         },
 
         removeElements: function (elements) {
-            elements = elements.length ? elements : [elements];
+            // Convert elements into an array
+            elements = elements.length ? Array.prototype.slice.call(elements) : [elements];
 
             var filtered = this.elements.filter(function (element) {
                 // If this is an element we want to remove

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -172,6 +172,13 @@
         }
     }
 
+    function handleEditableInput(event, editable) {
+        var textarea = editable.parentNode.querySelector('textarea[medium-editor-textarea-id="' + editable.getAttribute('medium-editor-textarea-id') + '"]');
+        if (textarea) {
+            textarea.value = editable.innerHTML.trim();
+        }
+    }
+
     // Internal helper methods which shouldn't be exposed externally
 
     function addToEditors(win) {
@@ -372,14 +379,8 @@
         return div;
     }
 
-    function initElements() {
-        var isTextareaUsed = false;
-
-        this.elements.forEach(function (element) {
-            if (element.getAttribute('data-medium-editor-element')) {
-                return;
-            }
-
+    function initElement(element) {
+        if (!element.getAttribute('data-medium-editor-element')) {
             if (!this.options.disableEditing && !element.getAttribute('data-disable-editing')) {
                 element.setAttribute('contentEditable', true);
                 element.setAttribute('spellcheck', this.options.spellcheck);
@@ -389,19 +390,17 @@
             element.setAttribute('aria-multiline', true);
             element.setAttribute('medium-editor-index', MediumEditor.util.guid());
 
-            if (element.getAttribute('medium-editor-textarea-id')) {
-                isTextareaUsed = true;
+            if (!this.instanceHandleEditableInput && element.getAttribute('medium-editor-textarea-id')) {
+                this.instanceHandleEditableInput = handleEditableInput.bind(this);
+                this.subscribe('editableInput', this.instanceHandleEditableInput);
             }
-        }, this);
-
-        if (isTextareaUsed) {
-            this.subscribe('editableInput', function (event, editable) {
-                var textarea = editable.parentNode.querySelector('textarea[medium-editor-textarea-id="' + editable.getAttribute('medium-editor-textarea-id') + '"]');
-                if (textarea) {
-                    textarea.value = this.serialize()[editable.id].value;
-                }
-            }.bind(this));
         }
+
+        return element;
+    }
+
+    function initElements() {
+        this.elements = this.elements.map(initElement, this);
     }
 
     function attachHandlers() {

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -389,6 +389,8 @@
             element.setAttribute('role', 'textbox');
             element.setAttribute('aria-multiline', true);
             element.setAttribute('medium-editor-index', MediumEditor.util.guid());
+
+            this.events.attachAllEvents(element);
         }
 
         return element;
@@ -444,8 +446,6 @@
                 this.on(element, 'keyup', handleKeyup.bind(this));
             }
         }
-
-        this.events.reAttachCustomEventsOnElement(element);
     }
 
     function initExtensions() {

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -405,7 +405,7 @@
             element.setAttribute('aria-multiline', true);
             element.setAttribute('medium-editor-index', MediumEditor.util.guid());
 
-            this.events.attachAllEvents(element);
+            this.events.attachAllEventsToElement(element);
         }
 
         return element;

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -67,6 +67,19 @@
             }
         },
 
+        // Attach all existing handlers to a new element
+        attachAllEventsToElement: function (element) {
+            if (this.listeners['editableInput']) {
+                this.contentCache[element.getAttribute('medium-editor-index')] = element.innerHTML;
+            }
+
+            if (this.eventsCache) {
+                this.eventsCache.forEach(function (e) {
+                    this.attachDOMEvent(element, e['name'], e['handler'].bind(this));
+                }, this);
+            }
+        },
+
         enableCustomEvent: function (event) {
             if (this.disabledEvents[event] !== undefined) {
                 delete this.disabledEvents[event];
@@ -112,19 +125,6 @@
                 this.customEvents[name].forEach(function (listener) {
                     listener(data, editable);
                 });
-            }
-        },
-
-        // Attach all existing handlers to a new element
-        attachAllEvents: function (element) {
-            if (this.listeners['editableInput']) {
-                this.contentCache[element.getAttribute('medium-editor-index')] = element.innerHTML;
-            }
-
-            if (this.eventsCache) {
-                this.eventsCache.forEach(function (e) {
-                    this.attachDOMEvent(element, e['name'], e['handler'].bind(this));
-                }, this);
             }
         },
 

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -269,7 +269,7 @@
                     this.contentCache = {};
                     this.base.elements.forEach(function (element) {
                         this.contentCache[element.getAttribute('medium-editor-index')] = element.innerHTML;
-                    }.bind(this));
+                    }, this);
 
                     // Attach to the 'oninput' event, handled correctly by most browsers
                     if (this.InputEventOnContenteditableSupported) {
@@ -359,7 +359,7 @@
         reAttachHandlersToElement: function (element) {
             this.eventsCache.forEach(function (e) {
                 this.attachDOMEvent(element, e['name'], e['handler'].bind(this));
-            }.bind(this));
+            }, this);
         },
 
         cleanupElement: function (element) {

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -86,8 +86,12 @@
             this.customEvents[event].push(listener);
         },
 
-        reAttachCustomEvents: function (element) {
-            this.reRunSetupListener(element);
+        reAttachCustomEventsOnElement: function (element) {
+            if (this.listeners['editableInput']) {
+                this.contentCache[element.getAttribute('medium-editor-index')] = element.innerHTML;
+            }
+
+            this.reAttachHandlersToElement(element);
         },
 
         detachCustomEvent: function (event, listener) {
@@ -239,21 +243,6 @@
             doc.execCommand = doc.execCommand.orig;
         },
 
-        reRunSetupListener: function (element) {
-            // rerun the part of setupListeners which is must be bound to this new element
-
-            if (this.listeners['editableInput']) {
-                this.contentCache[element.getAttribute('medium-editor-index')] = element.innerHTML;
-
-                // Attach to the 'oninput' event, handled correctly by most browsers
-                if (this.InputEventOnContenteditableSupported) {
-                    this.attachDOMEvent(element, 'input', this.handleInput.bind(this));
-                }
-            }
-
-            this.reAttachHandlersToElement(element);
-        },
-
         // Listening to browser events to emit events medium-editor cares about
         setupListener: function (name) {
             if (this.listeners[name]) {
@@ -280,12 +269,12 @@
                     this.contentCache = {};
                     this.base.elements.forEach(function (element) {
                         this.contentCache[element.getAttribute('medium-editor-index')] = element.innerHTML;
-
-                        // Attach to the 'oninput' event, handled correctly by most browsers
-                        if (this.InputEventOnContenteditableSupported) {
-                            this.attachDOMEvent(element, 'input', this.handleInput.bind(this));
-                        }
                     }.bind(this));
+
+                    // Attach to the 'oninput' event, handled correctly by most browsers
+                    if (this.InputEventOnContenteditableSupported) {
+                        this.attachToEachElement('input', this.handleInput);
+                    }
 
                     // For browsers which don't support the input event on contenteditable (IE)
                     // we'll attach to 'selectionchange' on the document and 'keypress' on the editables

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -86,14 +86,6 @@
             this.customEvents[event].push(listener);
         },
 
-        reAttachCustomEventsOnElement: function (element) {
-            if (this.listeners['editableInput']) {
-                this.contentCache[element.getAttribute('medium-editor-index')] = element.innerHTML;
-            }
-
-            this.reAttachHandlersToElement(element);
-        },
-
         detachCustomEvent: function (event, listener) {
             var index = this.indexOfCustomListener(event, listener);
             if (index !== -1) {
@@ -120,6 +112,19 @@
                 this.customEvents[name].forEach(function (listener) {
                     listener(data, editable);
                 });
+            }
+        },
+
+        // Attach all existing handlers to a new element
+        attachAllEvents: function (element) {
+            if (this.listeners['editableInput']) {
+                this.contentCache[element.getAttribute('medium-editor-index')] = element.innerHTML;
+            }
+
+            if (this.eventsCache) {
+                this.eventsCache.forEach(function (e) {
+                    this.attachDOMEvent(element, e['name'], e['handler'].bind(this));
+                }, this);
             }
         },
 
@@ -354,12 +359,6 @@
             }, this);
 
             this.eventsCache.push({ 'name': name, 'handler': handler });
-        },
-
-        reAttachHandlersToElement: function (element) {
-            this.eventsCache.forEach(function (e) {
-                this.attachDOMEvent(element, e['name'], e['handler'].bind(this));
-            }, this);
         },
 
         cleanupElement: function (element) {

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -1053,6 +1053,17 @@
             } else {
                 el.parentNode.removeChild(el);
             }
+        },
+
+        guid: function () {
+            function _s4() {
+                return Math
+                    .floor((1 + Math.random()) * 0x10000)
+                    .toString(16)
+                    .substring(1);
+            }
+
+            return _s4() + _s4() + '-' + _s4() + '-' + _s4() + '-' + _s4() + '-' + _s4() + _s4() + _s4();
         }
     };
 


### PR DESCRIPTION
This PR will replace my last [Dynamic add elements PR](https://github.com/yabwe/medium-editor/pull/1024) - now with one single commit :+1: 

The changes are much simpler now as everything is refactored according to our discussion @nmielnik ;)

* All events of `attachToEachElement` will be stored in a simple `this.eventsCache` array
* When adding an element, only the necessary code is run and we can simply iterate the eventsCache again and attach everything only to this new element in `attachAllEventsToElement`
* `addElements` is written in a way such that `setup` will use it when initializing, so a shared code path is used both for initialization and adding elements dynamically.
* The elements-exists check together with `cleanupElements` is removed and replaced with simple `removeElement(s)` instead, also the option flag is gone for it
* readme is rewritten to match the new logic for a "cleanupElements"

Now the only thing left i remember is your concern about the introduction of a guid instead of the existing array index on `medium-editor-index`, regarding backwards compatibility.

Yeah that's right.. unfortunately i really need this change because otherwise the cleanup functionality becomes unclean (irony) over time especially with the routing state changes of my ng2 app.

Anyway this needs to be mentioned in a change log for the release which will include this change. And, as far as one is not using the index from medium directly as a number/index for his own array.. it would still "just work" even with the new guid.. and... at least for myself.. why would one do that - i'd rather hack my own extension/change in my own fork/branch to introduce the change i want and call an api :P

***
##### What's Left
- [x] Allow selector string to be passed to `addElements` and `removeElements`
- [x] Fix bug and broken test around passing `<textarea>` in via `addElements`
- [x] Add tests around `removeElements` for `<textarea>` elements
- [x] Fix issue with cleaning up `<textarea>` via calls to `removeElements` (and add a test!)
- [x] Add more tests around `removeElements`
- [x] Create a failing test, and fix issue around adding an element with `data-disable-return` and/or `data-disable-double-return` attribute.