### PR TITLE
#1127 | Placeholder is visible when only empty table is in Editor.

### DIFF
--- a/spec/placeholder.spec.js
+++ b/spec/placeholder.spec.js
@@ -41,6 +41,12 @@ describe('MediumEditor.extensions.placeholder TestCase', function () {
         expect(editor.elements[0].className).not.toContain('medium-editor-placeholder');
     });
 
+    it('should not set a placeholder for elements with table', function () {
+        this.el.innerHTML = '<table></table>';
+        var editor = this.newMediumEditor('.editor');
+        expect(editor.elements[0].className).not.toContain('medium-editor-placeholder');
+    });
+
     it('should set placeholder for elements with empty children', function () {
         this.el.innerHTML = '<p><br></p><div class="empty"></div>';
         var editor = this.newMediumEditor('.editor');

--- a/src/js/extensions/placeholder.js
+++ b/src/js/extensions/placeholder.js
@@ -54,7 +54,7 @@
 
         updatePlaceholder: function (el, dontShow) {
             // If the element has content, hide the placeholder
-            if (el.querySelector('img, blockquote, ul, ol') || (el.textContent.replace(/^\s+|\s+$/g, '') !== '')) {
+            if (el.querySelector('img, blockquote, ul, ol, table') || (el.textContent.replace(/^\s+|\s+$/g, '') !== '')) {
                 return this.hidePlaceholder(el);
             }
 


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    |  1127
| License          | MIT





