### PR TITLE
Do not check only for null targets or it will fail when it's undefined.

### DIFF
--- a/src/js/events.js
+++ b/src/js/events.js
@@ -52,7 +52,7 @@
                 win = this.base.options.contentWindow,
                 doc = this.base.options.ownerDocument;
 
-            if (targets !== null) {
+            if (targets) {
                 targets = MediumEditor.util.isElement(targets) || [win, doc].indexOf(targets) > -1 ? [targets] : targets;
 
                 Array.prototype.forEach.call(targets, function (target) {


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| License          | MIT

### Description

In version 5.23.2 (and before, not sure from when) if you add a link with `data-disable-preview` it triggers an error when you `mouseout` it.

Here is a jsfiddle that repeat the issue. it pulls in medium-editor 5.23.2 from jscdn.

http://jsfiddle.net/92req5br/