### PR TITLE
Add div to list of block level elements.

### DIFF
--- a/src/js/util.js
+++ b/src/js/util.js
@@ -110,7 +110,7 @@
             // elements our editor generates
             'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'pre', 'ul', 'li', 'ol',
             // all other known block elements
-            'address', 'article', 'aside', 'audio', 'canvas', 'dd', 'dl', 'dt', 'fieldset',
+            'address', 'article', 'aside', 'audio', 'canvas', 'dd', 'div', 'dl', 'dt', 'fieldset',
             'figcaption', 'figure', 'footer', 'form', 'header', 'hgroup', 'main', 'nav',
             'noscript', 'output', 'section', 'video',
             'table', 'thead', 'tbody', 'tfoot', 'tr', 'th', 'td'


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | related to #1000 
| License          | MIT

### Description

When using medium-editor on a DIV node in Angular, Firefox would throw a NS_ERROR_FAILER when the editor was empty. This fix addresses this issue by adding DIV to the list of known block level elements.
