### PR TITLE
change font name with CSS

### DIFF
--- a/src/js/extensions/fontname.js
+++ b/src/js/extensions/fontname.js
@@ -6,7 +6,7 @@
         name: 'fontname',
         action: 'fontName',
         aria: 'change font name',
-        contentDefault: '&#xB1;', // ±
+        contentDefault: '<b>A</b>', // ±
         contentFA: '<i class="fa fa-font"></i>',
 
         fonts: ['', 'Arial', 'Verdana', 'Times New Roman'],
@@ -82,7 +82,6 @@
 
         doFormCancel: function () {
             this.base.restoreSelection();
-            this.clearFontName();
             this.base.checkSelection();
         },
 
@@ -145,21 +144,10 @@
             return this.getForm().querySelector('select.medium-editor-toolbar-select');
         },
 
-        clearFontName: function () {
-            MediumEditor.selection.getSelectedElements(this.document).forEach(function (el) {
-                if (el.nodeName.toLowerCase() === 'font' && el.hasAttribute('face')) {
-                    el.removeAttribute('face');
-                }
-            });
-        },
-
         handleFontChange: function () {
             var font = this.getSelect().value;
-            if (font === '') {
-                this.clearFontName();
-            } else {
-                this.execAction('fontName', { value: font });
-            }
+            this.base.options.ownerDocument.execCommand('styleWithCSS', false, true);
+            this.execAction('fontName', { value: font });
         },
 
         handleFormClick: function (event) {


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | ?
| New tests added? | not needed
| Fixed tickets    | N/A
| License          | MIT

### Description

As a global CSS font setting often overrides <font face="xxx">, we should style with CSS. Change `contentDefault` to not repeat the icon used by fontsize. Additionally, I think the FontName setting don't need to clear.
