### PR TITLE
Fix #719 - Respect form.reset for textarea elements within forms

### DIFF
--- a/API.md
+++ b/API.md
@@ -39,6 +39,7 @@
   - [`delay(fn)`](#delayfn)
   - [`getContent(index)`](#getcontentindex)
   - [`getExtensionByName(name)`](#getextensionbynamename)
+  - [`resetContent(element)`](#resetcontentelement)
   - [`serialize()`](#serialize)
   - [`setContent(html, index)`](#setcontenthtml-index)
 - [Static Functions/Properties](#static-functionsproperties)
@@ -459,6 +460,17 @@ Get a reference to an extension with the specified name.
 1. _**name** (`String`)_:
 
   * The name of the extension to retrieve (ie `toolbar`).
+
+***
+### `resetContent(element)`
+
+Reset the content of all editor **elements** to their value at the time they were added to the editor.  If a specific editor **element** is provided, only the content of that element will be reset.
+
+**Arguments**
+
+1. _**element** (`DOMElement`)_: _**OPTIONAL**_
+
+  * Specific editor **element** to reset the content of.
 
 ***
 ### `serialize()`

--- a/README.md
+++ b/README.md
@@ -558,6 +558,7 @@ View the [MediumEditor Object API documentation](API.md) on the Wiki for details
 * __.delay(fn)__: delay any function from being executed by the amount of time passed as the `delay` option
 * __.getContent(index)__: gets the trimmed `innerHTML` of the element at `index`
 * __.getExtensionByName(name)__: get a reference to an extension with the specified name
+* __.resetContent(element)__: reset the content of all elements or a specific element to its value when added to the editor initially
 * __.serialize()__: returns a JSON object with elements contents
 * __.setContent(html, index)__: sets the `innerHTML` to `html` of the element at `index`
 

--- a/spec/core-api.spec.js
+++ b/spec/core-api.spec.js
@@ -103,10 +103,10 @@ describe('Core-API', function () {
             editor.setContent('<p>changed content</p>', 1);
             expect(elementTwo.innerHTML).not.toEqual(initialTwo);
 
-            editor.resetContent(this.el);
+            editor.resetContent(elementTwo);
 
-            expect(this.el.innerHTML).toEqual(initialOne);
-            expect(elementTwo.innerHTML).not.toEqual(initialTwo);
+            expect(this.el.innerHTML).not.toEqual(initialOne);
+            expect(elementTwo.innerHTML).toEqual(initialTwo);
         });
 
         it('should not reset anything if an invalid element is provided', function () {

--- a/spec/core-api.spec.js
+++ b/spec/core-api.spec.js
@@ -74,6 +74,60 @@ describe('Core-API', function () {
         });
     });
 
+    describe('resetContent', function () {
+        it('should reset the content of all editor elements to their initial values', function () {
+            var initialOne = this.el.innerHTML,
+                initialTwo = 'Lorem ipsum dolor',
+                elementTwo = this.createElement('div', 'editor', initialTwo),
+                editor = this.newMediumEditor('.editor');
+
+            editor.setContent('<p>changed content</p>');
+            expect(this.el.innerHTML).not.toEqual(initialOne);
+            editor.setContent('<p>changed content</p>', 1);
+            expect(elementTwo.innerHTML).not.toEqual(initialTwo);
+
+            editor.resetContent();
+
+            expect(this.el.innerHTML).toEqual(initialOne);
+            expect(elementTwo.innerHTML).toEqual(initialTwo);
+        });
+
+        it('should reset the content of a specific element when provided', function () {
+            var initialOne = this.el.innerHTML,
+                initialTwo = 'Lorem ipsum dolor',
+                elementTwo = this.createElement('div', 'editor', initialTwo),
+                editor = this.newMediumEditor('.editor');
+
+            editor.setContent('<p>changed content</p>');
+            expect(this.el.innerHTML).not.toEqual(initialOne);
+            editor.setContent('<p>changed content</p>', 1);
+            expect(elementTwo.innerHTML).not.toEqual(initialTwo);
+
+            editor.resetContent(this.el);
+
+            expect(this.el.innerHTML).toEqual(initialOne);
+            expect(elementTwo.innerHTML).not.toEqual(initialTwo);
+        });
+
+        it('should not reset anything if an invalid element is provided', function () {
+            var initialOne = this.el.innerHTML,
+                initialTwo = 'Lorem ipsum dolor',
+                elementTwo = this.createElement('div', 'editor', initialTwo),
+                dummyElement = this.createElement('div', 'not-editor', '<p>dummy element</p>'),
+                editor = this.newMediumEditor('.editor');
+
+            editor.setContent('<p>changed content</p>');
+            expect(this.el.innerHTML).not.toEqual(initialOne);
+            editor.setContent('<p>changed content</p>', 1);
+            expect(elementTwo.innerHTML).not.toEqual(initialTwo);
+
+            editor.resetContent(dummyElement);
+
+            expect(this.el.innerHTML).not.toEqual(initialOne);
+            expect(elementTwo.innerHTML).not.toEqual(initialTwo);
+        });
+    });
+
     describe('saveSelection/restoreSelection', function () {
         it('should be applicable if html changes but text does not', function () {
             this.el.innerHTML = 'lorem <i>ipsum</i> dolor';

--- a/spec/textarea.spec.js
+++ b/spec/textarea.spec.js
@@ -100,6 +100,21 @@ describe('Textarea TestCase', function () {
             editor.destroy();
             expect(this.el.classList.contains('medium-editor-hidden')).toBe(false);
         });
+
+        it('should reset the value of created div when form containing textarea is reset', function () {
+            var form = this.createElement('form', null, null, true),
+                initialContent = this.el.value;
+            form.appendChild(this.el);
+            document.body.appendChild(form);
+            var editor = this.newMediumEditor('.editor');
+            expect(editor.elements[0].innerHTML).toEqual(initialContent);
+
+            editor.setContent('<p>custom content</p>');
+            expect(editor.elements[0].innerHTML).not.toEqual(initialContent);
+
+            form.reset();
+            expect(editor.elements[0].innerHTML).toEqual(initialContent);
+        });
     });
 
     describe('Dynamically adding textarea elements to the editor', function () {
@@ -213,6 +228,28 @@ describe('Textarea TestCase', function () {
             expect(this.el.classList.contains('medium-editor-hidden')).toBe(true);
             editor.destroy();
             expect(this.el.classList.contains('medium-editor-hidden')).toBe(false);
+        });
+
+        it('should reset the value of created div when form containing textarea is reset', function () {
+            var form = this.createElement('form', null, null, true),
+                initialContent = 'initial text',
+                otherTextarea = this.createElement('textarea', 'editor', initialContent, true),
+                editor = this.newMediumEditor('.editor');
+            otherTextarea.value = initialContent;
+            expect(editor.elements.length).toBe(1);
+
+            form.appendChild(otherTextarea);
+            document.body.appendChild(form);
+
+            editor.addElements(otherTextarea);
+            var createdDiv = editor.elements[1];
+            expect(createdDiv.innerHTML).toEqual(initialContent);
+
+            editor.setContent('<p>custom content</p>', 1);
+            expect(createdDiv.innerHTML).not.toEqual(initialContent);
+
+            form.reset();
+            expect(createdDiv.innerHTML).toEqual(initialContent);
         });
     });
 

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -1178,17 +1178,20 @@
         },
 
         resetContent: function (element) {
-            var elements = this.elements;
+            // For all elements that exist in the this.elements array, we can assume:
+            // - Its initial content has been set in the initialContent object
+            // - It has a medium-editor-index attribute which is the key value in the initialContent object
+
             if (element) {
-                elements = [];
-                if (this.elements.indexOf(element) !== -1) {
-                    elements.push(element);
+                var index = this.elements.indexOf(element);
+                if (index !== -1) {
+                    this.setContent(initialContent[element.getAttribute('medium-editor-index')], index);
                 }
+                return;
             }
-            elements.forEach(function (el, idx) {
-                if (el) {
-                    this.setContent(initialContent[el.getAttribute('medium-editor-index')], idx);
-                }
+
+            this.elements.forEach(function (el, idx) {
+                this.setContent(initialContent[el.getAttribute('medium-editor-index')], idx);
             }, this);
         },
 

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -333,15 +333,15 @@
         return !this.options.extensions['imageDragging'];
     }
 
-    function createContentEditable(textarea, doc) {
-        var div = doc.createElement('div'),
+    function createContentEditable(textarea) {
+        var div = this.options.ownerDocument.createElement('div'),
             now = Date.now(),
             uniqueId = 'medium-editor-' + now,
             atts = textarea.attributes;
 
         // Some browsers can move pretty fast, since we're using a timestamp
         // to make a unique-id, ensure that the id is actually unique on the page
-        while (doc.getElementById(uniqueId)) {
+        while (this.options.ownerDocument.getElementById(uniqueId)) {
             now++;
             uniqueId = 'medium-editor-' + now;
         }
@@ -360,6 +360,16 @@
             }
         }
 
+        // If textarea has a form, listen for reset on the form to clear
+        // the content of the created div
+        if (textarea.form) {
+            this.on(textarea.form, 'reset', function (event) {
+                if (!event.defaultPrevented) {
+                    this.resetContent(this.options.ownerDocument.getElementById(uniqueId));
+                }
+            }.bind(this));
+        }
+
         textarea.classList.add('medium-editor-hidden');
         textarea.parentNode.insertBefore(
             div,
@@ -372,7 +382,7 @@
     function initElement(element, editorId) {
         if (!element.getAttribute('data-medium-editor-element')) {
             if (element.nodeName.toLowerCase() === 'textarea') {
-                element = createContentEditable(element, this.options.ownerDocument);
+                element = createContentEditable.call(this, element);
 
                 // Make sure we only attach to editableInput once for <textarea> elements
                 if (!this.instanceHandleEditableInput) {

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -400,11 +400,17 @@
                 this.on(element, 'keyup', handleKeyup.bind(this));
             }
 
+            var elementId = MediumEditor.util.guid();
+
             element.setAttribute('data-medium-editor-element', true);
             element.setAttribute('role', 'textbox');
             element.setAttribute('aria-multiline', true);
-            element.setAttribute('medium-editor-index', MediumEditor.util.guid());
             element.setAttribute('data-medium-editor-editor-index', editorId);
+            // TODO: Merge data-medium-editor-element and medium-editor-index attributes for 6.0.0
+            // medium-editor-index is not named correctly anymore and can be re-purposed to signify
+            // whether the element has been initialized or not
+            element.setAttribute('medium-editor-index', elementId);
+            initialContent[elementId] = element.innerHTML;
 
             this.events.attachAllEventsToElement(element);
         }
@@ -622,6 +628,8 @@
             this.restoreSelection();
         }
     }
+
+    var initialContent = {};
 
     MediumEditor.prototype = {
         // NOT DOCUMENTED - exposed for backwards compatability
@@ -1157,6 +1165,21 @@
         checkContentChanged: function (editable) {
             editable = editable || MediumEditor.selection.getSelectionElement(this.options.contentWindow);
             this.events.updateInput(editable, { target: editable, currentTarget: editable });
+        },
+
+        resetContent: function (element) {
+            var elements = this.elements;
+            if (element) {
+                elements = [];
+                if (this.elements.indexOf(element) !== -1) {
+                    elements.push(element);
+                }
+            }
+            elements.forEach(function (el, idx) {
+                if (el) {
+                    this.setContent(initialContent[el.getAttribute('medium-editor-index')], idx);
+                }
+            }, this);
         },
 
         addElements: function (selector) {


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | yes
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | yes
| Fixed tickets    | #719 
| License          | MIT

### Description

The goal of this change was ensure that when a `<textarea>` element within a form is reset, that the editor `<div>` created by the editor is also reset back to its initial value.

To accomplish this, this change set also introduces a new `resetContent()` method for resetting any element back to its initial value when the editor was initialized or when the element was first added to the editor.
