### PR TITLE
Add a url option when executing image action

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -600,7 +600,7 @@
         }
 
         if (action === 'image') {
-            var src = this.options.contentWindow.getSelection().toString().trim();
+            var src = this.options.contentWindow.getSelection().toString().trim() || opts.url;
             return this.options.ownerDocument.execCommand('insertImage', false, src);
         }
 


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | yes
| BC breaks?       |  no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | no
| License          | MIT

### Description

[Description of the bug or feature]
when  i use execAction('image'), i don't see any options in your guide to put an url to this method.
so i decided to create my own one.
my use case: I handled image from clipboard, upload it to server and response an url, then i show it on medium editor by execAction('image',{url: 'https://mywebsite.com/example.jpg'}).
if you see it useful, you can merge this request.
and if my changed is bad, please improve it and update your readme.md.
Thank.

--
