### PR TITLE
Buttons are not properly aligned in toolbar

### DIFF
--- a/src/sass/components/_toolbar.scss
+++ b/src/sass/components/_toolbar.scss
@@ -47,7 +47,8 @@
             font-size: 14px;
             line-height: 1.33;
             margin: 0;
-            padding: 15px;
+            padding: 0 15px;
+            min-height: 30px;
             text-decoration: none;
 
             &:focus {


### PR DESCRIPTION

| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | #1170
| License          | MIT

### Description

When `buttonHeigh` is set to `30` in `positionToolbar` the buttons are not properly aligned in the toolbar.

