### PR TITLE
fix crash when 'extensions' in 'isElementDescendantOfExtension' is undefined

### DIFF
--- a/src/js/events.js
+++ b/src/js/events.js
@@ -2,7 +2,10 @@
     'use strict';
 
     function isElementDescendantOfExtension(extensions, element) {
-        if ( !extensions ) return false;
+        if (!extensions) {
+            return false;
+        }
+
         return extensions.some(function (extension) {
             if (typeof extension.getInteractionElements !== 'function') {
                 return false;

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -2,6 +2,7 @@
     'use strict';
 
     function isElementDescendantOfExtension(extensions, element) {
+        if ( !extensions ) return false;
         return extensions.some(function (extension) {
             if (typeof extension.getInteractionElements !== 'function') {
                 return false;


### PR DESCRIPTION


| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| License          | MIT

### Description

`extensions` can under some circumstances be `undefined`. This causes an error when calling `extensions.some()` and for example stops `execAction` from having effect. Not sure if this is a good way to solve the issue, but it prevents the error.
