### PR TITLE
misc: if before cursor is a contentEditable=false element, set the ra…

### DIFF
--- a/src/js/selection.js
+++ b/src/js/selection.js
@@ -213,6 +213,11 @@
                 range = this.importSelectionMoveCursorPastAnchor(selectionState, range);
             }
 
+            if (range.commonAncestorContainer.contentEditable == 'false') {
+              range.setStart(range.commonAncestorContainer.nextSibling, 0);
+              range.collapse(true);
+            }
+
             this.selectRange(doc, range);
         },
 


### PR DESCRIPTION
if before cursor is a contentEditable=false element, set the range to nextSibling

| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | yes/no
| Deprecations?    | yes/no
| New tests added? | not needed
| Fixed tickets    | comma-separated list of tickets fixed by the PR, if any
| License          | MIT

### Description

[Description of the bug or feature]

I use `pasteHtml` api to insert elements whose contentEditable attribute is 'false'; just like this:
```
<div contenteditable="false" id="imgcell">
   <img src="xx">
   <span>del img</span>
</div>
<p>test</p>
```
When the cursor at the start of the 'p' tag,  then call 'saveSelection' and blur the editor and then call 'restoreSelection' and 'pasteHtml' to insert other content, it will be fail;

The `importSelection` api did not consider the `contenteditable=false` elements

--

#### Please, don't submit `/dist` files with your PR!
