### PR TITLE
Cleanup after ordered/unordered list removal in Chrome

### DIFF
--- a/spec/content.spec.js
+++ b/spec/content.spec.js
@@ -810,4 +810,56 @@ describe('Content TestCase', function () {
             expect(para.querySelectorAll('div').length).toBe(0, 'Some <br> elements were replaced with <div> elements within the <p>');
         });
     });
+
+    describe('when list element is unlisted', function () {
+        it('should fix markup when one list element is unlisted', function () {
+            this.el.innerHTML = '<ul><li>lorem</li><li>ipsum</li><li>dolor</li></ul>';
+            var editor = this.newMediumEditor('.editor', {
+                    toolbar: {
+                        buttons: ['unorderedlist']
+                    }
+                }),
+                target = editor.elements[0].querySelector('li'),
+                toolbar = editor.getExtensionByName('toolbar');
+
+            selectElementContentsAndFire(target);
+            fireEvent(toolbar.getToolbarElement().querySelector('[data-action="insertunorderedlist"]'), 'click');
+            expect(this.el.innerHTML).toBe('<p>lorem</p><ul><li>ipsum</li><li>dolor</li></ul>');
+        });
+
+        it('should fix markup when miltiple list elements are unlisted', function () {
+            this.el.innerHTML = '<ol><li>lorem</li><li>ipsum</li><li>dolor</li></ol>';
+            var editor = this.newMediumEditor('.editor', {
+                    toolbar: {
+                        buttons: ['orderedlist']
+                    }
+                }),
+                toolbar = editor.getExtensionByName('toolbar'),
+                selection = document.getSelection(),
+                range = document.createRange();
+
+            range.setStart(this.el.querySelectorAll('li')[0].firstChild, 0);
+            range.setEnd(this.el.querySelectorAll('li')[1].firstChild, 5);
+            selection.removeAllRanges();
+            selection.addRange(range);
+
+            fireEvent(toolbar.getToolbarElement().querySelector('[data-action="insertorderedlist"]'), 'click');
+            expect(this.el.innerHTML).toBe('<p>lorem</p><p>ipsum</p><ol><li>dolor</li></ol>');
+        });
+
+        it('should fix markup when all list elements are unlisted', function () {
+            this.el.innerHTML = '<ul><li>lorem</li><li>ipsum</li><li>dolor</li></ul>';
+            var editor = this.newMediumEditor('.editor', {
+                    toolbar: {
+                        buttons: ['unorderedlist']
+                    }
+                }),
+                target = editor.elements[0].querySelector('ul'),
+                toolbar = editor.getExtensionByName('toolbar');
+
+            selectElementContentsAndFire(target);
+            fireEvent(toolbar.getToolbarElement().querySelector('[data-action="insertunorderedlist"]'), 'click');
+            expect(this.el.innerHTML).toBe('<p>lorem</p><p>ipsum</p><p>dolor</p>');
+        });
+    });
 });


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | no
| License          | MIT

### Description

Currently in Chrome when removing ordered/unordered list you get a `<span>` element followed by a `<br>`  for every line instead of just `<p>` elements. Furthermore, when inserting a line break in the middle of a span like this, everything that goes after gets wrapped in a div, which is unwanted.

This fix simply goes through these spans and replaces them with proper `<p>` elements.