### PR TITLE
Check for this.anchorPreview when hiding

### DIFF
--- a/src/js/extensions/anchor-preview.js
+++ b/src/js/extensions/anchor-preview.js
@@ -71,7 +71,9 @@
         },
 
         hidePreview: function () {
-            this.anchorPreview.classList.remove('medium-editor-anchor-preview-active');
+            if(this.anchorPreview){
+                this.anchorPreview.classList.remove('medium-editor-anchor-preview-active');
+            }
             this.activeAnchor = null;
         },
 


### PR DESCRIPTION
Bug fix?  yes
New feature? no
BC breaks? no
Deprecations? no
New tests added? not needed
License MIT

This fixes the following error:

```
TypeError: Cannot read property 'classList' of undefined
File .../vendor-edit-mode.js line x col xxxxx in hidePreview
File .../vendor-edit-mode.js line x col xxxxx in detachPreviewHandlers
File .../vendor-edit-mode.js line x col xxxxx in updatePreview
```

I have this come up in my production app on Windows 10 Chrome 52.
