### PR TITLE
Fix broken carousel

### DIFF
--- a/js/medium-editor-site.js
+++ b/js/medium-editor-site.js
@@ -98,7 +98,9 @@
 
 		function gotoCurrentTheme() {
 			var item = items[currentIndex];
-			carousel.style.transform = 'translateX(-' + (item.offsetLeft - carousel.offsetLeft) + 'px)';
+			var width = item.offsetWidth || item.clientWidth;
+
+			carousel.style.transform = 'translateX(' + -(width * currentIndex) + 'px)';
 		}
 
 		calculateWidth();


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| License          | MIT

### Description
Broken navigation of themes carousel on site.

#### Steps to reproduce:
- go to http://yabwe.github.io/medium-editor/
- scroll to `Themes` section
- click on links to change theme preview

#### Actual behavior:
![2016-12-23 05 17 33](https://cloud.githubusercontent.com/assets/6225592/21446633/67ef1ff2-c8d1-11e6-9ef2-4e550b2496f2.gif)

---

#### Fixed behavior:
![2016-12-23 05 29 41](https://cloud.githubusercontent.com/assets/6225592/21446653/99a90d6e-c8d1-11e6-9d3f-1a423d508a37.gif)

This fix was tested on macOS Sierra 10.12.1 (16B2659) in:
- Google Chrome 55.0.2883.95
- Firefox 50.1.0
- Safari 10.0.1 (12602.2.14.0.7)