### PR TITLE
remove first empty paragraph on backspace

### DIFF
--- a/spec/content.spec.js
+++ b/spec/content.spec.js
@@ -652,6 +652,22 @@ describe('Content TestCase', function () {
                 expect(this.el.innerHTML).toBe('<p>lorem ipsum</p><ul><li></li><li>lorem ipsum</li></ul>');
             });
         });
+
+        describe('within an empty paragraph which is the first element of the editor', function () {
+            it('should delete the paragraph and place the caret to the next paragraph', function () {
+                this.el.innerHTML = '<p class=""><br></p><p>test</p>';
+                var editor = this.newMediumEditor('.editor'),
+                    target = editor.elements[0].querySelector('p'),
+                    range;
+                placeCursorInsideElement(target, 0);
+                fireEvent(target, 'keydown', {
+                    keyCode: MediumEditor.util.keyCode.BACKSPACE
+                });
+                expect(this.el.innerHTML).toBe('<p>test</p>');
+                range = document.getSelection().getRangeAt(0);
+                expect(range.commonAncestorContainer.textContent).toBe('test');
+            });
+        });
     });
 
     describe('with header tags', function () {

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -152,6 +152,17 @@
             MediumEditor.selection.moveCursor(this.options.ownerDocument, p);
 
             event.preventDefault();
+        } else if (MediumEditor.util.isKey(event, MediumEditor.util.keyCode.BACKSPACE) &&
+                MediumEditor.util.isMediumEditorElement(node.parentElement) &&
+                !node.previousElementSibling &&
+                node.nextElementSibling &&
+                isEmpty.test(node.innerHTML)) {
+
+            // when cursor is in the first element, it's empty and user presses backspace,
+            // do delete action instead to get rid of the first element and move caret to 2nd
+            event.preventDefault();
+            MediumEditor.selection.moveCursor(this.options.ownerDocument, node.nextSibling);
+            node.parentElement.removeChild(node);
         }
     }
 


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | more or less
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | yes
| Fixed tickets    | -
| License          | MIT

### Description

Most users don't know the difference between backspace and delete. So if they create a paragraph as the first element in the editor and they want to delete it, they place caret to the paragraph and press backspace. Which does nothing. In order to delete that paragraph you need to press delete / fn+backspace on mac, or move caret to a beginning of next paragraph and press backspace there.

I've seen people struggling with this, so this PR solves this problem. If a caret is in the first and empty paragraph and you press backspace, it will do delete instead - it will delete the empty paragraph and move the caret to next one. 
