### PR TITLE
Make linkValidation allow hash links

### DIFF
--- a/spec/anchor.spec.js
+++ b/spec/anchor.spec.js
@@ -203,6 +203,7 @@ describe('Anchor Button TestCase', function () {
             });
             expect(editor.elements[0].querySelector('a')).toBeNull();
         });
+
         it('should add http:// if need be and linkValidation option is set to true', function () {
             var editor = this.newMediumEditor('.editor', {
                 anchor: {
@@ -220,6 +221,7 @@ describe('Anchor Button TestCase', function () {
             expect(link).not.toBeNull();
             expect(link.href).toBe('http://test.com/');
         });
+
         it('should add tel: if need be and linkValidation option is set to true', function () {
             var editor = this.newMediumEditor('.editor', {
                 anchor: {
@@ -237,6 +239,7 @@ describe('Anchor Button TestCase', function () {
             expect(link).not.toBeNull();
             expect(link.href).toBe('tel:347-999-9999');
         });
+
         it('should not change protocol when a valid one is included', function () {
             var editor = this.newMediumEditor('.editor', {
                 anchor: {
@@ -255,6 +258,7 @@ describe('Anchor Button TestCase', function () {
             expect(link).not.toBeNull();
             expect(link.href).toBe(validUrl);
         });
+
         it('should not change protocol when a tel scheme is included', function () {
             var editor = this.newMediumEditor('.editor', {
                 anchor: {
@@ -274,6 +278,7 @@ describe('Anchor Button TestCase', function () {
             expect(link).not.toBeNull();
             expect(link.href).toBe(validUrl);
         });
+
         it('should not change protocol when a maps scheme is included', function () {
             var editor = this.newMediumEditor('.editor', {
                 anchor: {
@@ -293,6 +298,7 @@ describe('Anchor Button TestCase', function () {
             expect(link).not.toBeNull();
             expect(link.href).toBe(validUrl);
         });
+
         it('should not change protocol for protocol-relative URLs', function () {
             var editor = this.newMediumEditor('.editor', {
                 anchor: {
@@ -311,6 +317,7 @@ describe('Anchor Button TestCase', function () {
             expect(link).not.toBeNull();
             expect(link.href).toBe(window.location.protocol + validUrl);
         });
+
         it('should not change protocol for any alphabetic scheme', function () {
             var editor = this.newMediumEditor('.editor', {
                 anchor: {
@@ -329,6 +336,7 @@ describe('Anchor Button TestCase', function () {
             expect(link).not.toBeNull();
             expect(link.href).toBe(validUrl.toLowerCase());
         });
+
         it('should not change fragment identifier when link begins with hash', function () {
             var editor = this.newMediumEditor('.editor', {
                     anchor: {
@@ -347,6 +355,7 @@ describe('Anchor Button TestCase', function () {
             expect(link).not.toBeNull();
             expect(link.getAttribute('href')).toBe(validHashLink);
         });
+
         it('should change spaces to %20 for a valid url if linkValidation options is set to true', function () {
             var editor = this.newMediumEditor('.editor', {
                 anchor: {
@@ -372,6 +381,7 @@ describe('Anchor Button TestCase', function () {
             expect(link).not.toBeNull();
             expect(link.href).toBe(expectedOpts.value);
         });
+
         it('should not change spaces to %20 if linkValidation is set to false', function () {
             var editor = this.newMediumEditor('.editor', {
                 anchor: {
@@ -399,6 +409,7 @@ describe('Anchor Button TestCase', function () {
             link = editor.elements[0].querySelector('a');
             expect(link).not.toBeNull();
         });
+
         it('should add target="_blank" when "open in a new window" checkbox is checked', function () {
             var editor = this.newMediumEditor('.editor', {
                 anchor: {
@@ -422,6 +433,7 @@ describe('Anchor Button TestCase', function () {
             expect(link).not.toBeNull();
             expect(link.target).toBe('_blank');
         });
+
         it('should add target="_blank" when respective option is set to true', function () {
             var editor = this.newMediumEditor('.editor', {
                 targetBlank: true
@@ -437,6 +449,7 @@ describe('Anchor Button TestCase', function () {
             expect(link).not.toBeNull();
             expect(link.target).toBe('_blank');
         });
+
         it('should create a button when user selects this option and presses enter', function () {
             spyOn(MediumEditor.prototype, 'createLink').and.callThrough();
             var editor = this.newMediumEditor('.editor', {

--- a/spec/anchor.spec.js
+++ b/spec/anchor.spec.js
@@ -329,6 +329,24 @@ describe('Anchor Button TestCase', function () {
             expect(link).not.toBeNull();
             expect(link.href).toBe(validUrl.toLowerCase());
         });
+        it('should not change fragment identifier when link begins with hash', function () {
+            var editor = this.newMediumEditor('.editor', {
+                    anchor: {
+                        linkValidation: true
+                    }
+                }),
+                validHashLink = '#!$&\'()*+,;=123abcDEF-._~:@/?',
+                link,
+                anchorExtension = editor.getExtensionByName('anchor');
+
+            selectElementContentsAndFire(editor.elements[0]);
+            anchorExtension.showForm(validHashLink);
+            fireEvent(anchorExtension.getForm().querySelector('a.medium-editor-toolbar-save'), 'click');
+
+            link = editor.elements[0].querySelector('a');
+            expect(link).not.toBeNull();
+            expect(link.getAttribute('href')).toBe(validHashLink);
+        });
         it('should change spaces to %20 for a valid url if linkValidation options is set to true', function () {
             var editor = this.newMediumEditor('.editor', {
                 anchor: {

--- a/src/js/extensions/anchor.js
+++ b/src/js/extensions/anchor.js
@@ -235,7 +235,8 @@
             // Matches any alphabetical characters followed by ://
             // Matches protocol relative "//"
             // Matches common external protocols "mailto:" "tel:" "maps:"
-            var urlSchemeRegex = /^([a-z]+:)?\/\/|^(mailto|tel|maps):/i,
+            // Matches relative hash link, "#" followed by any character
+            var urlSchemeRegex = /^([a-z]+:)?\/\/|^(mailto|tel|maps):|^\#.+/i,
             // var te is a regex for checking if the string is a telephone number
             telRegex = /^\+?\s?\(?(?:\d\s?\-?\)?){3,20}$/;
             if (telRegex.test(value)) {

--- a/src/js/extensions/anchor.js
+++ b/src/js/extensions/anchor.js
@@ -235,8 +235,8 @@
             // Matches any alphabetical characters followed by ://
             // Matches protocol relative "//"
             // Matches common external protocols "mailto:" "tel:" "maps:"
-            // Matches relative hash link, "#" followed by any character
-            var urlSchemeRegex = /^([a-z]+:)?\/\/|^(mailto|tel|maps):|^\#.+/i,
+            // Matches relative hash link, begins with "#"
+            var urlSchemeRegex = /^([a-z]+:)?\/\/|^(mailto|tel|maps):|^\#/i,
             // var te is a regex for checking if the string is a telephone number
             telRegex = /^\+?\s?\(?(?:\d\s?\-?\)?){3,20}$/;
             if (telRegex.test(value)) {


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | yes
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | yes
| Fixed tickets    | 
| License          | MIT

### Description

Allows hash links, e.g. `#fragment-identifier`, when `linkValidation` is set to `true`. This was brought up in this discussion: https://github.com/yabwe/medium-editor/issues/714
