### PR TITLE
Fix undefined 'value' error in showPreview method

### DIFF
--- a/src/js/extensions/anchor-preview.js
+++ b/src/js/extensions/anchor-preview.js
@@ -83,9 +83,11 @@
                 return true;
             }
 
-            if (this.previewValueSelector) {
-                this.anchorPreview.querySelector(this.previewValueSelector).textContent = anchorEl.attributes.href.value;
-                this.anchorPreview.querySelector(this.previewValueSelector).href = anchorEl.attributes.href.value;
+            const hrefAttribute = anchorEl.attributes.href;
+            if (hrefAttribute) {
+                const hrefValue = hrefAttribute.value;
+                this.anchorPreview.querySelector(this.previewValueSelector).textContent = hrefValue;
+                this.anchorPreview.querySelector(this.previewValueSelector).href = hrefValue;
             }
 
             this.anchorPreview.classList.add('medium-toolbar-arrow-over');


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| BC breaks?       | no
| Deprecations?    |no
| New tests added? | yes
| Fixed tickets    | 
| License          | MIT

### Description

[Description of the bug or feature]


**Summary:**
This pull request fixes a TypeError encountered in the `showPreview` method of `medium-editor.js`. The error occurred because the code attempted to access the `value` property of `undefined` when `href` attribute was missing.

**Details:**
- Added a check to ensure `hrefAttribute` exists before accessing its `value` property.
- This prevents runtime errors and improves stability.

![image](https://github.com/user-attachments/assets/61019a6c-1ea6-431b-84da-5f34ed7d2f6d)


--

#### Please, don't submit `/dist` files with your PR!
