### PR TITLE
Fix CJK IME input caused duplicated first char issue.

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -167,6 +167,11 @@
     }
 
     function handleKeyup(event) {
+        // According to https://developer.mozilla.org/en-US/docs/Web/Events/keyup
+        // Ignore composing keyUp event, prevent from duplicated first char with CJK IME.
+        if (event.isComposing || event.keyCode === 229) {
+            return;
+        }
         var node = MediumEditor.selection.getSelectionStart(this.options.ownerDocument),
             tagName;
 


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | #1485 
| License          | MIT

### Description

When do with CJK IME, the keyUp event should not trigger formatBlock, which will result wrong text in the input (with the extra first char there). 
According to https://developer.mozilla.org/en-US/docs/Web/Events/keyup the event can be judged for the IME input composing cases, so made this PR.

--

#### Please, don't submit `/dist` files with your PR!
