### PR TITLE
Fixed custom class option checkbox

### DIFF
--- a/src/js/extensions/anchor.js
+++ b/src/js/extensions/anchor.js
@@ -123,8 +123,8 @@
                 // and provide similar access to a `fa-` icon default.
                 template.push(
                     '<div class="medium-editor-toolbar-form-row">',
-                    '<input type="checkbox" class="medium-editor-toolbar-anchor-button">',
-                    '<label>',
+                    '<input type="checkbox" class="medium-editor-toolbar-anchor-button" id="medium-editor-toolbar-anchor-button-field-' + this.getEditorId() + '">',
+                    '<label for="medium-editor-toolbar-anchor-button-field-' + this.getEditorId() + '">',
                     this.customClassOptionText,
                     '</label>',
                     '</div>'


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | -
| License          | MIT

### Description

Custom class option checkbox is not clickable due to missing `id` on checkbox and related `for` on label.

--

#### Please, don't submit `/dist` files with your PR!
