### PR TITLE
Fix #1057 - replace break-all with break-word

### DIFF
--- a/src/sass/medium-editor.scss
+++ b/src/sass/medium-editor.scss
@@ -10,7 +10,7 @@
 
 // contenteditable rules
 [data-medium-editor-element] {
-    word-break: break-all;
+    word-wrap: break-word;
     min-height: 30px;
 
     img {


### PR DESCRIPTION
#1043 introduced `word-break: break-all;` which unfortunately did more harm than good.

It splits words at the end of a line even if it's not needed: 
![image](https://cloud.githubusercontent.com/assets/312938/14504419/091ab4c0-01b5-11e6-9243-72de9263c9af.png)

This small PR just replaces this wrong behavior with much safer `word-wrap: break-word;`

Fixes #1057