### PR TITLE
fix null error on pastedPlain.split

### DIFF
--- a/src/js/extensions/paste.js
+++ b/src/js/extensions/paste.js
@@ -205,6 +205,10 @@
                 return this.cleanPaste(pastedHTML);
             }
 
+            if (!pastedPlain) {
+                return;
+            }
+
             if (!(this.getEditorOption('disableReturn') || (editable && editable.getAttribute('data-disable-return')))) {
                 paragraphs = pastedPlain.split(/[\r\n]+/g);
                 // If there are no \r\n in data, don't wrap in <p>


### PR DESCRIPTION

| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | no
| License          | MIT

### Description

I saw some errors where pastedPlain was undefined, so the `.split` would throw an error.

I don't know if this is the best place to fix the bug, but I wanted to start a conversation around the bug nonetheless.
