### PR TITLE
Support any extension preventing blur of editor (Fix #830)

### DIFF
--- a/spec/extension.spec.js
+++ b/spec/extension.spec.js
@@ -1,4 +1,4 @@
-/*global selectElementContentsAndFire */
+/*global selectElementContentsAndFire, fireEvent */
 
 describe('Extensions TestCase', function () {
     'use strict';
@@ -283,6 +283,40 @@ describe('Extensions TestCase', function () {
 
             expect(tempExtension.getEditorOption('disableReturn')).toBe(true);
             expect(tempExtension.getEditorOption('spellcheck')).toBe(editor.options.spellcheck);
+        });
+
+        it('should be able to prevent blur on the editor when user iteracts with extension elements', function () {
+            var sampleElOne = this.createElement('button', null, 'Test Button'),
+                sampleElTwo = this.createElement('textarea', null, 'Test Div'),
+                externalEl = this.createElement('div', 'external-element', 'External Element'),
+                TempExtension = MediumEditor.Extension.extend({
+                    getInteractionElements: function () {
+                        return [sampleElOne, sampleElTwo];
+                    }
+                }),
+                editor = this.newMediumEditor('.editor', {
+                    extensions: {
+                        'temp-extension': new TempExtension()
+                    }
+                }),
+                spy = jasmine.createSpy('handler');
+
+            selectElementContentsAndFire(editor.elements[0]);
+            jasmine.clock().tick(1);
+            expect(editor.getExtensionByName('toolbar').isDisplayed()).toBe(true);
+
+            editor.subscribe('blur', spy);
+
+            fireEvent(sampleElTwo, 'mousedown');
+            fireEvent(sampleElTwo, 'mouseup');
+            fireEvent(sampleElTwo, 'click');
+            jasmine.clock().tick(51);
+            expect(spy).not.toHaveBeenCalled();
+
+            fireEvent(externalEl, 'mousedown');
+            fireEvent(document.body, 'mouseup');
+            fireEvent(document.body, 'click');
+            expect(spy).toHaveBeenCalled();
         });
     });
 

--- a/src/js/extension.js
+++ b/src/js/extension.js
@@ -178,11 +178,14 @@
 
         /* getInteractionElements: [function ()]
          *
-         * If the extension renders any elements that the user can interact with
-         * this function should be implemented and return the root element or an array
-         * containg all of the root elements. MediumEditor will call this function to
-         * prevent the editor from triggering 'blur' when a user interacts with
-         * elements rendered by an extension.
+         * If the extension renders any elements that the user can interact with,
+         * this method should be implemented and return the root element or an array
+         * containing all of the root elements. MediumEditor will call this function
+         * during interaction to see if the user clicked on something outside of the editor.
+         * The elements are used to check if the target element of a click or
+         * other user event is a descendant of any extension elements.
+         * This way, the editor can also count user interaction within editor elements as
+         * interactions with the editor, and thus not trigger 'blur'
          */
         getInteractionElements: undefined,
 

--- a/src/js/extension.js
+++ b/src/js/extension.js
@@ -176,6 +176,16 @@
          */
         setInactive: undefined,
 
+        /* getInteractionElements: [function ()]
+         *
+         * If the extension renders any elements that the user can interact with
+         * this function should be implemented and return the root element or an array
+         * containg all of the root elements. MediumEditor will call this function to
+         * prevent the editor from triggering 'blur' when a user interacts with
+         * elements rendered by an extension.
+         */
+        getInteractionElements: undefined,
+
         /************************ Helpers ************************
          * The following are helpers that are either set by MediumEditor
          * during initialization, or are helper methods which either

--- a/src/js/extensions/README.md
+++ b/src/js/extensions/README.md
@@ -21,6 +21,7 @@
     * [`checkState(node)`](#checkstatenode)
     * [`destroy()`](#destroy)
     * [`queryCommandState()`](#querycommandstate)
+    * [`getInteractionElements()`](#getinteractionelements)
     * [`isActive()`](#isactive)
     * [`isAlreadyApplied(node)`](#isalreadyappliednode)
     * [`setActive()`](#setactive)
@@ -234,9 +235,16 @@ If this method returns `true`, and the `setActive()` method is defined on the ex
 **Returns:** `boolean` OR `null`
 
 ***
+### `getInteractionElements()`
+
+If the extension renders any elements that the user can interact with, this method should be implemented and return the root element or an array containing all of the root elements.
+
+MediumEditor will call this function during interaction to see if the user clicked on something outside of the editor. The elements are used to check if the target element of a click or other user event is a descendant of any extension elements. This way, the editor can also count user interaction within editor elements as interactions with the editor, and thus not trigger 'blur'
+
+***
 ### `isActive()`
 
-If implemented, this method will be called from MediumEditor to determine whether the button has already been set as 'active'. 
+If implemented, this method will be called from MediumEditor to determine whether the button has already been set as 'active'.
 
 If it returns `true`, this extension/button will be skipped for checking its active state as MediumEditor responds to the change in selection.
 
@@ -252,7 +260,7 @@ If implemented, this method is similar to `checkState()` in that it will be call
 
 **NOTE:**
 
-* This method will NOT be called if `checkState()` has been implemented. 
+* This method will NOT be called if `checkState()` has been implemented.
 * This method will NOT be called if `queryCommandState()` is implemented and returns a non-null value when called.
 
 **Arguments**
@@ -273,7 +281,7 @@ Currently, this method is called when updating the editor & toolbar, and if `que
 ***
 ### `setInactive()`
 
-If implemented, this method is called when MediumEditor knows that this extension has not been applied to the current selection. Curently, this is called at the beginning of each state change for the editor & toolbar. 
+If implemented, this method is called when MediumEditor knows that this extension has not been applied to the current selection. Curently, this is called at the beginning of each state change for the editor & toolbar.
 
 After calling this, MediumEditor will attempt to update the extension, either via `checkState()` or the combination of `queryCommandState()`, `isAlreadyApplied(node)`, `isActive()`, and `setActive()`
 
@@ -540,7 +548,7 @@ var CustomButtonExtension = MediumEditor.extensions.button.extend({
   name: 'custom-button-extension',
 
   action: 'bold'
-  
+
   // ... other properties/methods ...
 })
 ```
@@ -559,24 +567,24 @@ var CustomButtonExtension = MediumEditor.extensions.button.extend({
   name: 'custom-button-extension',
 
   aria: 'bold text'
-  
+
   // ... other properties/methods ...
 })
 ```
 
 ***
 ### `tagNames` _(Array)_
-        
+
 Array of element tag names that would indicate that this button has already been applied. If this action has already been applied, the button will be displayed as 'active' in the toolbar.
 
-**NOTE:** 
+**NOTE:**
 
 `tagNames` is not used if `useQueryState` is set to `true`.
 
 **Example:**
 
 The following would create a custom button extension which would be 'active' in the toolbar if the selection is within a `<b>` or a `<strong>` tag:
-      
+
 ```js
 var CustomButtonExtension = MediumEditor.extensions.button.extend({
   name: 'custom-button-extension',
@@ -584,7 +592,7 @@ var CustomButtonExtension = MediumEditor.extensions.button.extend({
   useQueryState: false,
 
   tagNames: ['b', 'strong'],
-  
+
   // ... other properties/methods ...
 })
 ```
@@ -599,7 +607,7 @@ A pair of css property & value(s) that indicate that this button has already bee
 * **prop** *[String]*: name of the css property
 * **value** *[String]*: value(s) of the css property (multiple values can be separated by a '|')
 
-**NOTE:** 
+**NOTE:**
 
 `style` is not used if `useQueryState` is set to `true`.
 
@@ -617,7 +625,7 @@ var CustomButtonExtension = MediumEditor.extensions.button.extend({
     prop: 'font-weight',
     value: '700|bold'
   },
-  
+
   // ... other properties/methods ...
 })
 ```

--- a/src/js/extensions/anchor-preview.js
+++ b/src/js/extensions/anchor-preview.js
@@ -34,6 +34,11 @@
             this.attachToEditables();
         },
 
+        getInteractionElements: function () {
+            return this.getPreviewElement();
+        },
+
+        // TODO: Remove this function in 6.0.0
         getPreviewElement: function () {
             return this.anchorPreview;
         },

--- a/src/js/extensions/toolbar.js
+++ b/src/js/extensions/toolbar.js
@@ -189,6 +189,10 @@
 
         // Toolbar accessors
 
+        getInteractionElements: function () {
+            return this.getToolbarElement();
+        },
+
         getToolbarElement: function () {
             if (!this.toolbar) {
                 this.toolbar = this.createToolbar();


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | yes
| BC breaks?       | no
| Deprecations?    | yes
| New tests added? | yes
| Fixed tickets    | #830
| License          | MIT

Currently, if any extension render an element on the page, if the user clicks on that element it counts as a click on an element outside of the editor, which causes the editor to `blur` and potentially hide the toolbar altogether.

This change set introduces a new `getInteractionElements()` method that any extension can implement.  This allows extensions to let MediumEditor know that it has created HTML elements that, when clicked, should not count as external interactions, and thus should not cause the editor to `blur` when being interacted with.
