### PR TITLE
Reselect range safely on removal of paste bin

### DIFF
--- a/src/js/extensions/paste.js
+++ b/src/js/extensions/paste.js
@@ -4,7 +4,7 @@
     /* Helpers and internal variables that don't need to be members of actual paste handler */
 
     var pasteBinDefaultContent = '%ME_PASTEBIN%',
-        lastRange = null,
+        lastSelection = null,
         keyboardPasteEditable = null,
         stopProp = function (event) {
             event.stopPropagation();
@@ -308,7 +308,10 @@
                 }
             }
 
-            lastRange = range;
+            lastSelection = {
+                exported: this.base.exportSelection(),
+                range: range
+            };
 
             var pasteBinElm = this.document.createElement('div');
             pasteBinElm.id = this.pasteBinId = 'medium-editor-pastebin-' + (+Date.now());
@@ -335,9 +338,10 @@
         },
 
         removePasteBin: function () {
-            if (null !== lastRange) {
-                MediumEditor.selection.selectRange(this.document, lastRange);
-                lastRange = null;
+            if (null !== lastSelection) {
+                MediumEditor.selection.selectRange(this.document, lastSelection.range);
+                this.base.importSelection(lastSelection.exported);
+                lastSelection = null;
             }
 
             if (null !== keyboardPasteEditable) {


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    | no
| New tests added? | not needed
| Fixed tickets    | 
| License          | MIT

### Description
This fix targets the built-in paste extension, to address cursor positioning after a paste.

Current behaviour:
* During a paste operation, a `medium-editor-pastebin-*` div is created.
* The previous cursor selection is stored in the variable `lastRange` (this is the the result of `MediumEditor.selection.getSelectionRange`, which evaluates to `range[0]` of `document.getSelection()`)
* When the paste-bin is removed, `lastRange` is used to restore the selection.
* Unfortunately, this `Range` object placed into `lastRange` is mutable by the browser. In some cases it is being modified before the paste bin is removed (during `removePasteBin()`).
  * The specific situation I experienced was that, sometimes, when pasting into a newly-created medium-editor, `lastRange` would initially target a `TextNode`, yet by the time the paste was complete, it was targetting the containing `HTMLDivElement` (the parent of the `TextNode`), with incorrect offsets.

Modified behaviour:
* `lastRange` is replaced by `lastSelection`, containing two properties:
  * `range`: the `Range` object, as before
  * `exported`: the result of calling `this.base.exportSelection()`
* When the selection is being restored (during the `removePasteBin()` call), the range is _first_ selected using `MediumEditor.selection.selectRange` and `range` (essentially, this is the original behaviour)
* ... then the precise cursor position is restored using `this.base.importSelection(lastSelection.exported)`

For cases where the existing approach was working, there should be no difference. And in cases where the browser mutates the `Range`, the cursor position is preserved.

--

#### Please, don't submit `/dist` files with your PR!
