### PR TITLE
protect headers from newline

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -143,7 +143,9 @@
 
     function handleKeyup(event) {
         var node = MediumEditor.selection.getSelectionStart(this.options.ownerDocument),
-            tagName;
+            closestBlockTag,
+            tagName,
+            isHeader;
 
         if (!node) {
             return;
@@ -158,9 +160,12 @@
         // https://github.com/yabwe/medium-editor/issues/834
         // https://github.com/yabwe/medium-editor/pull/382
         // Don't call format block if this is a block element (ie h1, figCaption, etc.)
+        closestBlockTag = MediumEditor.util.getClosestBlockContainer(node).nodeName.toLowerCase();
+        isHeader = /h\d/i;
         if (MediumEditor.util.isKey(event, MediumEditor.util.keyCode.ENTER) &&
             !MediumEditor.util.isListItem(node) &&
-            !MediumEditor.util.isBlockContainer(node)) {
+            !MediumEditor.util.isBlockContainer(node) &&
+            !isHeader.test(closestBlockTag)) {
 
             tagName = node.nodeName.toLowerCase();
             // For anchor tags, unlink


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not yet
| Fixed tickets    | https://github.com/yabwe/medium-editor/issues/1060
| License          | MIT

### Description

This is temporary fix for https://github.com/yabwe/medium-editor/issues/1060 issue, I did it for a project in which I participate. It must be imporoved of course, because this bug involves not only `<h*>` elements, but every block-type elements.
It will be good if someone will give ideas for improvements and tests for this PR, I'm afraid to break something).

