### PR TITLE
Allow passing options to 'non-medium' commands

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -562,7 +562,7 @@
             return result;
         }
 
-        return this.options.ownerDocument.execCommand(action, false, null);
+        return this.options.ownerDocument.execCommand(action, false, opts);
     }
 
     /* If we've just justified text within a container block


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | yes
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | don't know it they are needed.
| Fixed tickets    | 
| License          | MIT

### Description

Allow passing options to comands executed through the 'execAction' method. Previously, ME didn't allow the execution of commands that need options (such as `insertHTML`, `insertText`, etc.)

E.g. allow passing text to the insertText action

--

I don't know where to add the tests for this, if any are required.