### PR TITLE
Ensure paragraph is selected for firefox. #1455

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -180,6 +180,12 @@
             this.options.ownerDocument.execCommand('formatBlock', false, 'p');
         }
 
+        // https://github.com/yabwe/medium-editor/issues/1455
+        // if somehow we have the BR as the selected element, typing does nothing, so move the cursor
+        if (node.nodeName === 'BR') {
+            MediumEditor.selection.moveCursor(this.options.ownerDocument, node.parentElement);
+        }
+
         // https://github.com/yabwe/medium-editor/issues/834
         // https://github.com/yabwe/medium-editor/pull/382
         // Don't call format block if this is a block element (ie h1, figCaption, etc.)
@@ -193,6 +199,14 @@
                 this.options.ownerDocument.execCommand('unlink', false, null);
             } else if (!event.shiftKey && !event.ctrlKey) {
                 this.options.ownerDocument.execCommand('formatBlock', false, 'p');
+                // https://github.com/yabwe/medium-editor/issues/1455
+                // firefox puts the focus on the br - so we need to move the cursor to the newly created p
+                if (MediumEditor.util.isFF) {
+                    var newParagraph = node.querySelector('p');
+                    if (newParagraph) {
+                        MediumEditor.selection.moveCursor(this.options.ownerDocument, newParagraph);
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Also ensure that we select the parent is selected if ever a br tag is the selected element when typing. 

| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | no
| Fixed tickets    | #1455
| License          | MIT

### Description

I noticed in the `handleKeyup` method that sometimes the selected node was a BR tag. When this is the case, typing does nothing. The use case in the issue (which was a problem for me also) is when you press enter from a new heading - so I've added a fix for that scenario (wrapped in the isFF util). I also added a fallback check - since I've seen other random places where typing seems to get "trapped".

Very happy to work with you if you have suggestions for improvement - as I'm not fully immersed in the library (or in contentEditable in general).

--

#### Please, don't submit `/dist` files with your PR!
