### PR TITLE
Add getContent method (Fix #492)

### DIFF
--- a/API.md
+++ b/API.md
@@ -37,6 +37,7 @@
 - [Helper Functions](#helper-functions)
   - [`checkContentChanged(editable)`](#checkContentChangededitable)
   - [`delay(fn)`](#delayfn)
+  - [`getContent(index)`](#getcontentindex)
   - [`getExtensionByName(name)`](#getextensionbynamename)
   - [`serialize()`](#serialize)
   - [`setContent(html, index)`](#setcontenthtml-index)
@@ -439,6 +440,16 @@ Delay any function from being executed by the amount of time passed as the **del
   * Function to delay execution for.
 
 ***
+### `getContent(index)`
+
+Returns the trimmed html content for the first editor **element**, or the **element** at `index`.
+
+**Arguments**
+
+1. _**index** (`integer`)_: _**OPTIONAL**_
+  * Index of the editor **element** to retrieve the content from. Defaults to 0 when not provided (returns content of the first editor **element**).
+
+***
 ### `getExtensionByName(name)`
 
 Get a reference to an extension with the specified name.
@@ -457,16 +468,15 @@ Returns a JSON object including the content of each of the **elements** inside t
 ***
 ### `setContent(html, index)`
 
-Sets the innerHTML content for the element at `index`.
-Trigger the `editableInput` event.
+Sets the html content for the first editor **element**, or the **element** at `index`. Ensures the the `editableInput` event is triggered.
 
 **Arguments**
 
 1. _**html** (`string`)_:
   * The content to set the element to
 
-2. _**index** (`integer`)_:
-  * Index of the element to set the content on. Defaults to 0 when not provided.
+2. _**index** (`integer`)_: _**OPTIONAL**_
+  * Index of the editor **element** to set the content of. Defaults to 0 when not provided (sets content of the first editor **element**).
 
 ***
 ## Static Functions/Properties

--- a/README.md
+++ b/README.md
@@ -555,6 +555,7 @@ View the [MediumEditor Object API documentation](API.md) on the Wiki for details
 
 ### Helper Methods
 * __.delay(fn)__: delay any function from being executed by the amount of time passed as the `delay` option
+* __.getContent(index)__: gets the trimmed `innerHTML` of the element at `index`
 * __.getExtensionByName(name)__: get a reference to an extension with the specified name
 * __.serialize()__: returns a JSON object with elements contents
 * __.setContent(html, index)__: sets the `innerHTML` to `html` of the element at `index`

--- a/spec/core-api.spec.js
+++ b/spec/core-api.spec.js
@@ -55,6 +55,25 @@ describe('Core-API', function () {
         });
     });
 
+    describe('getContent', function () {
+        it('should retrieve the content of the first element', function () {
+            var editor = this.newMediumEditor('.editor');
+            expect(editor.getContent()).toEqual('lore ipsum');
+        });
+
+        it('should retrieve the content of the element at the specified index', function () {
+            var otherHTML = 'something different';
+            this.createElement('div', 'editor', otherHTML);
+            var editor = this.newMediumEditor('.editor');
+            expect(editor.getContent(1)).toEqual(otherHTML);
+        });
+
+        it('should return null if no element exists', function () {
+            var editor = this.newMediumEditor('.no-valid-selector');
+            expect(editor.getContent()).toBeNull();
+        });
+    });
+
     describe('saveSelection/restoreSelection', function () {
         it('should be applicable if html changes but text does not', function () {
             this.el.innerHTML = 'lorem <i>ipsum</i> dolor';

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -1145,6 +1145,15 @@
             }
         },
 
+        getContent: function (index) {
+            index = index || 0;
+
+            if (this.elements[index]) {
+                return this.elements[index].innerHTML.trim();
+            }
+            return null;
+        },
+
         checkContentChanged: function (editable) {
             editable = editable || MediumEditor.selection.getSelectionElement(this.options.contentWindow);
             this.events.updateInput(editable, { target: editable, currentTarget: editable });


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | yes
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | yes
| Fixed tickets    | #492
| License          | MIT

### Description

Expose simple helper for retrieving content from a MediumEditor instance as requested in #492.  The `getContent()` method is a natural compliment to `setContent()` and behaves as expected based on the behavior of `setContent()`.