### PR TITLE
Auto-prefix mailto: for email addresses with linkValidation in anchor extension.

### DIFF
--- a/spec/anchor.spec.js
+++ b/spec/anchor.spec.js
@@ -240,6 +240,24 @@ describe('Anchor Button TestCase', function () {
             expect(link.href).toBe('tel:347-999-9999');
         });
 
+        it('should add mailto: if need be and linkValidation option is set to true', function () {
+            var editor = this.newMediumEditor('.editor', {
+                anchor: {
+                    linkValidation: true
+                }
+            }),
+                link,
+                anchorExtension = editor.getExtensionByName('anchor');
+
+            selectElementContentsAndFire(editor.elements[0]);
+            anchorExtension.showForm('test@example.com');
+            fireEvent(anchorExtension.getForm().querySelector('a.medium-editor-toolbar-save'), 'click');
+
+            link = editor.elements[0].querySelector('a');
+            expect(link).not.toBeNull();
+            expect(link.href).toBe('mailto:test@example.com');
+        });
+
         it('should not change protocol when a valid one is included', function () {
             var editor = this.newMediumEditor('.editor', {
                 anchor: {

--- a/src/js/extensions/anchor.js
+++ b/src/js/extensions/anchor.js
@@ -261,6 +261,9 @@
                 scheme = '',
                 // telRegex is a regex for checking if the string is a telephone number
                 telRegex = /^\+?\s?\(?(?:\d\s?\-?\)?){3,20}$/,
+                // emailRegex for checking if the string is an email address
+                // https://stackoverflow.com/questions/46155/how-to-validate-email-address-in-javascript
+                emailRegex = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
                 urlParts = value.match(/^(.*?)(?:\?(.*?))?(?:#(.*))?$/),
                 path = urlParts[1],
                 query = urlParts[2],
@@ -268,6 +271,8 @@
 
             if (telRegex.test(value)) {
                 return 'tel:' + value;
+            } else if (emailRegex.test(value)) {
+                return 'mailto:' + value;
             }
 
             if (!hasScheme) {


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | yes
| Fixed tickets    | 1312
| License          | MIT

### Description

Prepend mailto: for links that look like email addresses in the anchor extension when the linkValidation option is enabled.

--

#### Please, don't submit `/dist` files with your PR!
