### PR TITLE
Support function chaining in event functions and allow multiple targets when adding event listeners

### DIFF
--- a/API.md
+++ b/API.md
@@ -9,8 +9,8 @@
   - [`destroy()`](#destroy)
   - [`setup()`](#setup)
 - [Event Functions](#event-functions)
-  - [`on(target, event, listener, useCapture)`](#ontarget-event-listener-usecapture)
-  - [`off(target, event, listener, useCapture)`](#offtarget-event-listener-usecapture)
+  - [`on(targets, event, listener, useCapture)`](#ontargets-event-listener-usecapture)
+  - [`off(targets, event, listener, useCapture)`](#offtargets-event-listener-usecapture)
   - [`subscribe(name, listener)`](#subscribename-listener)
   - [`unsubscribe(name, listener)`](#unsubscribename-listener)
   - [`trigger(name, data, editable)`](#triggername-data-editable)
@@ -83,15 +83,15 @@ Initialize this instance of the editor if it has been destroyed.  This will reus
 ***
 ## Event Functions
 
-### `on(target, event, listener, useCapture)`
+### `on(targets, event, listener, useCapture)`
 
-Attaches an event listener to specific element via the browser's built-in `addEventListener(type, listener, useCapture)` API.  However, this helper method also ensures that when MediumEditor is destroyed, this event listener will be automatically be detached from the DOM.
+Attaches an event listener to a specific element or elements via the browser's built-in `addEventListener(type, listener, useCapture)` API.  However, this helper method also ensures that when MediumEditor is destroyed, this event listener will be automatically be detached from the DOM.
 
 **Arguments**
 
-1. _**target** (`HTMLElement`)_:
+1. _**targets** (`HTMLElement` / `NodeList`)_:
 
-  * Element to attach listener to via `addEventListener(type, listener, useCapture)`
+  * Element or elements to attach listener to via `addEventListener(type, listener, useCapture)`
 
 2. _**event** (`String`)_:
 
@@ -106,15 +106,15 @@ Attaches an event listener to specific element via the browser's built-in `addEv
    * useCapture argument for `addEventListener(type, listener, useCapture)`
 
 ***
-### `off(target, event, listener, useCapture)`
+### `off(targets, event, listener, useCapture)`
 
-Detach an event listener from a specific element via the browser's built-in `removeEventListener(type, listener, useCapture)` API.
+Detach an event listener from a specific element or elements via the browser's built-in `removeEventListener(type, listener, useCapture)` API.
 
 **Arguments**
 
-1. _**target** (`HTMLElement`)_:
+1. _**targets** (`HTMLElement` / `NodeList`)_:
 
-  * Element to detach listener from via `removeEventListener(type, listener, useCapture)`
+  * Element or elements to detach listener from via `removeEventListener(type, listener, useCapture)`
 
 2. _**event** (`String`)_:
 

--- a/spec/events.spec.js
+++ b/spec/events.spec.js
@@ -24,6 +24,21 @@ describe('MediumEditor.Events TestCase', function () {
             jasmine.clock().tick(1);
             expect(spy).toHaveBeenCalled();
         });
+
+        it('should bind listener even to list of elements', function () {
+            var el1, el2, elements, editor, spy;
+            el1 = this.createElement('div');
+            el1.classList.add('test-element');
+            el2 = this.createElement('div');
+            el2.classList.add('test-element');
+            elements = document.getElementsByClassName('test-element');
+            spy = jasmine.createSpy('handler');
+            editor = this.newMediumEditor('.editor');
+            editor.on(elements, 'click', spy);
+            fireEvent(el1, 'click');
+            jasmine.clock().tick(1);
+            expect(spy).toHaveBeenCalled();
+        });
     });
 
     describe('Off', function () {
@@ -35,6 +50,22 @@ describe('MediumEditor.Events TestCase', function () {
             editor.on(el, 'click', spy);
             editor.off(el, 'click', spy);
             fireEvent(el, 'click');
+            jasmine.clock().tick(1);
+            expect(spy).not.toHaveBeenCalled();
+        });
+
+        it('should unbind listener even from list of elements', function () {
+            var el1, el2, elements, editor, spy;
+            el1 = this.createElement('div');
+            el1.classList.add('test-element');
+            el2 = this.createElement('div');
+            el2.classList.add('test-element');
+            elements = document.getElementsByClassName('test-element');
+            spy = jasmine.createSpy('handler');
+            editor = this.newMediumEditor('.editor');
+            editor.on(elements, 'click', spy);
+            editor.off(elements, 'click', spy);
+            fireEvent(el1, 'click');
             jasmine.clock().tick(1);
             expect(spy).not.toHaveBeenCalled();
         });

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -665,22 +665,32 @@
 
         on: function (target, event, listener, useCapture) {
             this.events.attachDOMEvent(target, event, listener, useCapture);
+
+            return this;
         },
 
         off: function (target, event, listener, useCapture) {
             this.events.detachDOMEvent(target, event, listener, useCapture);
+
+            return this;
         },
 
         subscribe: function (event, listener) {
             this.events.attachCustomEvent(event, listener);
+
+            return this;
         },
 
         unsubscribe: function (event, listener) {
             this.events.detachCustomEvent(event, listener);
+
+            return this;
         },
 
         trigger: function (name, data, editable) {
             this.events.triggerCustomEvent(name, data, editable);
+
+            return this;
         },
 
         delay: function (fn) {

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -15,18 +15,26 @@
 
         // Helpers for event handling
 
-        attachDOMEvent: function (target, event, listener, useCapture) {
-            target.addEventListener(event, listener, useCapture);
-            this.events.push([target, event, listener, useCapture]);
+        attachDOMEvent: function (targets, event, listener, useCapture) {
+            targets = MediumEditor.util.isElement(targets) || [window, document].indexOf(targets) > -1 ? [targets] : targets;
+
+            Array.prototype.forEach.call(targets, function (target) {
+                target.addEventListener(event, listener, useCapture);
+                this.events.push([target, event, listener, useCapture]);
+            }.bind(this));
         },
 
-        detachDOMEvent: function (target, event, listener, useCapture) {
-            var index = this.indexOfListener(target, event, listener, useCapture),
-                e;
-            if (index !== -1) {
-                e = this.events.splice(index, 1)[0];
-                e[0].removeEventListener(e[1], e[2], e[3]);
-            }
+        detachDOMEvent: function (targets, event, listener, useCapture) {
+            var index, e;
+            targets = MediumEditor.util.isElement(targets) || [window, document].indexOf(targets) > -1 ? [targets] : targets;
+
+            Array.prototype.forEach.call(targets, function (target) {
+                index = this.indexOfListener(target, event, listener, useCapture);
+                if (index !== -1) {
+                    e = this.events.splice(index, 1)[0];
+                    e[0].removeEventListener(e[1], e[2], e[3]);
+                }
+            }.bind(this));
         },
 
         indexOfListener: function (target, event, listener, useCapture) {


### PR DESCRIPTION
This small PR consists of two minor improvements:

- Add support for function chaining in event functions (`on`, `off`, `subscribe`, `unsubscribe`, `trigger`), so you can write this:

```javascript
this
    .on(/*...*/)
    .on(/*...*/)
    .on(/*...*/);
```

... instead of this:

```javascript
this.on(/*...*/);
this.on(/*...*/);
this.on(/*...*/);
```

- Allow multiple targets when adding or removing event listeners:

```javascript
var elements = document.getElementsByClassName('some-class');
this.on(elements, 'click', listener);
```

... instead of this:

```javascript
var elements = document.getElementsByClassName('some-class');
this.on(elements[0], 'click', listener);
this.on(elements[1], 'click', listener);
```