### PR TITLE
Fix broken browser tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -290,7 +290,7 @@ module.exports = function (grunt) {
     gruntConfig['saucelabs-jasmine'] = {
         all: {
             options: {
-                urls: ['http://127.0.0.1:9999/_SpecRunner.html'],
+                urls: ['http://localhost:9999/_SpecRunner.html'],
                 tunnelTimeout: 5,
                 build: process.env.TRAVIS_JOB_ID,
                 concurrency: 3,

--- a/spec/buttons.spec.js
+++ b/spec/buttons.spec.js
@@ -431,6 +431,9 @@ describe('Buttons TestCase', function () {
             expect(button.classList.contains('medium-editor-button-active')).toBe(true);
 
             fireEvent(button, 'click');
+
+            this.el.innerHTML = stripAttrIfEmpty(this.el, 'style');
+
             // style="font-weight: bold" prevents IE9+10 from doing anything when 'bold' is triggered
             // but it should work in other browsers
             expect(!isOldIE() && button.classList.contains('medium-editor-button-active')).toBe(false);
@@ -507,6 +510,9 @@ describe('Buttons TestCase', function () {
             expect(button.classList.contains('medium-editor-button-active')).toBe(true);
 
             fireEvent(button, 'click');
+
+            this.el.innerHTML = stripAttrIfEmpty(this.el, 'style');
+
             // style="font-style: italic" prevents IE9+10 from doing anything when 'italic' is triggered
             // but it should work in other browsers
             expect(!isOldIE() && button.classList.contains('medium-editor-button-active')).toBe(false);
@@ -566,6 +572,9 @@ describe('Buttons TestCase', function () {
             expect(button.classList.contains('medium-editor-button-active')).toBe(true);
 
             fireEvent(button, 'click');
+
+            this.el.innerHTML = stripAttrIfEmpty(this.el, 'style');
+
             // style="text-decoration: underline" prevents IE9+10 from doing anything when 'underline' is triggered
             // but it should work in other browsers
             expect(!isOldIE() && button.classList.contains('medium-editor-button-active')).toBe(false);
@@ -625,6 +634,9 @@ describe('Buttons TestCase', function () {
             expect(button.classList.contains('medium-editor-button-active')).toBe(true);
 
             fireEvent(button, 'click');
+
+            this.el.innerHTML = stripAttrIfEmpty(this.el, 'style');
+
             // style="text-decoration: line-through" prevents IE9+10 from doing anything when 'strikethrough' is triggered
             // but it should work in other browsers
             expect(!isOldIE() && button.classList.contains('medium-editor-button-active')).toBe(false);
@@ -1056,3 +1068,14 @@ describe('Buttons TestCase', function () {
         });
     });
 });
+
+function stripAttrIfEmpty(element, attribute) {
+    // we want to strip empty attributes (especially styles,
+    // because the tests create style tags, inject style content,
+    // and then remove that style content.
+    //
+    // some browsers will remove empty attributes automatically.
+    //
+    // others (Chrome, seemingly) will not:
+    return element.innerHTML.replace(attribute + '=""', '');
+}

--- a/spec/content.spec.js
+++ b/spec/content.spec.js
@@ -649,8 +649,7 @@ describe('Content TestCase', function () {
                 fireEvent(target, 'keydown', {
                     keyCode: MediumEditor.util.keyCode.BACKSPACE
                 });
-                this.el.innerHTML = stripLinebreak(this.el);
-                expect(this.el.innerHTML).toBe('<p>lorem ipsum</p><ul><li></li><li>lorem ipsum</li></ul>');
+                expect(this.el.innerHTML).toMatch(/^<p>lorem ipsum<\/p><ul><li>(<br>)?<\/li><li>lorem ipsum<\/li><\/ul>$/);
             });
         });
 
@@ -812,7 +811,3 @@ describe('Content TestCase', function () {
         });
     });
 });
-
-function stripLinebreak(element) {
-    return element.innerHTML.replace('<br>', '');
-}

--- a/spec/content.spec.js
+++ b/spec/content.spec.js
@@ -649,6 +649,7 @@ describe('Content TestCase', function () {
                 fireEvent(target, 'keydown', {
                     keyCode: MediumEditor.util.keyCode.BACKSPACE
                 });
+                this.el.innerHTML = stripLinebreak(this.el);
                 expect(this.el.innerHTML).toBe('<p>lorem ipsum</p><ul><li></li><li>lorem ipsum</li></ul>');
             });
         });
@@ -811,3 +812,7 @@ describe('Content TestCase', function () {
         });
     });
 });
+
+function stripLinebreak(element) {
+    return element.innerHTML.replace('<br>', '');
+}


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| License          | MIT

### Description

See individual commit messages for details.

At a high level, I think these tests broke because the browsers decided to slightly change the markup they generate for `contenteditable` elements under various conditions.

This changeset finds a couple of places where this has been a problem and normalizes the output to what the tests expect. I don't think either of the normalizations that I'm performing is dangerous (i.e. potentially compromises the integrity of the tests and what they're meant to ensure), but please let me know if this is actually wrong.