### PR TITLE
Ensure the focus stays in the editor after execAction for Firefox. #1496

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -942,6 +942,12 @@
                 MediumEditor.util.cleanListDOM(this.options.ownerDocument, this.getSelectedParentElement());
             }
 
+            // https://github.com/yabwe/medium-editor/issues/1496
+            // ensure the focus remains in the editor for Firefox
+            if (MediumEditor.util.isFF) {
+                MediumEditor.util.getContainerEditorElement(this.getSelectedParentElement()).focus();
+            }
+
             this.checkSelection();
             return result;
         },


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | no
| Fixed tickets    | #1496
| License          | MIT

### Description

For some reason in Firefox, the body is the focussed element after exec action. If there's a nicer way to do this (or to _stop_ the body being the focus) let me know and I'll be happy to investigate further.
