### PR TITLE
Allow preview to be shown on empty links

### DIFF
--- a/spec/anchor-preview.spec.js
+++ b/spec/anchor-preview.spec.js
@@ -202,11 +202,29 @@ describe('Anchor Preview TestCase', function () {
             expect(anchor.getAnchorButtonCheckbox().checked).toBe(true);
         });
 
-        it('should NOT be displayed when the hovered link is empty', function () {
+        it('should be displayed by default when the hovered link is empty', function () {
             var editor = this.newMediumEditor('.editor', {
                     delay: 200
                 }),
                 anchorPreview = editor.getExtensionByName('anchor-preview');
+
+            // show preview
+            spyOn(MediumEditor.extensions.anchorPreview.prototype, 'showPreview').and.callThrough();
+            fireEvent(document.getElementById('test-empty-link'), 'mouseover');
+
+            // preview shows only after delay
+            jasmine.clock().tick(250);
+            expect(anchorPreview.showPreview).toHaveBeenCalled();
+        });
+
+        it('should NOT be displayed when the hovered link is empty and the option showOnEmptyLinks is set to false', function () {
+            var editor = this.newMediumEditor('.editor', {
+                delay: 200,
+                anchorPreview: {
+                    showOnEmptyLinks: false
+                }
+            }),
+            anchorPreview = editor.getExtensionByName('anchor-preview');
 
             // show preview
             spyOn(MediumEditor.extensions.anchorPreview.prototype, 'showPreview').and.callThrough();

--- a/src/js/extensions/anchor-preview.js
+++ b/src/js/extensions/anchor-preview.js
@@ -21,6 +21,11 @@
          */
         showWhenToolbarIsVisible: false,
 
+        /* showOnEmptyLinks: [boolean]
+        * determines whether the anchor tag preview shows up on links with href="" or href="#something"
+        */
+        showOnEmptyLinks: true,
+
         init: function () {
             this.anchorPreview = this.createPreview();
 
@@ -179,7 +184,8 @@
             // Detect empty href attributes
             // The browser will make href="" or href="#top"
             // into absolute urls when accessed as event.target.href, so check the html
-            if (!/href=["']\S+["']/.test(target.outerHTML) || /href=["']#\S+["']/.test(target.outerHTML)) {
+            if (!this.showOnEmptyLinks &&
+                (!/href=["']\S+["']/.test(target.outerHTML) || /href=["']#\S+["']/.test(target.outerHTML))) {
                 return true;
             }
 


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | yes
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | yes
| Fixed tickets    |  #1071 
| License          | MIT

### Description

By default anchor preview will be shown on empty links (href='' or href="#something"). This feature can be turned of when  showOnEmptyLinks = false in extension settings.

--