### PR TITLE
Fix #1105 - Fix bug with anchor-preview when clicked

### DIFF
--- a/spec/anchor-preview.spec.js
+++ b/spec/anchor-preview.spec.js
@@ -139,6 +139,9 @@ describe('Anchor Preview TestCase', function () {
             expect(toolbar.isDisplayed()).toBe(true);
             expect(anchor.isDisplayed()).toBe(true);
 
+            // textbox should contain the url
+            expect(anchor.getInput().value).toEqual('http://test.com');
+
             // the checkboxes should be unchecked
             expect(anchor.getAnchorTargetCheckbox().checked).toBe(false);
             expect(anchor.getAnchorButtonCheckbox().checked).toBe(false);
@@ -306,7 +309,7 @@ describe('Anchor Preview TestCase', function () {
         });
 
         // https://github.com/yabwe/medium-editor/issues/1047
-        it('should display the anchor form in the toolbar when clicked when showWhenToolbarIsVisible is set to true adn toolbar is visible', function () {
+        it('should display the anchor form in the toolbar when clicked when showWhenToolbarIsVisible is set to true and toolbar is visible', function () {
             var editor = this.newMediumEditor('.editor', {
                     anchorPreview: {
                         showWhenToolbarIsVisible: true

--- a/src/js/extensions/anchor-preview.js
+++ b/src/js/extensions/anchor-preview.js
@@ -155,7 +155,7 @@
                 this.base.delay(function () {
                     if (activeAnchor) {
                         var opts = {
-                            url: activeAnchor.attributes.href.value,
+                            value: activeAnchor.attributes.href.value,
                             target: activeAnchor.getAttribute('target'),
                             buttonClass: activeAnchor.getAttribute('class')
                         };


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | yes
| Fixed tickets    | #1105 
| License          | MIT

### Description

When the anchor-preview was clicked, it was displaying 'undefined' in the anchor form, this was caused by a previous change where we changed over from using `opts.url` to `opts.value` to standardize on how we pass arguments into `document.execCommand()`.  Updating the anchor-preview was missed during that change.

There surprisingly isn't a test ensuring that when you click the anchor-preview, the `href` of that link is pre-filled into the anchor form, I've updated an existing test to assert that this happens.