### PR TITLE
Expose method for getting editor instance from an element

### DIFF
--- a/API.md
+++ b/API.md
@@ -40,6 +40,9 @@
   - [`getExtensionByName(name)`](#getextensionbynamename)
   - [`serialize()`](#serialize)
   - [`setContent(html, index)`](#setcontenthtml-index)
+- [Static Functions/Properties](#static-functionsproperties)
+  - [`getEditorFromElement(element)`](#geteditorfromelementelement)
+  - [`version`](#version)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -464,3 +467,32 @@ Trigger the `editableInput` event.
 
 2. _**index** (`integer`)_:
   * Index of the element to set the content on. Defaults to 0 when not provided.
+
+***
+## Static Functions/Properties
+
+### `getEditorFromElement(element)`
+
+Given an editor **element**, retrieves the instance of MediumEditor which created/is monitoring the **element**
+
+**Arguments**
+
+1. _**element** (`DOMElement`)_:
+  * An editor **element** which is part of a MediumEditor instance
+
+### `version`
+
+Object containing data about the version of the current MediumEditor library
+
+**Properties of 'version'**
+
+1. _**major** (`Number`)_
+  * The major version number (ie the `3` in `"3.2.1"`)
+2. _**minor** (`Number`)_
+  * The minor version number (ie the `2` in `"3.2.1"`)
+3. _**revision** (`Number`)_
+  * The revision (aka "patch") version number (ie the `1` in `"3.2.1"`)
+4. _**preRelease** (`String`)_
+  * The pre-release version tag (ie the `"rc.1"` in `"5.0.0-rc.1"`)
+5. _**toString** (`Function`)_
+  * Returns the full version number as a string (ie `"5.0.0-rc.1"`)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ MediumEditor has been written using vanilla JavaScript, no additional frameworks
 
 [![Sauce Test Status](https://saucelabs.com/browser-matrix/mediumeditor.svg)](https://saucelabs.com/u/mediumeditor)
 
-![Supportd Browsers](https://cloud.githubusercontent.com/assets/2444240/12874138/d3960a04-cd9b-11e5-8cc5-8136d82cf5f6.png)
+![Supported Browsers](https://cloud.githubusercontent.com/assets/2444240/12874138/d3960a04-cd9b-11e5-8cc5-8136d82cf5f6.png)
 
 [![NPM info](https://nodei.co/npm/medium-editor.png?downloads=true)](https://www.npmjs.com/package/medium-editor)
 
@@ -559,15 +559,19 @@ View the [MediumEditor Object API documentation](API.md) on the Wiki for details
 * __.serialize()__: returns a JSON object with elements contents
 * __.setContent(html, index)__: sets the `innerHTML` to `html` of the element at `index`
 
+### Static Methods/Properties
+* __.getEditorFromElement(element)__: retrieve the instance of MediumEditor that is monitoring the provided editor element
+* __.version__: the version information for the MediumEditor library
+
 ## Dynamically add/remove elements to your instance
 
-It is possible to dynamically add new elements to your existing MediumtEditor instance:
+It is possible to dynamically add new elements to your existing MediumEditor instance:
 
 ```javascript
 var editor = new MediumEditor('.editable');
 editor.subscribe('editableInput', this._handleEditableInput.bind(this));
 
-// imagine an ajax fetch/any other dynamic functionality which will add new '.editable' elements to dom
+// imagine an ajax fetch/any other dynamic functionality which will add new '.editable' elements to the DOM
 
 editor.addElements('.editable');
 // OR editor.addElements(document.getElementsByClassName('editable'));
@@ -585,7 +589,7 @@ Passing an elements or array of elements to `addElements(elements)` will:
 
 ### Removing elements dynamically
 
-Straight forward, just call `removeElements` with the elemnt or array of elements you to want to tear down. Each element itself will remain a contenteditable - it will just remove all event handlers and all references to it so you can safely remove it from DOM.
+Straight forward, just call `removeElements` with the element or array of elements you to want to tear down. Each element itself will remain a contenteditable - it will just remove all event handlers and all references to it so you can safely remove it from DOM.
 
 ```javascript
 editor.removeElements(document.querySelector('#myElement'));
@@ -625,7 +629,7 @@ This is handy when you need to capture any modifications to the contenteditable 
 
 Why is this interesting and why should you use this event instead of just attaching to the `input` event on the contenteditable element?
 
-So for most modern browsers (Chrome, Firefox, Safari, etc.), the `input` event works just fine. Infact, `editableInput` is just a proxy for the `input` event in those browsers. However, the `input` event [is not supported for contenteditable elements in IE 9-11](https://connect.microsoft.com/IE/feedback/details/794285/ie10-11-input-event-does-not-fire-on-div-with-contenteditable-set) and is _mostly_ supported in Microsoft Edge, but not fully.
+So for most modern browsers (Chrome, Firefox, Safari, etc.), the `input` event works just fine. In fact, `editableInput` is just a proxy for the `input` event in those browsers. However, the `input` event [is not supported for contenteditable elements in IE 9-11](https://connect.microsoft.com/IE/feedback/details/794285/ie10-11-input-event-does-not-fire-on-div-with-contenteditable-set) and is _mostly_ supported in Microsoft Edge, but not fully.
 
 So, to properly support the `editableInput` event in Internet Explorer and Microsoft Edge, MediumEditor uses a combination of the `selectionchange` and `keypress` events, as well as monitoring calls to `document.execCommand`.
 

--- a/spec/core-api.spec.js
+++ b/spec/core-api.spec.js
@@ -253,4 +253,21 @@ describe('Core-API', function () {
             expect(spy).not.toHaveBeenCalled();
         });
     });
+
+    describe('getEditorFromElement', function () {
+        it('should return the editor instance the element belongs to', function () {
+            var elTwo = this.createElement('div', 'editor-two', 'lore ipsum'),
+                editorOne = this.newMediumEditor('.editor'),
+                editorTwo = this.newMediumEditor('.editor-two');
+            expect(editorOne.elements[0]).toBe(this.el);
+            expect(editorTwo.elements[0]).toBe(elTwo);
+
+            expect(MediumEditor.getEditorFromElement(this.el)).toBe(editorOne);
+            expect(MediumEditor.getEditorFromElement(elTwo)).toBe(editorTwo);
+        });
+
+        it('should return null if the element is not within an editor', function () {
+            expect(MediumEditor.getEditorFromElement(this.el)).toBeNull();
+        });
+    });
 });

--- a/spec/elements.spec.js
+++ b/spec/elements.spec.js
@@ -1,16 +1,16 @@
 describe('Elements TestCase', function () {
     'use strict';
 
+    beforeEach(function () {
+        setupTestHelpers.call(this);
+        this.el = this.createElement('div', 'editor', 'lore ipsum');
+    });
+
+    afterEach(function () {
+        this.cleanupTest();
+    });
+
     describe('Initialization', function () {
-        beforeEach(function () {
-            setupTestHelpers.call(this);
-            this.el = this.createElement('div', 'editor', 'lore ipsum');
-        });
-
-        afterEach(function () {
-            this.cleanupTest();
-        });
-
         it('should set element contenteditable attribute to true', function () {
             var editor = this.newMediumEditor('.editor');
             expect(editor.elements.length).toBe(1);
@@ -54,6 +54,43 @@ describe('Elements TestCase', function () {
             var editor = this.newMediumEditor('.editor');
             expect(editor.elements[0]).toBe(this.el);
             expect(parseInt(this.el.getAttribute('data-medium-editor-editor-index'))).toBe(editor.id);
+        });
+    });
+
+    describe('Destroy', function () {
+        it('should remove the contenteditable attribute', function () {
+            var editor = this.newMediumEditor('.editor');
+            expect(this.el.getAttribute('contenteditable')).toEqual('true');
+            editor.destroy();
+            expect(this.el.hasAttribute('contenteditable')).toBe(false);
+        });
+
+        it('should remove the medium-editor-element attribute', function () {
+            var editor = this.newMediumEditor('.editor');
+            expect(this.el.getAttribute('data-medium-editor-element')).toEqual('true');
+            editor.destroy();
+            expect(this.el.hasAttribute('data-medium-editor-element')).toBe(false);
+        });
+
+        it('should remove the role attribute', function () {
+            var editor = this.newMediumEditor('.editor');
+            expect(this.el.getAttribute('role')).toEqual('textbox');
+            editor.destroy();
+            expect(this.el.hasAttribute('role')).toBe(false);
+        });
+
+        it('should remove the aria-multiline attribute', function () {
+            var editor = this.newMediumEditor('.editor');
+            expect(this.el.getAttribute('aria-multiline')).toEqual('true');
+            editor.destroy();
+            expect(this.el.hasAttribute('aria-multiline')).toBe(false);
+        });
+
+        it('should remove the data-medium-editor-editor-index attribute', function () {
+            var editor = this.newMediumEditor('.editor');
+            expect(parseInt(this.el.getAttribute('data-medium-editor-editor-index'))).toBe(editor.id);
+            editor.destroy();
+            expect(this.el.hasAttribute('data-medium-editor-editor-index')).toBe(false);
         });
     });
 });

--- a/spec/elements.spec.js
+++ b/spec/elements.spec.js
@@ -49,5 +49,11 @@ describe('Elements TestCase', function () {
             expect(editor.elements.length).toBe(1);
             expect(this.el.getAttribute('aria-multiline')).toEqual('true');
         });
+
+        it('should set the data-medium-editor-editor-index attribute to be the id of the editor instance', function () {
+            var editor = this.newMediumEditor('.editor');
+            expect(editor.elements[0]).toBe(this.el);
+            expect(parseInt(this.el.getAttribute('data-medium-editor-editor-index'))).toBe(editor.id);
+        });
     });
 });

--- a/spec/textarea.spec.js
+++ b/spec/textarea.spec.js
@@ -58,6 +58,10 @@ describe('Textarea TestCase', function () {
         });
 
         it('should create unique div ids for multiple textareas', function () {
+            var origDateNow = Date.now;
+            Date.now = function () {
+                return 1464448478887;
+            };
             for (var i = 0; i < 12; i++) {
                 var ta = this.createElement('textarea', 'editor');
                 ta.value = 'test content';
@@ -66,9 +70,14 @@ describe('Textarea TestCase', function () {
             editor.elements.forEach(function (el) {
                 expect(document.querySelectorAll('div#' + el.id).length).toEqual(1);
             });
+            Date.now = origDateNow;
         });
 
         it('should create unique medium-editor-textarea-ids across all editor instances', function () {
+            var origDateNow = Date.now;
+            Date.now = function () {
+                return 1464448478887;
+            };
             var tas = [];
             for (var i = 0; i < 12; i++) {
                 var ta = this.createElement('textarea', 'editor');
@@ -82,6 +91,7 @@ describe('Textarea TestCase', function () {
                 expect(document.querySelectorAll('textarea[medium-editor-textarea-id="' +
                     editor.elements[0].getAttribute('medium-editor-textarea-id') + '"]').length).toEqual(1);
             });
+            Date.now = origDateNow;
         });
 
         it('should cleanup after destroy', function () {

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -333,17 +333,17 @@
         return !this.options.extensions['imageDragging'];
     }
 
-    function createContentEditable(textarea, id, doc) {
+    function createContentEditable(textarea, doc) {
         var div = doc.createElement('div'),
             now = Date.now(),
-            uniqueId = 'medium-editor-' + now + '-' + id,
+            uniqueId = 'medium-editor-' + now,
             atts = textarea.attributes;
 
         // Some browsers can move pretty fast, since we're using a timestamp
         // to make a unique-id, ensure that the id is actually unique on the page
         while (doc.getElementById(uniqueId)) {
             now++;
-            uniqueId = 'medium-editor-' + now + '-' + id;
+            uniqueId = 'medium-editor-' + now;
         }
 
         div.className = textarea.className;
@@ -369,10 +369,10 @@
         return div;
     }
 
-    function initElement(element, id) {
+    function initElement(element) {
         if (!element.getAttribute('data-medium-editor-element')) {
             if (element.nodeName.toLowerCase() === 'textarea') {
-                element = createContentEditable(element, id, this.options.ownerDocument);
+                element = createContentEditable(element, this.options.ownerDocument);
 
                 // Make sure we only attach to editableInput once for <textarea> elements
                 if (!this.instanceHandleEditableInput) {

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -1193,4 +1193,13 @@
             }, this);
         }
     };
+
+    MediumEditor.getEditorFromElement = function (element) {
+        var index = element.getAttribute('data-medium-editor-editor-index'),
+            win = element && element.ownerDocument && (element.ownerDocument.defaultView || element.ownerDocument.parentWindow);
+        if (win && win._mediumEditors && win._mediumEditors[index]) {
+            return win._mediumEditors[index];
+        }
+        return null;
+    };
 }());

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -369,7 +369,7 @@
         return div;
     }
 
-    function initElement(element) {
+    function initElement(element, editorId) {
         if (!element.getAttribute('data-medium-editor-element')) {
             if (element.nodeName.toLowerCase() === 'textarea') {
                 element = createContentEditable(element, this.options.ownerDocument);
@@ -404,6 +404,7 @@
             element.setAttribute('role', 'textbox');
             element.setAttribute('aria-multiline', true);
             element.setAttribute('medium-editor-index', MediumEditor.util.guid());
+            element.setAttribute('data-medium-editor-editor-index', editorId);
 
             this.events.attachAllEventsToElement(element);
         }
@@ -640,6 +641,7 @@
                 return;
             }
 
+            addToEditors.call(this, this.options.contentWindow);
             this.events = new MediumEditor.Events(this);
             this.elements = [];
 
@@ -650,7 +652,6 @@
             }
 
             this.isActive = true;
-            addToEditors.call(this, this.options.contentWindow);
 
             // Call initialization helpers
             initExtensions.call(this);
@@ -685,6 +686,7 @@
                 element.removeAttribute('role');
                 element.removeAttribute('aria-multiline');
                 element.removeAttribute('medium-editor-index');
+                element.removeAttribute('data-medium-editor-editor-index');
 
                 // Remove any elements created for textareas
                 if (element.getAttribute('medium-editor-textarea-id')) {
@@ -1159,7 +1161,7 @@
 
             elements.forEach(function (element) {
                 // Initialize all new elements (we check that in those functions don't worry)
-                element = initElement.call(this, element);
+                element = initElement.call(this, element, this.id);
 
                 // Add new elements to our internal elements array
                 this.elements.push(element);


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | yes
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | yes
| License          | MIT

### Description

Introduce new static method `MediumEditor.getEditorFromElement(element)` which returns the corresponding instance of MediumEditor provided an editor element.

This allows for developers to not have to store instances of MediumEditor provided they can get access to the editor elements themselves from the DOM.

Internally, it leverages the already existing global array of instance of MediumEditor by adding a data attribute to each editor element that specifies which index in the global array the instance is located.
