### PR TITLE
Added undefined check and fallback in Paste extension

### DIFF
--- a/src/js/extensions/paste.js
+++ b/src/js/extensions/paste.js
@@ -297,8 +297,10 @@
                 // on empty line, rects is empty so we grab information from the first container of the range
                 if (rects.length) {
                     top += rects[0].top;
-                } else {
+                } else if (range.startContainer.getBoundingClientRect !== undefined) {
                     top += range.startContainer.getBoundingClientRect().top;
+                } else {
+                    top += range.getBoundingClientRect().top;
                 }
             }
 


### PR DESCRIPTION

| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | #1345
| License          | MIT

### Description

This fixes a use-case where `range.startContainer.getBoundingClientRect` is `undefined`, as described in #1345.
