### PR TITLE
support encoded urls

### DIFF
--- a/spec/anchor.spec.js
+++ b/spec/anchor.spec.js
@@ -356,7 +356,7 @@ describe('Anchor Button TestCase', function () {
             expect(link.getAttribute('href')).toBe(validHashLink);
         });
 
-        it('should change spaces to %20 for a valid url if linkValidation options is set to true', function () {
+        it('should change spaces to %20 for a valid url if linkValidation option is set to true', function () {
             var editor = this.newMediumEditor('.editor', {
                     anchor: {
                         linkValidation: true
@@ -382,7 +382,7 @@ describe('Anchor Button TestCase', function () {
             expect(link.href).toBe(expectedOpts.value);
         });
 
-        it('should not encode an encoded URL if linkValidation options is set to true', function () {
+        it('should not encode an encoded URL if linkValidation option is set to true', function () {
             var editor = this.newMediumEditor('.editor', {
                     anchor: {
                         linkValidation: true
@@ -396,7 +396,6 @@ describe('Anchor Button TestCase', function () {
                 };
 
             spyOn(editor, 'execAction').and.callThrough();
-
             selectElementContentsAndFire(editor.elements[0]);
             anchorExtension.showForm('a%20b.com/');
             fireEvent(anchorExtension.getForm().querySelector('a.medium-editor-toolbar-save'), 'click');
@@ -408,7 +407,7 @@ describe('Anchor Button TestCase', function () {
             expect(link.href).toBe(expectedOpts.value);
         });
 
-        it('should encode query params if linkValidation options is set to true', function () {
+        it('should encode query params if linkValidation option is set to true', function () {
             var editor = this.newMediumEditor('.editor', {
                     anchor: {
                         linkValidation: true
@@ -434,7 +433,7 @@ describe('Anchor Button TestCase', function () {
             expect(link.href).toBe(expectedOpts.value);
         });
 
-        it('should not encode an encoded query param if linkValidation options is set to true', function () {
+        it('should not encode an encoded query param if linkValidation option is set to true', function () {
             var editor = this.newMediumEditor('.editor', {
                     anchor: {
                         linkValidation: true

--- a/spec/anchor.spec.js
+++ b/spec/anchor.spec.js
@@ -358,10 +358,10 @@ describe('Anchor Button TestCase', function () {
 
         it('should change spaces to %20 for a valid url if linkValidation options is set to true', function () {
             var editor = this.newMediumEditor('.editor', {
-                anchor: {
-                    linkValidation: true
-                }
-            }),
+                    anchor: {
+                        linkValidation: true
+                    }
+                }),
                 link,
                 anchorExtension = editor.getExtensionByName('anchor'),
                 expectedOpts = {
@@ -373,6 +373,84 @@ describe('Anchor Button TestCase', function () {
 
             selectElementContentsAndFire(editor.elements[0]);
             anchorExtension.showForm('te s t.com/');
+            fireEvent(anchorExtension.getForm().querySelector('a.medium-editor-toolbar-save'), 'click');
+
+            expect(editor.execAction).toHaveBeenCalledWith('createLink', expectedOpts);
+
+            link = editor.elements[0].querySelector('a');
+            expect(link).not.toBeNull();
+            expect(link.href).toBe(expectedOpts.value);
+        });
+
+        it('should not encode an encoded URL if linkValidation options is set to true', function () {
+            var editor = this.newMediumEditor('.editor', {
+                    anchor: {
+                        linkValidation: true
+                    }
+                }),
+                link,
+                anchorExtension = editor.getExtensionByName('anchor'),
+                expectedOpts = {
+                    value: 'http://a%20b.com/',
+                    target: '_self'
+                };
+
+            spyOn(editor, 'execAction').and.callThrough();
+
+            selectElementContentsAndFire(editor.elements[0]);
+            anchorExtension.showForm('a%20b.com/');
+            fireEvent(anchorExtension.getForm().querySelector('a.medium-editor-toolbar-save'), 'click');
+
+            expect(editor.execAction).toHaveBeenCalledWith('createLink', expectedOpts);
+
+            link = editor.elements[0].querySelector('a');
+            expect(link).not.toBeNull();
+            expect(link.href).toBe(expectedOpts.value);
+        });
+
+        it('should encode query params if linkValidation options is set to true', function () {
+            var editor = this.newMediumEditor('.editor', {
+                    anchor: {
+                        linkValidation: true
+                    }
+                }),
+                link,
+                anchorExtension = editor.getExtensionByName('anchor'),
+                expectedOpts = {
+                    value: 'http://a.com/?q=http%3A%2F%2Fb.com&q2=http%3A%2F%2Fc.com',
+                    target: '_self'
+                };
+
+            spyOn(editor, 'execAction').and.callThrough();
+
+            selectElementContentsAndFire(editor.elements[0]);
+            anchorExtension.showForm('a.com/?q=http://b.com&q2=http://c.com');
+            fireEvent(anchorExtension.getForm().querySelector('a.medium-editor-toolbar-save'), 'click');
+
+            expect(editor.execAction).toHaveBeenCalledWith('createLink', expectedOpts);
+
+            link = editor.elements[0].querySelector('a');
+            expect(link).not.toBeNull();
+            expect(link.href).toBe(expectedOpts.value);
+        });
+
+        it('should not encode an encoded query param if linkValidation options is set to true', function () {
+            var editor = this.newMediumEditor('.editor', {
+                    anchor: {
+                        linkValidation: true
+                    }
+                }),
+                link,
+                anchorExtension = editor.getExtensionByName('anchor'),
+                expectedOpts = {
+                    value: 'http://a.com/?q=http%3A%2F%2Fb.com&q2=http%3A%2F%2Fc.com',
+                    target: '_self'
+                };
+
+            spyOn(editor, 'execAction').and.callThrough();
+
+            selectElementContentsAndFire(editor.elements[0]);
+            anchorExtension.showForm('a.com/?q=http%3A%2F%2Fb.com&q2=http://c.com');
             fireEvent(anchorExtension.getForm().querySelector('a.medium-editor-toolbar-save'), 'click');
 
             expect(editor.execAction).toHaveBeenCalledWith('createLink', expectedOpts);

--- a/src/js/extensions/anchor.js
+++ b/src/js/extensions/anchor.js
@@ -231,19 +231,47 @@
             this.base.checkSelection();
         },
 
+        ensureEncodedUri: function (str) {
+            return str === decodeURI(str) ? encodeURI(str) : str;
+        },
+
+        ensureEncodedUriComponent: function (str) {
+            return str === decodeURIComponent(str) ? encodeURIComponent(str) : str;
+        },
+
+        ensureEncodedParam: function (param) {
+            var split = param.split('='),
+                key = split[0],
+                val = split[1];
+
+            return key + (val === undefined ? '' : '=' + this.ensureEncodedUriComponent(val));
+        },
+
+        ensureEncodedQuery: function (queryString) {
+            return queryString.split('&').map(this.ensureEncodedParam.bind(this)).join('&');
+        },
+
         checkLinkFormat: function (value) {
             // Matches any alphabetical characters followed by ://
             // Matches protocol relative "//"
             // Matches common external protocols "mailto:" "tel:" "maps:"
             // Matches relative hash link, begins with "#"
             var urlSchemeRegex = /^([a-z]+:)?\/\/|^(mailto|tel|maps):|^\#/i,
-            // var te is a regex for checking if the string is a telephone number
-            telRegex = /^\+?\s?\(?(?:\d\s?\-?\)?){3,20}$/;
+                // var te is a regex for checking if the string is a telephone number
+                telRegex = /^\+?\s?\(?(?:\d\s?\-?\)?){3,20}$/,
+                split = value.split('?'),
+                path = split[0],
+                query = split[1];
+
             if (telRegex.test(value)) {
                 return 'tel:' + value;
             } else {
                 // Check for URL scheme and default to http:// if none found
-                return (urlSchemeRegex.test(value) ? '' : 'http://') + encodeURI(value);
+                return (urlSchemeRegex.test(value) ? '' : 'http://') +
+                    // Ensure path is encoded
+                    this.ensureEncodedUri(path) +
+                    // Ensure query is encoded
+                    (query === undefined ? '' : '?' + this.ensureEncodedQuery(query));
             }
         },
 

--- a/src/js/extensions/anchor.js
+++ b/src/js/extensions/anchor.js
@@ -257,7 +257,7 @@
             // Matches common external protocols "mailto:" "tel:" "maps:"
             // Matches relative hash link, begins with "#"
             var urlSchemeRegex = /^([a-z]+:)?\/\/|^(mailto|tel|maps):|^\#/i,
-                // var te is a regex for checking if the string is a telephone number
+                // telRegex is a regex for checking if the string is a telephone number
                 telRegex = /^\+?\s?\(?(?:\d\s?\-?\)?){3,20}$/,
                 split = value.split('?'),
                 path = split[0],


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | yes
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | yes
| Fixed tickets    | https://github.com/yabwe/medium-editor/issues/1218
| License          | MIT

### Description

This PR adds some functionality to linkValidation: an URL's unencoded path and query are encoded, and encoded path and query are not encoded.

--


