### PR TITLE
Allow extensions to hook into the get/set content

### DIFF
--- a/spec/toolbar.spec.js
+++ b/spec/toolbar.spec.js
@@ -528,12 +528,15 @@ describe('MediumEditor.extensions.toolbar TestCase', function () {
             expect(document.getElementsByClassName('medium-editor-toolbar-actions').length).toBe(0);
         });
 
+        /*
+        // Only disable using options, it is possible to add elements later who don't have the disable-toolbar attr and will not work
         it('should not create the toolbar if all elements has data attr of disable-toolbar', function () {
             this.el.setAttribute('data-disable-toolbar', 'true');
             var editor = this.newMediumEditor('.editor');
             expect(document.getElementsByClassName('medium-editor-toolbar-actions').length).toBe(0);
             expect(editor.getExtensionByName('toolbar')).toBeUndefined();
         });
+        */
 
         it('should not show the toolbar when one element has a data attr of disable-toolbar set and text is selected', function () {
             var element = this.createElement('div', 'editor', 'lorem ipsum'),


### PR DESCRIPTION
Updated all methods that set/get the editor content, extensions can change the html that is being set/get.

Moved the extension init before the addElements method to allow
extension hook into the setContent and getContent. Because of the move
the elements are not available in the extension init method, the
extension should subscribe to the add addElement and removeElement
events.

Always enable toolbar when not disabled in options, even when all
elements on page have data-disable-toolbar set, it is possible that
elements are added later that require the toolbar.

| Q                | A
| ---------------- | ---
| Bug fix?         | yes/no
| New feature?     | yes/no
| BC breaks?       | yes/no
| Deprecations?    | yes/no
| New tests added? | yes/not needed
| Fixed tickets    | comma-separated list of tickets fixed by the PR, if any
| License          | MIT

### Description

[Description of the bug or feature]

--

#### Please, don't submit `/dist` files with your PR!
