### PR TITLE
Add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,21 @@
+### Description
+
+[Description of the bug or feature]
+
+### Steps to reproduce
+
+1. [First step]
+2. [Second step]
+3. [and so on...]
+
+**Expected behavior:** [What you expected to happen]
+
+**Actual behavior:** [What actually happened]
+
+**Link to [JSFiddle](https://jsfiddle.net/):** [If you're reporting a bug that's not reproducible on our [demo page](https://yabwe.github.io/medium-editor/demo.html), please try to reproduce it on [JSFiddle](https://jsfiddle.net/) and paste a link here]
+
+### Versions
+
+- medium-editor:
+- browser:
+- OS:

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -12,7 +12,7 @@
 
 **Actual behavior:** [What actually happened]
 
-**Link to [JSFiddle](https://jsfiddle.net/):** [If you're reporting a bug that's not reproducible on our [demo page](https://yabwe.github.io/medium-editor/demo.html), please try to reproduce it on [JSFiddle](https://jsfiddle.net/) and paste a link here]
+**Link to an example:** [If you're reporting a bug that's not reproducible on our [demo page](https://yabwe.github.io/medium-editor/demo.html), please try to reproduce it on [JSFiddle](https://jsfiddle.net/), [JS Bin](https://jsbin.com), [CodePen](http://codepen.io/) or a similar service and paste a link here]
 
 ### Versions
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+| Q                | A
+| ---------------- | ---
+| Bug fix?         | yes/no
+| New feature?     | yes/no
+| BC breaks?       | yes/no
+| Deprecations?    | yes/no
+| New tests added? | yes/not needed
+| Fixed tickets    | comma-separated list of tickets fixed by the PR, if any
+| License          | MIT
+
+### Description
+
+[Description of the bug or feature]
+
+--
+
+#### Please, don't submit `/dist` files with your PR!


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | -
| License          | MIT

### Description

First draft of issue and PR templates. Feel free to comment, if I've forgotten something, or if something is not needed. 

The PR template is inspired by [symfony's template](https://github.com/symfony/symfony/blob/v3.0.4/.github/PULL_REQUEST_TEMPLATE.md) and the issue template by [atom's one](https://github.com/atom/atom/blob/v1.7.1/ISSUE_TEMPLATE.md).