### PR TITLE
Fix #1216 from previous PR #1217

### DIFF
--- a/spec/anchor.spec.js
+++ b/spec/anchor.spec.js
@@ -636,9 +636,9 @@ describe('Anchor Button TestCase', function () {
             expect(editor.createLink).toHaveBeenCalledWith(opts);
 
             link = editor.elements[0].querySelector('a');
-            expect(link).not.toBeNull();
-            expect(link.classList.contains('btn')).toBe(true);
-            expect(link.classList.contains('btn-default')).toBe(true);
+            expect(link).not.toBeNull('Link does not exist');
+            expect(link.classList.contains('btn')).toBe(true, 'Link does not contain class btn');
+            expect(link.classList.contains('btn-default')).toBe(true, 'Link does not contain class btn-default');
         });
 
         it('should remove the target _blank from the anchor tag when the open in a new window checkbox,' +

--- a/spec/anchor.spec.js
+++ b/spec/anchor.spec.js
@@ -16,8 +16,8 @@ describe('Anchor Button TestCase', function () {
     describe('Anchor Form', function () {
         it('should add class for visible state and remove it for invisivble', function () {
             var editor = this.newMediumEditor('.editor', {
-                buttonLabels: 'fontawesome'
-            }),
+                    buttonLabels: 'fontawesome'
+                }),
                 anchorExtension = editor.getExtensionByName('anchor'),
                 toolbar = editor.getExtensionByName('toolbar'),
                 activeClass = anchorExtension.activeClass;
@@ -33,8 +33,8 @@ describe('Anchor Button TestCase', function () {
 
         it('should not hide the toolbar when mouseup fires inside the anchor form', function () {
             var editor = this.newMediumEditor('.editor', {
-                buttonLabels: 'fontawesome'
-            }),
+                    buttonLabels: 'fontawesome'
+                }),
                 anchorExtension = editor.getExtensionByName('anchor'),
                 toolbar = editor.getExtensionByName('toolbar');
 
@@ -339,10 +339,10 @@ describe('Anchor Button TestCase', function () {
 
         it('should not change fragment identifier when link begins with hash', function () {
             var editor = this.newMediumEditor('.editor', {
-                anchor: {
-                    linkValidation: true
-                }
-            }),
+                    anchor: {
+                        linkValidation: true
+                    }
+                }),
                 validHashLink = '#!$&\'()*+,;=123abcDEF-._~:@/?',
                 link,
                 anchorExtension = editor.getExtensionByName('anchor');
@@ -556,10 +556,10 @@ describe('Anchor Button TestCase', function () {
         it('should create a button when user selects this option and presses enter', function () {
             spyOn(MediumEditor.prototype, 'createLink').and.callThrough();
             var editor = this.newMediumEditor('.editor', {
-                anchor: {
-                    customClassOption: 'btn btn-default'
-                }
-            }),
+                    anchor: {
+                        customClassOption: 'btn btn-default'
+                    }
+                }),
                 save,
                 input,
                 button,
@@ -595,15 +595,16 @@ describe('Anchor Button TestCase', function () {
             expect(link.classList.contains('btn-default')).toBe(true);
         });
 
-        it('should create a button when user selects this option, even if selected text carries tags and the selection doesn\'t exactly match those tags', function () {
+        it('should create a button when user selects this option, even if selected text carries tags ' +
+                'and the selection doesn\'t exactly match those tags', function () {
             spyOn(MediumEditor.prototype, 'createLink').and.callThrough();
             this.el.innerHTML = '<p>Hello <b>world</b>&nbsp;!</p>';
 
             var editor = this.newMediumEditor('.editor', {
-                anchor: {
-                    customClassOption: 'btn btn-default'
-                }
-            }),
+                    anchor: {
+                        customClassOption: 'btn btn-default'
+                    }
+                }),
                 p = this.el.querySelector('p'),
                 b = p.childNodes[1],
                 emptySpacePart = p.childNodes[2],
@@ -641,76 +642,76 @@ describe('Anchor Button TestCase', function () {
         });
 
         it('should remove the target _blank from the anchor tag when the open in a new window checkbox,' +
-            ' is unchecked and the form is saved', function () {
-                var editor = this.newMediumEditor('.editor', {
+                ' is unchecked and the form is saved', function () {
+            var editor = this.newMediumEditor('.editor', {
                     anchor: {
                         targetCheckbox: true
                     }
                 }),
-                    anchorExtension = editor.getExtensionByName('anchor'),
-                    targetCheckbox,
-                    link;
+                anchorExtension = editor.getExtensionByName('anchor'),
+                targetCheckbox,
+                link;
 
-                selectElementContentsAndFire(editor.elements[0]);
-                anchorExtension.showForm('http://test.com');
-                expect(anchorExtension.isDisplayed()).toBe(true);
-                targetCheckbox = anchorExtension.getForm().querySelector('input.medium-editor-toolbar-anchor-target');
-                targetCheckbox.checked = true;
-                fireEvent(anchorExtension.getForm().querySelector('a.medium-editor-toolbar-save'), 'click');
-                link = editor.elements[0].querySelector('a');
-                expect(link.target).toBe('_blank');
+            selectElementContentsAndFire(editor.elements[0]);
+            anchorExtension.showForm('http://test.com');
+            expect(anchorExtension.isDisplayed()).toBe(true);
+            targetCheckbox = anchorExtension.getForm().querySelector('input.medium-editor-toolbar-anchor-target');
+            targetCheckbox.checked = true;
+            fireEvent(anchorExtension.getForm().querySelector('a.medium-editor-toolbar-save'), 'click');
+            link = editor.elements[0].querySelector('a');
+            expect(link.target).toBe('_blank');
 
-                selectElementContentsAndFire(editor.elements[0]);
-                anchorExtension.showForm('http://test.com');
-                targetCheckbox = anchorExtension.getForm().querySelector('input.medium-editor-toolbar-anchor-target');
-                targetCheckbox.checked = false;
-                fireEvent(anchorExtension.getForm().querySelector('a.medium-editor-toolbar-save'), 'click');
-                link = editor.elements[0].querySelector('a');
-                expect(link.target).toBe('');
-            });
+            selectElementContentsAndFire(editor.elements[0]);
+            anchorExtension.showForm('http://test.com');
+            targetCheckbox = anchorExtension.getForm().querySelector('input.medium-editor-toolbar-anchor-target');
+            targetCheckbox.checked = false;
+            fireEvent(anchorExtension.getForm().querySelector('a.medium-editor-toolbar-save'), 'click');
+            link = editor.elements[0].querySelector('a');
+            expect(link.target).toBe('');
+        });
 
         it('should fire editableInput only once when the user creates a link open to a new window,' +
-            ' and it should fire at the end of the DOM and selection modifications', function () {
-                spyOn(MediumEditor.prototype, 'createLink').and.callThrough();
-                this.el.innerHTML = '<p>Lorem ipsum et dolitur sunt.</p>';
-                var editor = this.newMediumEditor('.editor', {
+                ' and it should fire at the end of the DOM and selection modifications', function () {
+            spyOn(MediumEditor.prototype, 'createLink').and.callThrough();
+            this.el.innerHTML = '<p>Lorem ipsum et dolitur sunt.</p>';
+            var editor = this.newMediumEditor('.editor', {
                     anchor: {
                         targetCheckbox: true
                     }
                 }),
-                    p = this.el.lastChild,
-                    anchorExtension = editor.getExtensionByName('anchor'),
-                    toolbar = editor.getExtensionByName('toolbar'),
-                    selectionWhenEventsFired = [],
-                    listener = function () {
-                        selectionWhenEventsFired.push(window.getSelection().toString());
-                    };
+                p = this.el.lastChild,
+                anchorExtension = editor.getExtensionByName('anchor'),
+                toolbar = editor.getExtensionByName('toolbar'),
+                selectionWhenEventsFired = [],
+                listener = function () {
+                    selectionWhenEventsFired.push(window.getSelection().toString());
+                };
 
-                MediumEditor.selection.select(document, p.firstChild, 'Lorem '.length, p.firstChild, 'Lorem ipsum'.length);
-                fireEvent(editor.elements[0], 'focus');
-                jasmine.clock().tick(1);
+            MediumEditor.selection.select(document, p.firstChild, 'Lorem '.length, p.firstChild, 'Lorem ipsum'.length);
+            fireEvent(editor.elements[0], 'focus');
+            jasmine.clock().tick(1);
 
-                // Click the 'anchor' button in the toolbar
-                fireEvent(toolbar.getToolbarElement().querySelector('[data-action="createLink"]'), 'click');
+            // Click the 'anchor' button in the toolbar
+            fireEvent(toolbar.getToolbarElement().querySelector('[data-action="createLink"]'), 'click');
 
-                // Input a url and save
-                var input = anchorExtension.getInput(),
-                    checkbox = anchorExtension.getAnchorTargetCheckbox();
-                input.value = 'http://www.example.com';
-                checkbox.checked = true;
-                editor.subscribe('editableInput', listener);
-                fireEvent(input, 'keyup', {
-                    keyCode: MediumEditor.util.keyCode.ENTER
-                });
-
-                expect(editor.createLink).toHaveBeenCalledWith({
-                    value: 'http://www.example.com',
-                    target: '_blank'
-                });
-                expect(window.getSelection().toString()).toBe('ipsum', 'selected text should remain selected');
-                expect(selectionWhenEventsFired.length).toBe(1, 'only one editableInput event should have been registered');
-                expect(selectionWhenEventsFired[0]).toBe('ipsum', 'selected text should have been the same when event fired');
+            // Input a url and save
+            var input = anchorExtension.getInput(),
+                checkbox = anchorExtension.getAnchorTargetCheckbox();
+            input.value = 'http://www.example.com';
+            checkbox.checked = true;
+            editor.subscribe('editableInput', listener);
+            fireEvent(input, 'keyup', {
+                keyCode: MediumEditor.util.keyCode.ENTER
             });
+
+            expect(editor.createLink).toHaveBeenCalledWith({
+                value: 'http://www.example.com',
+                target: '_blank'
+            });
+            expect(window.getSelection().toString()).toBe('ipsum', 'selected text should remain selected');
+            expect(selectionWhenEventsFired.length).toBe(1, 'only one editableInput event should have been registered');
+            expect(selectionWhenEventsFired[0]).toBe('ipsum', 'selected text should have been the same when event fired');
+        });
 
         // https://github.com/yabwe/medium-editor/issues/757
         it('should not select empty paragraphs when link is created at beginning of paragraph after empty paragraphs', function () {

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -32,7 +32,7 @@
             testText = document.createTextNode(' ');
         testParent.appendChild(testText);
         nodeContainsWorksWithTextNodes = testParent.contains(testText);
-    } catch (exc) { }
+    } catch (exc) {}
 
     var Util = {
 
@@ -228,8 +228,8 @@
             endSplitPoint = matchEndIndex - currentTextIndex -
                     (newNode ? currentNode.nodeValue.length : 0);
             if (textIndexOfEndOfFarthestNode >= matchEndIndex &&
-                currentTextIndex !== textIndexOfEndOfFarthestNode &&
-                endSplitPoint !== 0) {
+                    currentTextIndex !== textIndexOfEndOfFarthestNode &&
+                    endSplitPoint !== 0) {
                 (newNode || currentNode).splitText(endSplitPoint);
             }
         },
@@ -452,7 +452,7 @@
             if (!MediumEditor.util.isEdge && doc.queryCommandSupported('insertHTML')) {
                 try {
                     return doc.execCommand.apply(doc, ecArgs);
-                } catch (ignore) { }
+                } catch (ignore) {}
             }
 
             selection = doc.getSelection();
@@ -466,13 +466,13 @@
                 if (Util.isMediumEditorElement(toReplace) && !toReplace.firstChild) {
                     range.selectNode(toReplace.appendChild(doc.createTextNode('')));
                 } else if ((toReplace.nodeType === 3 && range.startOffset === 0 && range.endOffset === toReplace.nodeValue.length) ||
-                    (toReplace.nodeType !== 3 && toReplace.innerHTML === range.toString())) {
+                        (toReplace.nodeType !== 3 && toReplace.innerHTML === range.toString())) {
                     // Ensure range covers maximum amount of nodes as possible
                     // By moving up the DOM and selecting ancestors whose only child is the range
                     while (!Util.isMediumEditorElement(toReplace) &&
-                        toReplace.parentNode &&
-                        toReplace.parentNode.childNodes.length === 1 &&
-                        !Util.isMediumEditorElement(toReplace.parentNode)) {
+                            toReplace.parentNode &&
+                            toReplace.parentNode.childNodes.length === 1 &&
+                            !Util.isMediumEditorElement(toReplace.parentNode)) {
                         toReplace = toReplace.parentNode;
                     }
                     range.selectNode(toReplace);

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -629,10 +629,8 @@
             } else {
                 var aChildren = el.getElementsByTagName('a');
                 if (aChildren.length === 0) {
-                    while (el.nodeName.toLowerCase() !== 'a') {
-                        el = el.parentNode;
-                    }
-                    el = [el];
+                    var parentAnchor = Util.getClosestTag(el, 'a');
+                    el = parentAnchor ? [parentAnchor] : [];
                 } else {
                     el = aChildren;
                 }


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | yes
| Fixed tickets    | #1216 
| License          | MIT

### Description

From @annayafi in #1216:

> The problem was : when you call addClassToAnchors(el, buttonClass) function : 
> - if el is an `<a>` : no problem, it adds the css class(es)
> - if el has `<a>` children : no problem, it adds the css class(es) to children
> - if el is a child of an `<a>` : the function never looks for parent and won't add the css class(es). 
> This happens very easily when you select more than a node, for example you select exactly `<i>hello</i>`, css is never added.

This PR wraps up #1216 by fixing some spacing issues and resolving a bug in the code.  Thanks again @annayafi for opening the issue and fixing it! (Sorry for the massive delay in getting your fix merged!)