### PR TITLE
Fix null pointer during the cleanupElement event

### DIFF
--- a/src/js/events.js
+++ b/src/js/events.js
@@ -366,7 +366,7 @@
             if (index) {
                 this.detachAllEventsFromElement(element);
                 
-                if(this.contentCache) {
+                if (this.contentCache) {
                     delete this.contentCache[index];
                 }
             }

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -365,7 +365,10 @@
             var index = element.getAttribute('medium-editor-index');
             if (index) {
                 this.detachAllEventsFromElement(element);
-                delete this.contentCache[index];
+                
+                if(this.contentCache){
+                    delete this.contentCache[index];
+                }
             }
         },
 

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -366,7 +366,7 @@
             if (index) {
                 this.detachAllEventsFromElement(element);
                 
-                if(this.contentCache){
+                if(this.contentCache) {
                     delete this.contentCache[index];
                 }
             }

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -365,7 +365,6 @@
             var index = element.getAttribute('medium-editor-index');
             if (index) {
                 this.detachAllEventsFromElement(element);
-                
                 if (this.contentCache) {
                     delete this.contentCache[index];
                 }


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | 
| License          | MIT

### Description

I ran into an issue that after manually adding elements to the editor (through addElements), and later deleting them again there (through removeElements) was a TypeError being thrown.

It appears that contentCache is not set when only using dynamically added elements, thus while removing that element it will run into an error resulting the element not being removed properly.

This checks if contentCache is set.
