### PR TITLE
Update _placeholder.scss

### DIFF
--- a/src/sass/components/_placeholder.scss
+++ b/src/sass/components/_placeholder.scss
@@ -10,6 +10,7 @@
         white-space: pre;
         padding: inherit;
         margin: inherit;
+        cursor: text;
     }
 }
 
@@ -23,5 +24,6 @@
         white-space: pre;
         padding: inherit;
         margin: inherit;
+        cursor: text;
     }
 }


### PR DESCRIPTION

| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | none
| License          | MIT

### Description

Make it appear like element is editable (by showing text cursor) when hovering over placeholder (as would happen over a normal editable element). Currently a normal allow is shown (when hovering over placeholder) which makes it seem like the element is not editable, when it actually is.

--

#### Please, don't submit `/dist` files with your PR!
