### PR TITLE
Update README + Add simple dev server for running locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,6 +652,13 @@ A list of existing extensions and plugins, such as [Images and Media embeds](htt
 
 ## Development
 
+To run the demo locally:
+
+1. Clone this repo locally
+2. Run `npm install` from your console at the root
+3. Run `node index.js` from the root
+4. Navigate to `http://localhost:8088/demo/index.html` to view the demo
+
 MediumEditor development tasks are managed by Grunt. To install all the necessary packages, just invoke:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 ﻿# MediumEditor
 
-[![Join the chat at https://gitter.im/yabwe/medium-editor](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/yabwe/medium-editor?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-
 This is a clone of [medium.com](https://medium.com) inline editor toolbar.
 
 MediumEditor has been written using vanilla JavaScript, no additional frameworks required.
 
+![screenshot](https://raw.github.com/yabwe/medium-editor/master/demo/img/medium-editor.jpg)
+
+[![Join the chat at https://gitter.im/yabwe/medium-editor](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/yabwe/medium-editor?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
 ## Browser Support
 
-[![Sauce Test Status](https://saucelabs.com/browser-matrix/mediumeditor.svg)](https://saucelabs.com/u/mediumeditor)
+[![Saucelabs Build Status](https://saucelabs.com/browser-matrix/mediumeditor.svg)](https://saucelabs.com/beta/dashboard/builds)
 
 ![Supported Browsers](https://cloud.githubusercontent.com/assets/2444240/12874138/d3960a04-cd9b-11e5-8cc5-8136d82cf5f6.png)
 
@@ -21,7 +23,7 @@ MediumEditor has been written using vanilla JavaScript, no additional frameworks
 
 # Basic usage
 
-![screenshot](https://raw.github.com/yabwe/medium-editor/master/demo/img/medium-editor.jpg)
+### Demo
 
 __demo__: [http://yabwe.github.io/medium-editor/](http://yabwe.github.io/medium-editor/)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a clone of [medium.com](https://medium.com) inline editor toolbar.
 
 MediumEditor has been written using vanilla JavaScript, no additional frameworks required.
 
-![screenshot](https://raw.github.com/yabwe/medium-editor/master/demo/img/medium-editor.jpg)
+[![screenshot](https://raw.github.com/yabwe/medium-editor/master/demo/img/medium-editor.jpg)](http://yabwe.github.io/medium-editor/)
 
 [![Join the chat at https://gitter.im/yabwe/medium-editor](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/yabwe/medium-editor?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 

--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+var connect = require('connect');
+var serveStatic = require('serve-static');
+connect().use(serveStatic(__dirname)).listen(8088);

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "license": "MIT",
   "devDependencies": {
     "brfs": "1.4.2",
+    "connect": "3.5.0",
     "grunt": "0.4.5",
     "grunt-autoprefixer": "3.0.3",
     "grunt-bump": "0.7.0",
@@ -61,6 +62,7 @@
     "jshint-stylish": "2.1.0",
     "load-grunt-tasks": "3.4.0",
     "lodash": "3.10.1",
+    "serve-static": "1.11.2",
     "time-grunt": "1.3.0"
   },
   "scripts": {


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | 
| License          | MIT

### Description

Re-arranged README to:
* Bring basic screenshot above the fold
* Link to the actual demo via the screenshot
* Make the basic installation steps easier to find
* Update the image/link to saucelabs
* Add documentation for quickly running medium-editor demo

I've always had a basic static server file for running/developing/testing medium-editor locally, figured I should probably just check it in and save new people a little big of time when trying to run things locally.  I checked it in as `index.js` which can just be run via `node index.js` after doing an `npm install`.
