### PR TITLE
Adding new 'html' button from #1235

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,6 +516,7 @@ These are all the built-in buttons supported by MediumEditor.
 * __h5__
 * __h6__
 * __removeFormat__ (clears inline style formatting, preserves blocks)
+* __html__ (parses selected html and converts into actual html elements)
 
 ## Themes
 

--- a/demo/custom-toolbar.html
+++ b/demo/custom-toolbar.html
@@ -27,7 +27,7 @@
     <script>
         var editor = new MediumEditor('.editable', {
                 toolbar: {
-                    buttons: ['bold', 'italic', 'underline', 'strikethrough', 'quote', 'anchor', 'image', 'justifyLeft', 'justifyCenter', 'justifyRight', 'justifyFull', 'superscript', 'subscript', 'orderedlist', 'unorderedlist', 'pre', 'removeFormat', 'outdent', 'indent', 'h2', 'h3'],
+                    buttons: ['bold', 'italic', 'underline', 'strikethrough', 'quote', 'anchor', 'image', 'justifyLeft', 'justifyCenter', 'justifyRight', 'justifyFull', 'superscript', 'subscript', 'orderedlist', 'unorderedlist', 'pre', 'removeFormat', 'outdent', 'indent', 'h2', 'h3', 'html'],
                 },
                 buttonLabels: 'fontawesome',
                 anchor: {

--- a/spec/buttons.spec.js
+++ b/spec/buttons.spec.js
@@ -760,7 +760,7 @@ describe('Buttons TestCase', function () {
 
             fireEvent(button, 'click');
 
-            expect(this.el.innerHTML).toContain('<iframe width="854" height="480" src="https://www.youtube.com/embed/QHH3iSeDBLo" frameborder="0" allowfullscreen=""></iframe>');
+            expect(this.el.innerHTML).toMatch(/<iframe(?: width="854"| height="480"| src="https:\/\/www.youtube.com\/embed\/QHH3iSeDBLo"| frameborder="0"| allowfullscreen=""){5}>(<br>)?<\/iframe>/gi);
         });
     });
 

--- a/spec/buttons.spec.js
+++ b/spec/buttons.spec.js
@@ -744,19 +744,19 @@ describe('Buttons TestCase', function () {
         });
     });
 
-    describe('Eval', function () {
+    describe('Html', function () {
         it('should create an evaluated html tag', function () {
             var editor = this.newMediumEditor('.editor', {
                     toolbar: {
-                        buttons: ['eval']
+                        buttons: ['html']
                     }
                 }),
                 toolbar = editor.getExtensionByName('toolbar'),
-                button = toolbar.getToolbarElement().querySelector('[data-action="eval"]');
+                button = toolbar.getToolbarElement().querySelector('[data-action="html"]');
             spyOn(document, 'execCommand').and.callThrough();
-            this.el.innerHTML = '<span id="span-eval">&lt;iframe width="854" height="480" src="https://www.youtube.com/embed/QHH3iSeDBLo" frameborder="0" allowfullscreen&gt;&lt;/iframe&gt;  \n\n</span>';
+            this.el.innerHTML = '<span id="span-html">&lt;iframe width="854" height="480" src="https://www.youtube.com/embed/QHH3iSeDBLo" frameborder="0" allowfullscreen&gt;&lt;/iframe&gt;  \n\n</span>';
 
-            selectElementContentsAndFire(document.getElementById('span-eval'));
+            selectElementContentsAndFire(document.getElementById('span-html'));
 
             fireEvent(button, 'click');
 

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -604,7 +604,7 @@
             return this.options.ownerDocument.execCommand('insertImage', false, src);
         }
 
-        if (action === 'eval') {
+        if (action === 'html') {
             var html = this.options.contentWindow.getSelection().toString().trim();
             return MediumEditor.util.insertHTMLCommand(this.options.ownerDocument, html);
         }

--- a/src/js/defaults/buttons.js
+++ b/src/js/defaults/buttons.js
@@ -93,7 +93,7 @@
             aria: 'evaluate html',
             tagNames: ['iframe', 'object'],
             contentDefault: '<b>html</b>',
-            contentFA: '<i class="fa fa-play-circle"></i>'
+            contentFA: '<i class="fa fa-code"></i>'
         },
         'orderedlist': {
             name: 'orderedlist',

--- a/src/js/defaults/buttons.js
+++ b/src/js/defaults/buttons.js
@@ -87,12 +87,12 @@
             contentDefault: '<b>image</b>',
             contentFA: '<i class="fa fa-picture-o"></i>'
         },
-        'eval': {
-            name: 'eval',
-            action: 'eval',
+        'html': {
+            name: 'html',
+            action: 'html',
             aria: 'evaluate html',
             tagNames: ['iframe', 'object'],
-            contentDefault: '<b>eval</b>',
+            contentDefault: '<b>html</b>',
             contentFA: '<i class="fa fa-play-circle"></i>'
         },
         'orderedlist': {

--- a/src/js/extensions/README.md
+++ b/src/js/extensions/README.md
@@ -118,6 +118,7 @@
 * justifyLeft, justifyCenter, justifyRight, justifyFull
 * h1, h2, h3, h4, h5, h6
 * removeFormat
+* html
 
 #### Examples of custom built external buttons:
 * [MediumEditor tables](https://github.com/yabwe/medium-editor-tables)


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | yes
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | yes
| Fixed tickets    | (Finishing #1235)
| License          | MIT

### Description

A new tool button for evaluating inserted html, basically for embedding videos or objects.

Thanks to @vendelin8 for creating the feature!
