### PR TITLE
Fixes an issue where while a user is holding down delete and clicks around both in and out of the content editable the node is null.

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -52,8 +52,13 @@
     }
 
     function handleBlockDeleteKeydowns(event) {
-        var p, node = MediumEditor.selection.getSelectionStart(this.options.ownerDocument),
-            tagName = node.nodeName.toLowerCase(),
+        var p, node = MediumEditor.selection.getSelectionStart(this.options.ownerDocument);
+
+        if (!node) {
+            return;
+        }
+
+        var tagName = node.nodeName.toLowerCase(),
             isEmpty = /^(\s+|<br\/?>)?$/i,
             isHeader = /h\d/i;
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes/no |
| Deprecations? | no |
| New tests added? | not needed - Not even sure how to create a test for the behavior I'm experiencing. |
| Fixed tickets |  |
| License | MIT |
### Description

[Description of the bug or feature]
## 
#### Please, don't submit `/dist` files with your PR!

…round, both in and out of the contenteditable, the node can be null
