### PR TITLE
add external button example

### DIFF
--- a/src/js/extensions/README.md
+++ b/src/js/extensions/README.md
@@ -117,6 +117,8 @@
   * An extension that inserts custom HTML using a new button in the MediumEditor toolbar
 * [MediumButton](https://github.com/arcs-/MediumButton)
   * Extends your Medium Editor with the possibility add buttons.
+* [MediumEditor Phrase](https://github.com/nymag/medium-editor-phrase)
+  * Adds a configurable button to the MediumEditor toolbar which adds phrasing content tags (e.g. `span` tags) to selected text.
 * [MediumEditor Handsontable](https://github.com/asselinpaul/medium-editor-handsontable)
   * Supports adding [handsontable](https://handsontable.com/) spreadsheets to MediumEditor.
 * [MediumEditor Lists](https://github.com/mkawczynski07/medium-editor-list)


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | 
| License          | MIT

### Description

Adds an example of a custom button extension.

--

#### Please, don't submit `/dist` files with your PR!

