### PR TITLE
when caret is at the end of blockquote and you press enter, create paragraph, not another blockquote

### DIFF
--- a/spec/content.spec.js
+++ b/spec/content.spec.js
@@ -422,6 +422,35 @@ describe('Content TestCase', function () {
             });
             expect(document.execCommand).toHaveBeenCalledWith('unlink', false, null);
         });
+
+        describe('within a blockquote element', function () {
+
+            it('at the end of the blockquote, p tag should be created next, not blockquote', function () {
+                this.el.innerHTML = '<blockquote>lorem ipsum</blockquote>';
+                var editor = this.newMediumEditor('.editor'),
+                    target = editor.elements[0].querySelector('blockquote').firstChild;
+
+                placeCursorInsideElement(target, target.textContent.length);
+                fireEvent(target, 'keydown', {
+                    keyCode: MediumEditor.util.keyCode.ENTER
+                });
+
+                expect(this.el.innerHTML).toBe('<blockquote>lorem ipsum</blockquote><p><br></p>');
+            });
+
+            it('NOT at the start of the blockqoute, no formatting should be changed', function () {
+                this.el.innerHTML = '<blockquote>lorem ipsum</blockquote>';
+                var editor = this.newMediumEditor('.editor'),
+                    target = editor.elements[0].querySelector('blockquote').firstChild;
+
+                placeCursorInsideElement(target, 0);
+                fireEvent(target, 'keydown', {
+                    keyCode: MediumEditor.util.keyCode.ENTER
+                });
+
+                expect(this.el.innerHTML).toBe('<blockquote>lorem ipsum</blockquote>');
+            });
+        });
     });
 
     describe('when the ctrl key and m key is pressed', function () {

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -138,6 +138,20 @@
             // then pressing backspace key should change the <blockquote> to a <p> tag
             event.preventDefault();
             MediumEditor.util.execFormatBlock(this.options.ownerDocument, 'p');
+        } else if (MediumEditor.util.isKey(event, MediumEditor.util.keyCode.ENTER) &&
+                (MediumEditor.util.getClosestTag(node, 'blockquote') !== false) &&
+                MediumEditor.selection.getCaretOffsets(node).right === 0) {
+
+            // when cursor is at the end of <blockquote>
+            // then pressing enter key should <p> tag, not <blockquote>
+            p = this.options.ownerDocument.createElement('p');
+            p.innerHTML = '<br>';
+            node.parentElement.insertBefore(p, node.nextSibling);
+
+            // move the cursor into the new paragraph
+            MediumEditor.selection.moveCursor(this.options.ownerDocument, p);
+
+            event.preventDefault();
         }
     }
 

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -142,8 +142,8 @@
                 (MediumEditor.util.getClosestTag(node, 'blockquote') !== false) &&
                 MediumEditor.selection.getCaretOffsets(node).right === 0) {
 
-            // when cursor is at the end of <blockquote>
-            // then pressing enter key should <p> tag, not <blockquote>
+            // when cursor is at the end of <blockquote>,
+            // then pressing enter key should create <p> tag, not <blockquote>
             p = this.options.ownerDocument.createElement('p');
             p.innerHTML = '<br>';
             node.parentElement.insertBefore(p, node.nextSibling);


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | yes
| Fixed tickets    | #294, #1054
| License          | MIT

### Description

We had this reported a bunch of times. When you place a caret at the end of a blockquote and press enter, a new blockquote is created instead of a plain paragraph and you have to press backspace to get rid of it. This is not a standard behavior. When you do the same with other block elements (h1, h2...) you will get a paragraph as expected. For some reason, this doesn't work with blockquotes.

Also when you try it in other "standard" editors (Word, Pages, Google Docs...), it behaves as expected - on enter you will get rid of the current "style" and start a new plain paragraph.

This PR solves this problem and forces a new paragraph after pressing enter at the end of a blockquote. Pressing enter anywhere else in the blockquote is not affected. 
