### PR TITLE
Stops mouseout errors on hover over anchors

### DIFF
--- a/src/js/extensions/anchor-preview.js
+++ b/src/js/extensions/anchor-preview.js
@@ -210,6 +210,10 @@
             if (false === target) {
                 return;
             }
+            
+            if ( target.getAttribute('data-disable-preview') === 'true' ) {
+                return;
+            }
 
             // Detect empty href attributes
             // The browser will make href="" or href="#top"


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| New tests added? | not needed |
| Fixed tickets | #1200 |
| License | MIT |
### Description

When using data-disable-preview="true" on a link in the editor, errors were thrown while the editor tries to detach the mouseout event.
This fixes #1200
