### PR TITLE
When disableEditing is true, enable editing via toolbars.

### DIFF
--- a/src/js/extensions/button.js
+++ b/src/js/extensions/button.js
@@ -167,7 +167,17 @@
             var action = this.getAction();
 
             if (action) {
-                this.execAction(action);
+                if (this.getEditorOption('disableEditing')) {
+                    this.getEditorElements().forEach(function (element) {
+                        element.setAttribute('contentEditable', 'true');
+                    });
+                    this.execAction(action);
+                    this.getEditorElements().forEach(function (element) {
+                        element.setAttribute('contentEditable', 'inherit');
+                    });
+                } else {
+                    this.execAction(action);
+                }
             }
         },
 


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | yes
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | yes/not needed
| Fixed tickets    | comma-separated list of tickets fixed by the PR, if any
| License          | MIT

Inspired by #1084

### Description

Currently, when `disableEditing: true` and when you highlight a piece of text, you can see the Medium toolbar, but clicking on the buttons doesn't change the text since `contenteditable=false`.

![image](https://user-images.githubusercontent.com/7733219/34626204-a3802386-f210-11e7-88c0-ecaf742b168d.png)

**Fix: allow toolbar editing when disable editing**
![medium-editing](https://user-images.githubusercontent.com/7733219/34626267-dbb05dc0-f210-11e7-972c-7f7bec1fed18.gif)

This is my first time contributing to this repo - would love to hear your thoughts and suggestions!

