### PR TITLE
Change mouse cursor for placeholder to I-beam

### DIFF
--- a/src/sass/components/_placeholder.scss
+++ b/src/sass/components/_placeholder.scss
@@ -3,6 +3,7 @@
 
     &:after {
         content: attr(data-placeholder) !important;
+        cursor: text;
         font-style: italic;
         position: absolute;
         left: 0;
@@ -18,6 +19,7 @@
 
     &:after {
         content: attr(data-placeholder) !important;
+        cursor: text;
         font-style: italic;
         position: relative;
         white-space: pre;


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | 
| License          | MIT

### Description

Change mouse cursor for placeholder from default to I-beam