### PR TITLE
execActionInternal should pass opt to document.execCommand if action …

### DIFF
--- a/spec/anchor.spec.js
+++ b/spec/anchor.spec.js
@@ -338,7 +338,7 @@ describe('Anchor Button TestCase', function () {
                 link,
                 anchorExtension = editor.getExtensionByName('anchor'),
                 expectedOpts = {
-                    url: 'http://te%20s%20t.com/',
+                    value: 'http://te%20s%20t.com/',
                     target: '_self'
                 };
 
@@ -352,7 +352,7 @@ describe('Anchor Button TestCase', function () {
 
             link = editor.elements[0].querySelector('a');
             expect(link).not.toBeNull();
-            expect(link.href).toBe(expectedOpts.url);
+            expect(link.href).toBe(expectedOpts.value);
         });
         it('should not change spaces to %20 if linkValidation is set to false', function () {
             var editor = this.newMediumEditor('.editor', {
@@ -363,14 +363,14 @@ describe('Anchor Button TestCase', function () {
                 link,
                 anchorExtension = editor.getExtensionByName('anchor'),
                 expectedOpts = {
-                    url: 'http://te s t.com/',
+                    value: 'http://te s t.com/',
                     target: '_self'
                 };
 
             spyOn(editor, 'execAction').and.callThrough();
 
             selectElementContentsAndFire(editor.elements[0]);
-            anchorExtension.showForm(expectedOpts.url);
+            anchorExtension.showForm(expectedOpts.value);
             fireEvent(anchorExtension.getForm().querySelector('a.medium-editor-toolbar-save'), 'click');
 
             // Chrome, Edge, and IE will automatically escape the href once it's set on the link
@@ -449,7 +449,7 @@ describe('Anchor Button TestCase', function () {
                 keyCode: MediumEditor.util.keyCode.ENTER
             });
             opts = {
-                url: 'http://test.com',
+                value: 'http://test.com',
                 target: '_self',
                 buttonClass: 'btn btn-default'
             };
@@ -525,7 +525,7 @@ describe('Anchor Button TestCase', function () {
             });
 
             expect(editor.createLink).toHaveBeenCalledWith({
-                url: 'http://www.example.com',
+                value: 'http://www.example.com',
                 target: '_blank'
             });
             expect(window.getSelection().toString()).toBe('ipsum', 'selected text should remain selected');
@@ -558,7 +558,7 @@ describe('Anchor Button TestCase', function () {
             });
 
             expect(editor.createLink).toHaveBeenCalledWith({
-                url: 'http://www.example.com',
+                value: 'http://www.example.com',
                 target: '_self'
             });
 
@@ -598,7 +598,7 @@ describe('Anchor Button TestCase', function () {
             });
 
             expect(editor.createLink).toHaveBeenCalledWith({
-                url: 'http://www.example.com',
+                value: 'http://www.example.com',
                 target: '_self'
             });
 
@@ -637,7 +637,7 @@ describe('Anchor Button TestCase', function () {
             });
 
             expect(editor.createLink).toHaveBeenCalledWith({
-                url: 'http://www.example.com',
+                value: 'http://www.example.com',
                 target: '_self'
             });
 

--- a/spec/core-api.spec.js
+++ b/spec/core-api.spec.js
@@ -103,6 +103,16 @@ describe('Core-API', function () {
         });
     });
 
+    describe('execAction', function () {
+        it('should pass opt directly to document.execCommand', function () {
+            spyOn(document, 'execCommand').and.callThrough();
+            var editor = this.newMediumEditor('.editor');
+
+            editor.execAction('foreColor', 'red');
+            expect(document.execCommand).toHaveBeenCalledWith('foreColor', false, 'red');
+        });
+    });
+
     describe('checkContentChanged', function () {
         it('should trigger editableInput when called after the html has changed', function () {
             var editor = this.newMediumEditor('.editor', {

--- a/spec/core-api.spec.js
+++ b/spec/core-api.spec.js
@@ -108,8 +108,40 @@ describe('Core-API', function () {
             spyOn(document, 'execCommand').and.callThrough();
             var editor = this.newMediumEditor('.editor');
 
-            editor.execAction('foreColor', 'red');
+            editor.execAction('foreColor', { value: 'red' });
             expect(document.execCommand).toHaveBeenCalledWith('foreColor', false, 'red');
+        });
+
+        it('fontName support old style', function () {
+            spyOn(document, 'execCommand').and.callThrough();
+            var editor = this.newMediumEditor('.editor');
+
+            editor.execAction('fontName', { name: 'Tahoma' });
+            expect(document.execCommand).toHaveBeenCalledWith('fontName', false, 'Tahoma');
+        });
+
+        it('fontName support new stle', function () {
+            spyOn(document, 'execCommand').and.callThrough();
+            var editor = this.newMediumEditor('.editor');
+
+            editor.execAction('fontName', { value: 'Tahoma' });
+            expect(document.execCommand).toHaveBeenCalledWith('fontName', false, 'Tahoma');
+        });
+
+        it('fontSize support old style', function () {
+            spyOn(document, 'execCommand').and.callThrough();
+            var editor = this.newMediumEditor('.editor');
+
+            editor.execAction('fontSize', { size: 14 });
+            expect(document.execCommand).toHaveBeenCalledWith('fontSize', false, 14);
+        });
+
+        it('fontSize support new stle', function () {
+            spyOn(document, 'execCommand').and.callThrough();
+            var editor = this.newMediumEditor('.editor');
+
+            editor.execAction('fontSize', { value: 14 });
+            expect(document.execCommand).toHaveBeenCalledWith('fontSize', false, 14);
         });
     });
 

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -497,7 +497,8 @@
         /*jslint regexp: true*/
         var appendAction = /^append-(.+)$/gi,
             justifyAction = /justify([A-Za-z]*)$/g, /* Detecting if is justifyCenter|Right|Left */
-            match;
+            match,
+            cmdValueArgument;
         /*jslint regexp: false*/
 
         // Actions starting with 'append-' should attempt to format a block of text ('formatBlock') using a specific
@@ -508,11 +509,13 @@
         }
 
         if (action === 'fontSize') {
-            return this.options.ownerDocument.execCommand('fontSize', false, opts.size);
+            cmdValueArgument = opts.value || opts.size;
+            return this.options.ownerDocument.execCommand('fontSize', false, cmdValueArgument);
         }
 
         if (action === 'fontName') {
-            return this.options.ownerDocument.execCommand('fontName', false, opts.name);
+            cmdValueArgument = opts.value || opts.name;
+            return this.options.ownerDocument.execCommand('fontName', false, cmdValueArgument);
         }
 
         if (action === 'createLink') {
@@ -536,7 +539,8 @@
             return result;
         }
 
-        return this.options.ownerDocument.execCommand(action, false, opts);
+        cmdValueArgument = opts && opts.value;
+        return this.options.ownerDocument.execCommand(action, false, cmdValueArgument);
     }
 
     /* If we've just justified text within a container block
@@ -942,7 +946,8 @@
 
         createLink: function (opts) {
             var currentEditor = MediumEditor.selection.getSelectionElement(this.options.contentWindow),
-                customEvent = {};
+                customEvent = {},
+                targetUrl;
 
             // Make sure the selection is within an element this editor is tracking
             if (this.elements.indexOf(currentEditor) === -1) {
@@ -951,7 +956,8 @@
 
             try {
                 this.events.disableCustomEvent('editableInput');
-                if (opts.url && opts.url.trim().length > 0) {
+                targetUrl = opts.url || opts.value;
+                if (targetUrl && targetUrl.trim().length > 0) {
                     var currentSelection = this.options.contentWindow.getSelection();
                     if (currentSelection) {
                         var currRange = currentSelection.getRangeAt(0),
@@ -1043,7 +1049,7 @@
                             }
 
                             // Creates the link in the document fragment
-                            MediumEditor.util.createLink(this.options.ownerDocument, textNodes, opts.url.trim());
+                            MediumEditor.util.createLink(this.options.ownerDocument, textNodes, targetUrl.trim());
 
                             // Chrome trims the leading whitespaces when inserting HTML, which messes up restoring the selection.
                             var leadingWhitespacesCount = (fragment.firstChild.innerHTML.match(/^\s+/) || [''])[0].length;
@@ -1055,13 +1061,13 @@
 
                             this.importSelection(exportedSelection);
                         } else {
-                            this.options.ownerDocument.execCommand('createLink', false, opts.url);
+                            this.options.ownerDocument.execCommand('createLink', false, targetUrl);
                         }
 
                         if (this.options.targetBlank || opts.target === '_blank') {
-                            MediumEditor.util.setTargetBlank(MediumEditor.selection.getSelectionStart(this.options.ownerDocument), opts.url);
+                            MediumEditor.util.setTargetBlank(MediumEditor.selection.getSelectionStart(this.options.ownerDocument), targetUrl);
                         } else {
-                            MediumEditor.util.removeTargetBlank(MediumEditor.selection.getSelectionStart(this.options.ownerDocument), opts.url);
+                            MediumEditor.util.removeTargetBlank(MediumEditor.selection.getSelectionStart(this.options.ownerDocument), targetUrl);
                         }
 
                         if (opts.buttonClass) {

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -536,7 +536,7 @@
             return result;
         }
 
-        return this.options.ownerDocument.execCommand(action, false, null);
+        return this.options.ownerDocument.execCommand(action, false, opts);
     }
 
     /* If we've just justified text within a container block

--- a/src/js/extensions/anchor.js
+++ b/src/js/extensions/anchor.js
@@ -150,12 +150,12 @@
                 targetCheckbox = this.getAnchorTargetCheckbox(),
                 buttonCheckbox = this.getAnchorButtonCheckbox();
 
-            opts = opts || { url: '' };
+            opts = opts || { value: '' };
             // TODO: This is for backwards compatability
             // We don't need to support the 'string' argument in 6.0.0
             if (typeof opts === 'string') {
                 opts = {
-                    url: opts
+                    value: opts
                 };
             }
 
@@ -164,7 +164,7 @@
             MediumEditor.extensions.form.prototype.showForm.apply(this);
             this.setToolbarPosition();
 
-            input.value = opts.url;
+            input.value = opts.value;
             input.focus();
 
             // If we have a target checkbox, we want it to be checked/unchecked
@@ -201,11 +201,11 @@
             var targetCheckbox = this.getAnchorTargetCheckbox(),
                 buttonCheckbox = this.getAnchorButtonCheckbox(),
                 opts = {
-                    url: this.getInput().value.trim()
+                    value: this.getInput().value.trim()
                 };
 
             if (this.linkValidation) {
-                opts.url = this.checkLinkFormat(opts.url);
+                opts.value = this.checkLinkFormat(opts.value);
             }
 
             opts.target = '_self';

--- a/src/js/extensions/fontname.js
+++ b/src/js/extensions/fontname.js
@@ -158,7 +158,7 @@
             if (font === '') {
                 this.clearFontName();
             } else {
-                this.execAction('fontName', { name: font });
+                this.execAction('fontName', { value: font });
             }
         },
 

--- a/src/js/extensions/fontsize.js
+++ b/src/js/extensions/fontsize.js
@@ -151,7 +151,7 @@
             if (size === '4') {
                 this.clearFontSize();
             } else {
-                this.execAction('fontSize', { size: size });
+                this.execAction('fontSize', { value: size });
             }
         },
 


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | yes
| Fixed tickets    |
| License          | MIT

### Description

I think it should pass opts parameter of MediumEditor.execAction through the 3rd parameter of Document.execCommand.

It will give a chance to caller to be able to execute command that are not support by MediumEditor's internal command, for example, `foreColor` command.

If a given command is not require any value to be passed, it will send undefined or maybe I think the browser just ignore it.