### PR TITLE
Bug fix for #1369

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -381,7 +381,7 @@
         for (var i = 0, n = atts.length; i < n; i++) {
             // do not re-create existing attributes
             if (!div.hasAttribute(atts[i].nodeName)) {
-                div.setAttribute(atts[i].nodeName, atts[i].nodeValue);
+                div.setAttribute(atts[i].nodeName, atts[i].value);
             }
         }
 


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | #1369 
| License          | MIT

### Description

Firefox console warning when there are multiple medium editor textareas: "Use of attributes' nodeValue attribute is deprecated. Use value instead." This is coming from line 6929 in dist/js/medium-editor.js. By changing atts[i].nodeValue to atts[i].value the warning goes away as well as the bug this caused in the application where medium editor was being used (Firefox only).