### PR TITLE
Fix #1156 - placeholder text color in flat theme

### DIFF
--- a/src/sass/themes/flat.scss
+++ b/src/sass/themes/flat.scss
@@ -86,5 +86,5 @@ $medium-editor-placeholder-color: #fff;
 }
 
 .medium-editor-placeholder:after {
-    color: $medium-editor-border-color;
+    color: lighten($medium-editor-bgcolor, 20);
 }


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | #1156 
| License          | MIT

### Description
For the flat theme, the color of the placeholder text ended up being white, which made it unreadable.

I've update the text color of the placeholder text to be a lighter version of the green the flat theme uses for the toolbar (this makes is similar to the bootstrap theme).
