### PR TITLE
Fix for #1151

### DIFF
--- a/src/js/events.js
+++ b/src/js/events.js
@@ -52,15 +52,17 @@
                 win = this.base.options.contentWindow,
                 doc = this.base.options.ownerDocument;
 
-            targets = MediumEditor.util.isElement(targets) || [win, doc].indexOf(targets) > -1 ? [targets] : targets;
+            if (targets !== null) {
+                targets = MediumEditor.util.isElement(targets) || [win, doc].indexOf(targets) > -1 ? [targets] : targets;
 
-            Array.prototype.forEach.call(targets, function (target) {
-                index = this.indexOfListener(target, event, listener, useCapture);
-                if (index !== -1) {
-                    e = this.events.splice(index, 1)[0];
-                    e[0].removeEventListener(e[1], e[2], e[3]);
-                }
-            }.bind(this));
+                Array.prototype.forEach.call(targets, function (target) {
+                    index = this.indexOfListener(target, event, listener, useCapture);
+                    if (index !== -1) {
+                        e = this.events.splice(index, 1)[0];
+                        e[0].removeEventListener(e[1], e[2], e[3]);
+                    }
+                }.bind(this));
+            }
         },
 
         indexOfListener: function (target, event, listener, useCapture) {


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    |no
| New tests added? | not needed
| Fixed tickets    | [#1151](https://github.com/yabwe/medium-editor/issues/1151)
| License          | MIT

### Description

--

`events.detachDOMEvent()` is attempting to run `forEach` on a null value.  This specifically occurs when you have a word or block of words formatted as a link.  Trying to format that same text block a second time triggers the error consistently. 

