### PR TITLE
Fix #994 - Prevent Firefox NS_ERROR_FAILURE: on keyup

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -149,6 +149,8 @@
             return;
         }
 
+        // https://github.com/yabwe/medium-editor/issues/994
+        // Firefox thrown an error when calling `formatBlock` on an empty editable blockContainer that's not a <div>
         if (MediumEditor.util.isMediumEditorElement(node) && node.children.length === 0 && !MediumEditor.util.isBlockContainer(node)) {
             this.options.ownerDocument.execCommand('formatBlock', false, 'p');
         }


### PR DESCRIPTION
From @nextend in #1020:
> In Firefox if the editable is a node without children, then NS_ERROR_FAILURE: error thrown for every keyup until it gets a child node. 

> Issue: https://github.com/yabwe/medium-editor/issues/994

This completes #1020 by adding a test to verify the fix.

In addition to adding a new test, I also rearranged the tests in `content.spec.js` to be grouped a bit better.