### PR TITLE
Fix test failure in Chrome 51

### DIFF
--- a/spec/init.spec.js
+++ b/spec/init.spec.js
@@ -65,7 +65,7 @@ describe('Initialization TestCase', function () {
 
             // nodeList is a NodeList, similar to an array but not of the same type
             expect(editor.elements.length).toEqual(nodeList.length);
-            expect(typeof nodeList.forEach).toBe('undefined');
+            expect(Array.isArray(nodeList)).toBe(false);
             expect(typeof editor.elements.forEach).toBe('function');
             editor.destroy();
 


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | changed
| License          | MIT

### Description

Now in Chrome 51, `NodeList` objects have defined a `forEach` method.  There was a test that attempted to confirm that `forEach` wasn't defined on a `NodeList` to ensure that code that had depended on `forEach` was safely executing.

I've updated the test to assert that the `NodeList` is not an `Array` instead.
