### PR TITLE
Deprecate some execAction and createLink options

### DIFF
--- a/spec/core-api.spec.js
+++ b/spec/core-api.spec.js
@@ -173,6 +173,40 @@ describe('Core-API', function () {
             expect(document.execCommand).toHaveBeenCalledWith('fontSize', false, 14);
             MediumEditor.Events.prototype.InputEventOnContenteditableSupported = origSupported;
         });
+
+        it('createLink support old style', function () {
+            // In order to safely spy on document.execCommand we need to disable functionality
+            // which overrides document.execCommand in IE & Edge
+            var origSupported = MediumEditor.Events.prototype.InputEventOnContenteditableSupported;
+            MediumEditor.Events.prototype.InputEventOnContenteditableSupported = true;
+
+            spyOn(document, 'execCommand').and.callThrough();
+            var editor = this.newMediumEditor('.editor');
+
+            selectElementContentsAndFire(editor.elements[0].firstChild);
+            jasmine.clock().tick(1);
+
+            editor.execAction('createLink', { url: 'http://www.test.com' });
+            expect(document.execCommand).toHaveBeenCalledWith('createLink', false, 'http://www.test.com');
+            MediumEditor.Events.prototype.InputEventOnContenteditableSupported = origSupported;
+        });
+
+        it('createLink support new style', function () {
+            // In order to safely spy on document.execCommand we need to disable functionality
+            // which overrides document.execCommand in IE & Edge
+            var origSupported = MediumEditor.Events.prototype.InputEventOnContenteditableSupported;
+            MediumEditor.Events.prototype.InputEventOnContenteditableSupported = true;
+
+            spyOn(document, 'execCommand').and.callThrough();
+            var editor = this.newMediumEditor('.editor');
+
+            selectElementContentsAndFire(editor.elements[0].firstChild);
+            jasmine.clock().tick(1);
+
+            editor.execAction('createLink', { value: 'http://www.test.com' });
+            expect(document.execCommand).toHaveBeenCalledWith('createLink', false, 'http://www.test.com');
+            MediumEditor.Events.prototype.InputEventOnContenteditableSupported = origSupported;
+        });
     });
 
     describe('checkContentChanged', function () {

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -544,7 +544,7 @@
         }
 
         if (action === 'fontName') {
-            // TODO: Deprecate support for opts.size in 6.0.0
+            // TODO: Deprecate support for opts.name in 6.0.0
             if (opts.name) {
                 MediumEditor.util.deprecated('.name option for fontName command', '.value', '6.0.0');
             }
@@ -987,7 +987,7 @@
 
             try {
                 this.events.disableCustomEvent('editableInput');
-                // TODO: Deprecated support for opts.url in 6.0.0
+                // TODO: Deprecate support for opts.url in 6.0.0
                 if (opts.url) {
                     MediumEditor.util.deprecated('.url option for createLink', '.value', '6.0.0');
                 }

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -535,11 +535,19 @@
         }
 
         if (action === 'fontSize') {
+            // TODO: Deprecate support for opts.size in 6.0.0
+            if (opts.size) {
+                MediumEditor.util.deprecated('.size option for fontSize command', '.value', '6.0.0');
+            }
             cmdValueArgument = opts.value || opts.size;
             return this.options.ownerDocument.execCommand('fontSize', false, cmdValueArgument);
         }
 
         if (action === 'fontName') {
+            // TODO: Deprecate support for opts.size in 6.0.0
+            if (opts.name) {
+                MediumEditor.util.deprecated('.name option for fontName command', '.value', '6.0.0');
+            }
             cmdValueArgument = opts.value || opts.name;
             return this.options.ownerDocument.execCommand('fontName', false, cmdValueArgument);
         }
@@ -979,6 +987,10 @@
 
             try {
                 this.events.disableCustomEvent('editableInput');
+                // TODO: Deprecated support for opts.url in 6.0.0
+                if (opts.url) {
+                    MediumEditor.util.deprecated('.url option for createLink', '.value', '6.0.0');
+                }
                 targetUrl = opts.url || opts.value;
                 if (targetUrl && targetUrl.trim().length > 0) {
                     var currentSelection = this.options.contentWindow.getSelection();


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | yes
| New tests added? | yes
| License          | MIT

### Description

Deprecate usage of `.url` for `createLink()`, and usage of `.size` + `.name` for `fontSize` and `fontName` command respectively when calling `.execAction()`.

Also, add test to ensure `.url` is properly supported for backwards compatibility until 6.0.0 is released.