### PR TITLE
add regex to clean font tag provided by word / open office on paste

### DIFF
--- a/src/js/extensions/paste.js
+++ b/src/js/extensions/paste.js
@@ -60,7 +60,10 @@
             [new RegExp(/<\/?o:[a-z]*>/gi), ''],
 
             // Microsoft Word adds some special elements around list items
-            [new RegExp(/<!\[if !supportLists\]>(((?!<!).)*)<!\[endif]\>/gi), '$1']
+            [new RegExp(/<!\[if !supportLists\]>(((?!<!).)*)<!\[endif]\>/gi), '$1'],
+
+            // remove font tag
+            [new RegExp(/<font[^><]*>|<.font[^><]*>/gi), '']
         ];
     }
     /*jslint regexp: false*/


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | [#1154](https://github.com/yabwe/medium-editor/issues/1154)
| License          | MIT

### Description

Removing font style tag added by editors like Microsoft Word or Open Office when cleanPastedHTML is true.

