### PR TITLE
remove src from bower ignored files

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,6 @@
     "Gruntfile.js",
     "demo",
     "package.json",
-    "src",
     "CHANGES.md",
     "MAINTAINERS.md",
     "CODE_OF_CONDUCT.md",


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    |  
| License          | MIT

### Description

In bower the directory ``src`` is ignored. That makes the sass part of medium not usable when loaded with bower.

